### PR TITLE
kydavis UUIDv7 updates

### DIFF
--- a/draft-peabody-dispatch-new-uuid-format-01.html
+++ b/draft-peabody-dispatch-new-uuid-format-01.html
@@ -19,11 +19,11 @@
  This document is a proposal to update   with three new UUID versions that address these concerns, each with different trade-offs.
        
     " name="description">
-<meta content="xml2rfc 3.5.0" name="generator">
+<meta content="xml2rfc 3.7.0" name="generator">
 <meta content="uuid" name="keyword">
 <meta name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.5.0
+  xml2rfc 3.7.0
     Python 3.6.9
     appdirs 1.4.4
     ConfigArgParse 1.2.3
@@ -40,7 +40,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/GOdx50HXZK.dir/draft-peabody-dispatch-new-uuid-format-01.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/32SHmixI3E.dir/draft-peabody-dispatch-new-uuid-format-01.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1168,6 +1168,14 @@ dd > ul:first-child {
 dt+dd:empty::before{
   content: "\00a0";
 }
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type {
+  margin-bottom: 0;
+}
 </style>
 <link href="rfc-local.css" rel="stylesheet" type="text/css">
 <script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
@@ -1178,11 +1186,11 @@ dt+dd:empty::before{
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">new-uuid-format</td>
-<td class="right">February 2021</td>
+<td class="right">April 2021</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 21 August 2021</td>
+<td class="center">Expires 24 October 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1198,12 +1206,12 @@ dt+dd:empty::before{
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-02-17" class="published">17 February 2021</time>
+<time datetime="2021-04-22" class="published">22 April 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-08-21">21 August 2021</time></dd>
+<dd class="expires"><time datetime="2021-10-24">24 October 2021</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1246,7 +1254,7 @@ dt+dd:empty::before{
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 21 August 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 24 October 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1274,101 +1282,101 @@ dt+dd:empty::before{
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
 <a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1">
-            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
+<nav class="toc"><ul class="toc ulEmpty compact">
+<li class="toc ulEmpty compact" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-background" class="xref">Background</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-background" class="xref">Background</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="xref">3</a>.  <a href="#name-summary-of-changes" class="xref">Summary of Changes</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="xref">3</a>.  <a href="#name-summary-of-changes" class="xref">Summary of Changes</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-versions" class="xref">Versions</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a></p>
+<ul class="toc ulEmpty compact">
+<li class="toc ulEmpty compact" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-versions" class="xref">Versions</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-variant" class="xref">Variant</a><a href="#section-toc.1-1.4.2.2.1" class="pilcrow">¶</a></p>
+              <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-variant" class="xref">Variant</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.3">
-                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuidv6-layout-and-bit-order" class="xref">UUIDv6 Layout and Bit Order</a><a href="#section-toc.1-1.4.2.3.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.4.2.3.2.1">
-                    <p id="section-toc.1-1.4.2.3.2.1.1"><a href="#section-4.3.1" class="xref">4.3.1</a>.  <a href="#name-uuidv6-timestamp-usage" class="xref">UUIDv6 Timestamp Usage</a><a href="#section-toc.1-1.4.2.3.2.1.1" class="pilcrow">¶</a></p>
+              <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.3">
+                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuidv6-layout-and-bit-order" class="xref">UUIDv6 Layout and Bit Order</a></p>
+<ul class="toc ulEmpty compact">
+<li class="toc ulEmpty compact" id="section-toc.1-1.4.2.3.2.1">
+                    <p id="section-toc.1-1.4.2.3.2.1.1"><a href="#section-4.3.1" class="xref">4.3.1</a>.  <a href="#name-uuidv6-timestamp-usage" class="xref">UUIDv6 Timestamp Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.3.2.2">
-                    <p id="section-toc.1-1.4.2.3.2.2.1"><a href="#section-4.3.2" class="xref">4.3.2</a>.  <a href="#name-uuidv6-clock-sequence-usage" class="xref">UUIDv6 Clock Sequence  Usage</a><a href="#section-toc.1-1.4.2.3.2.2.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.3.2.2">
+                    <p id="section-toc.1-1.4.2.3.2.2.1"><a href="#section-4.3.2" class="xref">4.3.2</a>.  <a href="#name-uuidv6-clock-sequence-usage" class="xref">UUIDv6 Clock Sequence  Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.3.2.3">
-                    <p id="section-toc.1-1.4.2.3.2.3.1"><a href="#section-4.3.3" class="xref">4.3.3</a>.  <a href="#name-uuidv6-node-usage" class="xref">UUIDv6 Node Usage</a><a href="#section-toc.1-1.4.2.3.2.3.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.3.2.3">
+                    <p id="section-toc.1-1.4.2.3.2.3.1"><a href="#section-4.3.3" class="xref">4.3.3</a>.  <a href="#name-uuidv6-node-usage" class="xref">UUIDv6 Node Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.3.2.4">
-                    <p id="section-toc.1-1.4.2.3.2.4.1"><a href="#section-4.3.4" class="xref">4.3.4</a>.  <a href="#name-uuidv6-basic-creation-algor" class="xref">UUIDv6 Basic Creation Algorithm</a><a href="#section-toc.1-1.4.2.3.2.4.1" class="pilcrow">¶</a></p>
-</li>
-                </ul>
-</li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.4">
-                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuidv7-layout-and-bit-order" class="xref">UUIDv7 Layout and Bit Order</a><a href="#section-toc.1-1.4.2.4.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.4.2.4.2.1">
-                    <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-uuidv7-timestamp-usage" class="xref">UUIDv7 Timestamp Usage</a><a href="#section-toc.1-1.4.2.4.2.1.1" class="pilcrow">¶</a></p>
-</li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.4.2.2">
-                    <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-uuidv7-clock-sequence-usage" class="xref">UUIDv7 Clock Sequence Usage</a><a href="#section-toc.1-1.4.2.4.2.2.1" class="pilcrow">¶</a></p>
-</li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.4.2.3">
-                    <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-uuidv7-node-usage" class="xref">UUIDv7 Node Usage</a><a href="#section-toc.1-1.4.2.4.2.3.1" class="pilcrow">¶</a></p>
-</li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.4.2.4">
-                    <p id="section-toc.1-1.4.2.4.2.4.1"><a href="#section-4.4.4" class="xref">4.4.4</a>.  <a href="#name-uuidv7-basic-creation-algor" class="xref">UUIDv7 Basic Creation Algorithm</a><a href="#section-toc.1-1.4.2.4.2.4.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.3.2.4">
+                    <p id="section-toc.1-1.4.2.3.2.4.1"><a href="#section-4.3.4" class="xref">4.3.4</a>.  <a href="#name-uuidv6-basic-creation-algor" class="xref">UUIDv6 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.5">
-                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-uuidv8-layout-and-bit-order" class="xref">UUIDv8 Layout and Bit Order</a><a href="#section-toc.1-1.4.2.5.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.4.2.5.2.1">
-                    <p id="section-toc.1-1.4.2.5.2.1.1"><a href="#section-4.5.1" class="xref">4.5.1</a>.  <a href="#name-uuidv8-timestamp-usage" class="xref">UUIDv8 Timestamp Usage</a><a href="#section-toc.1-1.4.2.5.2.1.1" class="pilcrow">¶</a></p>
+              <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.4">
+                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuidv7-layout-and-bit-order" class="xref">UUIDv7 Layout and Bit Order</a></p>
+<ul class="toc ulEmpty compact">
+<li class="toc ulEmpty compact" id="section-toc.1-1.4.2.4.2.1">
+                    <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-uuidv7-timestamp-usage" class="xref">UUIDv7 Timestamp Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.5.2.2">
-                    <p id="section-toc.1-1.4.2.5.2.2.1"><a href="#section-4.5.2" class="xref">4.5.2</a>.  <a href="#name-uuidv8-clock-sequence-usage" class="xref">UUIDv8 Clock Sequence Usage</a><a href="#section-toc.1-1.4.2.5.2.2.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.4.2.2">
+                    <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-uuidv7-clock-sequence-usage" class="xref">UUIDv7 Clock Sequence Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.5.2.3">
-                    <p id="section-toc.1-1.4.2.5.2.3.1"><a href="#section-4.5.3" class="xref">4.5.3</a>.  <a href="#name-uuidv8-node-usage" class="xref">UUIDv8 Node Usage</a><a href="#section-toc.1-1.4.2.5.2.3.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.4.2.3">
+                    <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-uuidv7-node-usage" class="xref">UUIDv7 Node Usage</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.4.2.5.2.4">
-                    <p id="section-toc.1-1.4.2.5.2.4.1"><a href="#section-4.5.4" class="xref">4.5.4</a>.  <a href="#name-uuidv6-basic-creation-algori" class="xref">UUIDv6 Basic Creation Algorithm</a><a href="#section-toc.1-1.4.2.5.2.4.1" class="pilcrow">¶</a></p>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.4.2.4">
+                    <p id="section-toc.1-1.4.2.4.2.4.1"><a href="#section-4.4.4" class="xref">4.4.4</a>.  <a href="#name-uuidv7-encoding-and-decodin" class="xref">UUIDv7 Encoding and Decoding</a></p>
+</li>
+                </ul>
+</li>
+              <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.5">
+                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-uuidv8-layout-and-bit-order" class="xref">UUIDv8 Layout and Bit Order</a></p>
+<ul class="toc ulEmpty compact">
+<li class="toc ulEmpty compact" id="section-toc.1-1.4.2.5.2.1">
+                    <p id="section-toc.1-1.4.2.5.2.1.1"><a href="#section-4.5.1" class="xref">4.5.1</a>.  <a href="#name-uuidv8-timestamp-usage" class="xref">UUIDv8 Timestamp Usage</a></p>
+</li>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.5.2.2">
+                    <p id="section-toc.1-1.4.2.5.2.2.1"><a href="#section-4.5.2" class="xref">4.5.2</a>.  <a href="#name-uuidv8-clock-sequence-usage" class="xref">UUIDv8 Clock Sequence Usage</a></p>
+</li>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.5.2.3">
+                    <p id="section-toc.1-1.4.2.5.2.3.1"><a href="#section-4.5.3" class="xref">4.5.3</a>.  <a href="#name-uuidv8-node-usage" class="xref">UUIDv8 Node Usage</a></p>
+</li>
+                  <li class="toc ulEmpty compact" id="section-toc.1-1.4.2.5.2.4">
+                    <p id="section-toc.1-1.4.2.5.2.4.1"><a href="#section-4.5.4" class="xref">4.5.4</a>.  <a href="#name-uuidv6-basic-creation-algori" class="xref">UUIDv6 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-encoding-and-storage" class="xref">Encoding and Storage</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-encoding-and-storage" class="xref">Encoding and Storage</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-global-uniqueness" class="xref">Global Uniqueness</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-global-uniqueness" class="xref">Global Uniqueness</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
 </li>
-          <li class="ulEmpty compact toc" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.12.1" class="pilcrow">¶</a></p>
+          <li class="toc ulEmpty compact" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#section-appendix.a" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1437,7 +1445,7 @@ dt+dd:empty::before{
  time-based, sortable unique identifier for use as a database key. This has lead to numerous implementations 
  over the past 10+ years solving the same problem in slightly different ways.<a href="#section-2-8" class="pilcrow">¶</a></p>
 <p id="section-2-9">
-    While preparing this specification the following 16 different implementations were analyzed for trends in total ID length, bit Layout, lexical formatting/encoding, timestamp type, timestamp format, timestamp accurancy, node format/components, collision handling and multi-timestamp tick generation sequencing.<a href="#section-2-9" class="pilcrow">¶</a></p>
+    While preparing this specification the following 16 different implementations were analyzed for trends in total ID length, bit Layout, lexical formatting/encoding, timestamp type, timestamp format, timestamp accuracy, node format/components, collision handling and multi-timestamp tick generation sequencing.<a href="#section-2-9" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="compact type-1" id="section-2-10">
  <li id="section-2-10.1">
           <p id="section-2-10.1.1"><span>[<a href="#LexicalUUID" class="xref">LexicalUUID</a>]</span> by Twitter<a href="#section-2-10.1.1" class="pilcrow">¶</a></p>
@@ -1490,27 +1498,27 @@ dt+dd:empty::before{
       </ol>
 <p id="section-2-11">
  An inspection of these implementations details the following trends that help define this standard:<a href="#section-2-11" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact">
-<li class="ulEmpty compact" id="section-2-12.1">
+<ul class="compact ulEmpty">
+<li class="compact ulEmpty" id="section-2-12.1">
           <p id="section-2-12.1.1">- Timestamps MUST be k-sortable. That is, values within or close to the same timestamp are ordered properly by sorting algorithms.<a href="#section-2-12.1.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.2">
+        <li class="compact ulEmpty" id="section-2-12.2">
           <p id="section-2-12.2.1">- Timestamps SHOULD be big-endian with the most-significant bits of the time embedded as-is without reordering.<a href="#section-2-12.2.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.3">
+        <li class="compact ulEmpty" id="section-2-12.3">
           <p id="section-2-12.3.1">- Timestamps SHOULD utilize millisecond precision and Unix Epoch as timestamp source. Although,
    there is some variation to this among implementations depending on the application requirements.<a href="#section-2-12.3.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.4">
+        <li class="compact ulEmpty" id="section-2-12.4">
           <p id="section-2-12.4.1">- The ID format SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-2-12.4.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.5">
+        <li class="compact ulEmpty" id="section-2-12.5">
           <p id="section-2-12.5.1">- IDs MUST ensure proper embedded sequencing to facilitate sorting when multiple UUIDs are created during a given timestamp.<a href="#section-2-12.5.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.6">
+        <li class="compact ulEmpty" id="section-2-12.6">
           <p id="section-2-12.6.1">- IDs MUST remove unique network identifiers while still retaining application uniqueness.<a href="#section-2-12.6.1" class="pilcrow">¶</a></p>
 </li>
-        <li class="ulEmpty compact" id="section-2-12.7">
+        <li class="compact ulEmpty" id="section-2-12.7">
           <p id="section-2-12.7.1">- Distributed nodes MUST be able to create collision resistant Unique IDs 
    without a consulting a centralized resource.<a href="#section-2-12.7.1" class="pilcrow">¶</a></p>
 </li>
@@ -1612,7 +1620,7 @@ dt+dd:empty::before{
  The variant bits utilized by UUIDs in this specification 
  remains the same as <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
 <p id="section-4.2-2">
-        The Table 2 lists the contents of the variant field, bits 64 and 65,
+ The Table 2 lists the contents of the variant field, bits 64 and 65,
  where the letter "x" indicates a "don't-care" value. Common hex values of 
  8 (1000), 9 (1001), A (1010), and B (1011) frequent the text representation.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
 <span id="name-uuid-variant-defined-by-thi"></span><table class="center" id="table-2">
@@ -1646,15 +1654,15 @@ dt+dd:empty::before{
         </h3>
 <p id="section-4.3-1">
  UUIDv6 aims to be the easiest to implement by reusing most of the layout of bits
-        found in UUIDv1 but with changes to bit ordering for the timestamp.
-        Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
-        time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
-        from the timestamp intact and changes the order to time_high, time_mid, and time_low.
-        Incidentally this will match the original 60-bit Gregorian timestamp source.
-        The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
-        The 48-bit node MUST be set to a pseudo-random value.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
+ found in UUIDv1 but with changes to bit ordering for the timestamp.
+ Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
+ time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
+ from the timestamp intact and changes the order to time_high, time_mid, and time_low.
+ Incidentally this will match the original 60-bit Gregorian timestamp source.
+ The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
+ The 48-bit node MUST be set to a pseudo-random value.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <p id="section-4.3-2">
-        The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 1<a href="#section-4.3-2" class="pilcrow">¶</a></p>
+ The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 1<a href="#section-4.3-2" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-1">
           <div class="artwork art-text alignLeft" id="section-4.3-3.1">
 <pre>
@@ -1716,7 +1724,7 @@ dt+dd:empty::before{
           </h4>
 <p id="section-4.3.1-1">
  UUIDv6 reuses the 60-bit Gregorian timestamp with 100-nanosecond
-            precision defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>.<a href="#section-4.3.1-1" class="pilcrow">¶</a></p>
+ precision defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>.<a href="#section-4.3.1-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="uuidv6sequence">
@@ -1734,9 +1742,9 @@ dt+dd:empty::before{
 <a href="#section-4.3.3" class="section-number selfRef">4.3.3. </a><a href="#name-uuidv6-node-usage" class="section-name selfRef">UUIDv6 Node Usage</a>
           </h4>
 <p id="section-4.3.3-1">
-            UUIDv6 node bits SHOULD be set to a 48-bit random or pseudo-random number.
-            UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
-            <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span> method of generating a random multicast IEEE 802 MAC address.<a href="#section-4.3.3-1" class="pilcrow">¶</a></p>
+ UUIDv6 node bits SHOULD be set to a 48-bit random or pseudo-random number.
+ UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
+ <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span> method of generating a random multicast IEEE 802 MAC address.<a href="#section-4.3.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="uuidv6pseudo">
@@ -1745,8 +1753,8 @@ dt+dd:empty::before{
 <a href="#section-4.3.4" class="section-number selfRef">4.3.4. </a><a href="#name-uuidv6-basic-creation-algor" class="section-name selfRef">UUIDv6 Basic Creation Algorithm</a>
           </h4>
 <p id="section-4.3.4-1">
-            The following implementation algorithm is based on <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>
-            but with changes specific to UUIDv6:<a href="#section-4.3.4-1" class="pilcrow">¶</a></p>
+ The following implementation algorithm is based on <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>
+ but with changes specific to UUIDv6:<a href="#section-4.3.4-1" class="pilcrow">¶</a></p>
 <ol start="1" type="1" class="normal type-1" id="section-4.3.4-2">
  <li id="section-4.3.4-2.1">
               <p id="section-4.3.4-2.1.1">From a system-wide shared stable store (e.g., a file) or global variable, read the
@@ -1802,11 +1810,11 @@ dt+dd:empty::before{
 </li>
           </ol>
 <p id="section-4.3.4-3">
-            The steps for splitting time_high_and_time_mid into time_high and time_mid are optional
-            since the 48-bits of time_high and time_mid will remain in the same order as time_high_and_time_mid
-            during the final concatenation. This extra step of splitting into the most significant
-            32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
-            In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.3.4-3" class="pilcrow">¶</a></p>
+ The steps for splitting time_high_and_time_mid into time_high and time_mid are optional
+ since the 48-bits of time_high and time_mid will remain in the same order as time_high_and_time_mid
+ during the final concatenation. This extra step of splitting into the most significant
+ 32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
+ In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.3.4-3" class="pilcrow">¶</a></p>
 <span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-3">
             <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:
@@ -1846,30 +1854,66 @@ dt+dd:empty::before{
         <h3 id="name-uuidv7-layout-and-bit-order">
 <a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-uuidv7-layout-and-bit-order" class="section-name selfRef">UUIDv7 Layout and Bit Order</a>
         </h3>
+<p id="section-4.4-1">
+ The UUIDv7 format is designed to encode a Unix timestamp with arbitrary sub-second precision.
+ The key property provided by UUIDv7 is that timestamp values generated by one system and parsed by
+ another are guaranteed to have sub-section precision of either the generator or the parser,
+ whichever is less. Additionally, the system parsing the UUIDv7 value does not need to know which precision
+ was used during encoding in order to function correctly.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
+<p id="section-4.4-2">
+ The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 2<a href="#section-4.4-2" class="pilcrow">¶</a></p>
 <span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-2">
-          <div class="artwork art-text alignLeft" id="section-4.4-1.1">
+          <div class="artwork art-text alignLeft" id="section-4.4-3.1">
 <pre>
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                      unix_timestamp_sec                       |
+    |                            unixts                             |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |       |       ms_time         |  ver  |      us_time          |
+    |unixts |       subsec_a        |  ver  |       subsec_b        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    | var |    ns_time    |           node                          |
+    |var|                   subsec_seq_node                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                                                               |
+    |                       subsec_seq_node                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
 <figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
 <a href="#name-uuidv7-field-and-bit-layout" class="selfRef">UUIDv7 Field and Bit Layout</a>
           </figcaption></figure>
+<span class="break"></span><dl class="dlNewline" id="section-4.4-4">
+          <dt id="section-4.4-4.1">unixts:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.2">36-bit big-endian unsigned Unix Timestamp value<a href="#section-4.4-4.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-4.4-4.3">subsec_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.4">12-bits allocated to sub-section precision values.<a href="#section-4.4-4.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-4.4-4.5">ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.6">The 4 bit UUIDv8 version (0111)<a href="#section-4.4-4.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-4.4-4.7">subsec_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.8">12-bits allocated to sub-section precision values.<a href="#section-4.4-4.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-4.4-4.9">var:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.10">2-bit UUID variant (10)<a href="#section-4.4-4.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-4.4-4.11">subsec_seq_node:</dt>
+          <dd style="margin-left: 1.5em" id="section-4.4-4.12">The remaining 62 bits which MAY be allocated to any combination of additional sub-section precision, sequence counter, or pseudo-random data.<a href="#section-4.4-4.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
 <div id="uuidv7timestamp">
 <section id="section-4.4.1">
           <h4 id="name-uuidv7-timestamp-usage">
 <a href="#section-4.4.1" class="section-number selfRef">4.4.1. </a><a href="#name-uuidv7-timestamp-usage" class="section-name selfRef">UUIDv7 Timestamp Usage</a>
           </h4>
+<p id="section-4.4.1-1">UUIDv7 utilizes a 36-bit big-endian unsigned Unix Timestamp value (number of seconds since the epoch of 1 Jan 1970, leap seconds excluded so each hour is exactly 3600 seconds long).<a href="#section-4.4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.4.1-2">Additional sub-second precision (millisecond, nanosecond, microsecond, etc) MAY be provided for encoding and decoding in the remaining bits in the layout.<a href="#section-4.4.1-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="uuidv7sequence">
@@ -1877,6 +1921,18 @@ dt+dd:empty::before{
           <h4 id="name-uuidv7-clock-sequence-usage">
 <a href="#section-4.4.2" class="section-number selfRef">4.4.2. </a><a href="#name-uuidv7-clock-sequence-usage" class="section-name selfRef">UUIDv7 Clock Sequence Usage</a>
           </h4>
+<p id="section-4.4.2-1">
+ UUIDv7 SHOULD utilize a motonic sequence counter to provide additional sequencing guarantees when multiple UUIDv7 values are created in the same UNIXTS and SUBSEC timestamp.
+ The amount of bits allocates to the sequence counter depend on the precision of the timestamp. For example, a more accurate timestamp source using nanosecond precision will require less clock sequence bits than a timestamp source utilizing seconds for precision.
+ For best sequencing results the sequence counter SHOULD be placed immediately after available sub-second bits.<a href="#section-4.4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.4.2-2">
+ The clock sequence MUST start at zero and increment monotonically
+ for each new UUID created on by the application on the same timestamp.
+ When the timestamp increments the clock sequence MUST be reset to zero.
+ The clock sequence MUST NOT rollover or reset to zero unless the timestamp
+ has incremented. Care MUST be given to ensure that an adequate sized
+ clock sequence is selected for a given application based on expected
+ timestamp precision and expected UUID generation rates.<a href="#section-4.4.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="uuidv7node">
@@ -1884,13 +1940,233 @@ dt+dd:empty::before{
           <h4 id="name-uuidv7-node-usage">
 <a href="#section-4.4.3" class="section-number selfRef">4.4.3. </a><a href="#name-uuidv7-node-usage" class="section-name selfRef">UUIDv7 Node Usage</a>
           </h4>
+<p id="section-4.4.3-1">
+ UUIDv7 implementations, even with very detailed sub-second precision and the optional sequence counter, MAY have leftover bits that will be identified as the Node for this section.
+ The UUIDv7 Node MAY contain any set of data an implementation desires however the node MUST NOT be set to all 0s which does not ensure global uniqueness. In most scenarios the node SHOULD be filled with pseudo-random data.<a href="#section-4.4.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="uuidv7pseudo">
+<div id="uuidv7encodingdecoding">
 <section id="section-4.4.4">
-          <h4 id="name-uuidv7-basic-creation-algor">
-<a href="#section-4.4.4" class="section-number selfRef">4.4.4. </a><a href="#name-uuidv7-basic-creation-algor" class="section-name selfRef">UUIDv7 Basic Creation Algorithm</a>
+          <h4 id="name-uuidv7-encoding-and-decodin">
+<a href="#section-4.4.4" class="section-number selfRef">4.4.4. </a><a href="#name-uuidv7-encoding-and-decodin" class="section-name selfRef">UUIDv7 Encoding and Decoding</a>
           </h4>
+<p id="section-4.4.4-1">
+ The UUIDv7 bit layout for encoding and decoding are described separately in this document.<a href="#section-4.4.4-1" class="pilcrow">¶</a></p>
+<div id="uuidv7encoding">
+<section id="section-4.4.4.1">
+            <h5 id="name-uuidv7-encoding">
+<a href="#section-4.4.4.1" class="section-number selfRef">4.4.4.1. </a><a href="#name-uuidv7-encoding" class="section-name selfRef">UUIDv7 Encoding</a>
+            </h5>
+<p id="section-4.4.4.1-1">
+  Since the UUIDv7 Unix timestamp is fixed at 36 bits in length the exact layout for encoding UUIDv7 depends on the precision (number of bits)
+  used for the sub-second portion and the sizes of the optionally desired sequence counter and node bits.<a href="#section-4.4.4.1-1" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-2">
+ Three examples of UUIDv7 encoding are given below as a general guidelines but implementations are not limited to just these three examples.<a href="#section-4.4.4.1-2" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-3">
+ All of these fields are only used during encoding, and during decoding the system is unaware of the bit layout used for them and considers this information opaque.
+ As such, implementations generating these values can assign whatever lengths to each field it deems applicable, as long as it does not break decoding compatibility
+ (i.e. Unix timestamp (unixts), version (ver) and variant (var) have to stay where they are, and clock sequence counter (seq), random (random) or other implementation specific values must follow the sub-second encoding).<a href="#section-4.4.4.1-3" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-4">
+ In Figure 3 the UUIDv7 has been created with millisecond precision with the available sub-second precision bits.<a href="#section-4.4.4.1-4" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-5">
+ Examining Figure 3 one can observe:<a href="#section-4.4.4.1-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.4.4.1-6.1">
+                <p id="section-4.4.4.1-6.1.1">The first 36 bits have been dedicated to the Unix Timestamp (unixts)<a href="#section-4.4.4.1-6.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-6.2">
+                <p id="section-4.4.4.1-6.2.1">All 12 bits of scenario subsec_a is fully dedicated to millisecond information (msec).<a href="#section-4.4.4.1-6.2.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-6.3">
+                <p id="section-4.4.4.1-6.3.1">The 4 Version bits remain unchanged (ver).<a href="#section-4.4.4.1-6.3.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-6.4">
+                <p id="section-4.4.4.1-6.4.1">All 12 bits of subsec_b have been dedicated to a motonic clock sequence counter (seq).<a href="#section-4.4.4.1-6.4.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-6.5">
+                <p id="section-4.4.4.1-6.5.1">The 2 Variant bits remain unchanged (var).<a href="#section-4.4.4.1-6.5.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-6.6">
+                <p id="section-4.4.4.1-6.6.1">Finally the remaining 62 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).<a href="#section-4.4.4.1-6.6.1" class="pilcrow">¶</a></p>
+</li>
+            </ul>
+<span id="name-uuidv7-field-and-bit-layout-"></span><figure id="figure-3">
+              <div class="artwork art-text alignLeft" id="section-4.4.4.1-7.1">
+<pre>
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            unixts                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |unixts |         msec          |  ver  |          seq          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |var|                         rand                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                             rand                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<a href="#name-uuidv7-field-and-bit-layout-" class="selfRef">UUIDv7 Field and Bit Layout - Encoding Example (Millisecond Precision)</a>
+              </figcaption></figure>
+<p id="section-4.4.4.1-8">
+ In Figure 4 the UUIDv7 has been created with Microsecond precision with the available sub-second precision bits.<a href="#section-4.4.4.1-8" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-9">
+ Examining Figure 4 one can observe:<a href="#section-4.4.4.1-9" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.4.4.1-10.1">
+                <p id="section-4.4.4.1-10.1.1">The first 36 bits have been dedicated to the Unix Timestamp (unixts)<a href="#section-4.4.4.1-10.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.2">
+                <p id="section-4.4.4.1-10.2.1">All 12 bits of scenario subsec_a is fully dedicated to providing sub-second encoding for the Microsecond precision (usec).<a href="#section-4.4.4.1-10.2.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.3">
+                <p id="section-4.4.4.1-10.3.1">The 4 Version bits remain unchanged (ver).<a href="#section-4.4.4.1-10.3.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.4">
+                <p id="section-4.4.4.1-10.4.1">All 12 bits of subsec_b have been dedicated to providing sub-second encoding for the Microsecond precision (usec).<a href="#section-4.4.4.1-10.4.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.5">
+                <p id="section-4.4.4.1-10.5.1">The 2 Variant bits remain unchanged (var).<a href="#section-4.4.4.1-10.5.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.6">
+                <p id="section-4.4.4.1-10.6.1">A 14 bit motonic clock sequence counter (seq) has been embedded in the most significant position of subsec_seq_node<a href="#section-4.4.4.1-10.6.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-10.7">
+                <p id="section-4.4.4.1-10.7.1">Finally the remaining 48 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).<a href="#section-4.4.4.1-10.7.1" class="pilcrow">¶</a></p>
+</li>
+            </ul>
+<span id="name-uuidv7-field-and-bit-layout-e"></span><figure id="figure-4">
+              <div class="artwork art-text alignLeft" id="section-4.4.4.1-11.1">
+<pre>
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            unixts                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |unixts |         usec          |  ver  |         usec          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |var|             seq           |            rand               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                             rand                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-uuidv7-field-and-bit-layout-e" class="selfRef">UUIDv7 Field and Bit Layout - Encoding Example (Microsecond Precision)</a>
+              </figcaption></figure>
+<p id="section-4.4.4.1-12">
+ In Figure 5 the UUIDv7 has been created with Nanosecond precision with the available sub-second precision bits.<a href="#section-4.4.4.1-12" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.1-13">
+ Examining Figure 5 one can observe:<a href="#section-4.4.4.1-13" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-4.4.4.1-14.1">
+                <p id="section-4.4.4.1-14.1.1">The first 36 bits have been dedicated to the Unix Timestamp (unixts)<a href="#section-4.4.4.1-14.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.2">
+                <p id="section-4.4.4.1-14.2.1">All 12 bits of scenario subsec_a is fully dedicated to providing sub-second encoding for the Nanosecond precision (nsec).<a href="#section-4.4.4.1-14.2.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.3">
+                <p id="section-4.4.4.1-14.3.1">The 4 Version bits remain unchanged (ver).<a href="#section-4.4.4.1-14.3.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.4">
+                <p id="section-4.4.4.1-14.4.1">All 12 bits of subsec_b have been dedicated to providing sub-second encoding for the Nanosecond precision (nsec).<a href="#section-4.4.4.1-14.4.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.5">
+                <p id="section-4.4.4.1-14.5.1">The 2 Variant bits remain unchanged (var).<a href="#section-4.4.4.1-14.5.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.6">
+                <p id="section-4.4.4.1-14.6.1">The first 14 bit of the subsec_seq_node dedicated to providing sub-second encoding for the Nanosecond precision (nsec).<a href="#section-4.4.4.1-14.6.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.7">
+                <p id="section-4.4.4.1-14.7.1">The next 8 bits of subsec_seq_node dedicated a motonic clock sequence counter (seq).<a href="#section-4.4.4.1-14.7.1" class="pilcrow">¶</a></p>
+</li>
+              <li class="normal" id="section-4.4.4.1-14.8">
+                <p id="section-4.4.4.1-14.8.1">Finally the remaining 40 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).<a href="#section-4.4.4.1-14.8.1" class="pilcrow">¶</a></p>
+</li>
+            </ul>
+<span id="name-uuidv7-field-and-bit-layout-en"></span><figure id="figure-5">
+              <div class="artwork art-text alignLeft" id="section-4.4.4.1-15.1">
+<pre>
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            unixts                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |unixts |         nsec          |  ver  |         nsec          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |var|             nsec          |      seq      |     rand      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                             rand                              |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<a href="#name-uuidv7-field-and-bit-layout-en" class="selfRef">UUIDv7 Field and Bit Layout - Encoding Example (Nanosecond Precision)</a>
+              </figcaption></figure>
+</section>
+</div>
+<div id="uuidv7decoding">
+<section id="section-4.4.4.2">
+            <h5 id="name-uuidv7-decoding">
+<a href="#section-4.4.4.2" class="section-number selfRef">4.4.4.2. </a><a href="#name-uuidv7-decoding" class="section-name selfRef">UUIDv7 Decoding</a>
+            </h5>
+<p id="section-4.4.4.2-1">
+ When decoding or parsing a UUIDv7 value there are only two values to be considered:<a href="#section-4.4.4.2-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.4.4.2-2">
+ <li id="section-4.4.4.2-2.1">
+                <p id="section-4.4.4.2-2.1.1">The unix timestamp defined as unixts<a href="#section-4.4.4.2-2.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li id="section-4.4.4.2-2.2">
+                <p id="section-4.4.4.2-2.2.1">The sub-second precision values defined as subsec_a, subsec_b, and subsec_seq_node<a href="#section-4.4.4.2-2.2.1" class="pilcrow">¶</a></p>
+</li>
+            </ol>
+<p id="section-4.4.4.2-3">As detailed in Figure 2 the unix timestamp (unixts) is always the first 36 bits of the UUIDv7 layout.<a href="#section-4.4.4.2-3" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.2-4">
+ Similarly as per Figure 2, the sub-second precision values lie within subsec_a, subsec_b, and subsec_seq_node which are all interpreted as sub-second information after skipping over the version (ver) and (var) bits.  
+ These concatenated sub-second information bits are interpreted in a way where most to least significant bits represent a further division by two.
+ This is the same normal place notation used to express fractional numbers, except in binary. For example, in decimal ".1" means one tenth, and ".01" means one hundredth.
+ In this subsec field, a 1 means one half, 01 means one quarter, 001 is one eighth, etc.
+ This scheme can work for any number of bits up to the maximum available, and keeps the most significant data leftmost in the bit sequence.<a href="#section-4.4.4.2-4" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.2-5">
+ To perform the sub-second math, simply take the first (most significant/leftmost) N bits of subsec and divide it by 2^N. Take for example:<a href="#section-4.4.4.2-5" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.4.4.2-6">
+ <li id="section-4.4.4.2-6.1">
+                <p id="section-4.4.4.2-6.1.1">To parse the first 16 bits, extract that value as an integer and divide it by 65536 (2 to the 16th).<a href="#section-4.4.4.2-6.1.1" class="pilcrow">¶</a></p>
+</li>
+              <li id="section-4.4.4.2-6.2">
+                <p id="section-4.4.4.2-6.2.1">If these 16 bits are 0101 0101 0101 0101, then treating that as an integer gives 0x5555 or 21845 in decimal, and dividing by 65536 gives 0.3333282<a href="#section-4.4.4.2-6.2.1" class="pilcrow">¶</a></p>
+</li>
+            </ol>
+<p id="section-4.4.4.2-7">
+ This sub-second encoding scheme provides maximum interoperability across systems where different levels of time precision are required/feasible/available.
+ The timestamp value derived from a UUIDv7 value SHOULD be "as close to the correct value as possible" when parsed, even across disparate systems.<a href="#section-4.4.4.2-7" class="pilcrow">¶</a></p>
+<p id="section-4.4.4.2-8">
+ Take for example the starting point for our next two UUIDv7 parsing scenarios:<a href="#section-4.4.4.2-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.4.4.2-9">
+ <li id="section-4.4.4.2-9.1">System A produces a UUIDv7 with a microsecond-precise timestamp value.<a href="#section-4.4.4.2-9.1" class="pilcrow">¶</a>
+</li>
+              <li id="section-4.4.4.2-9.2">System B is unaware of the precision encoded in the UUIDv7 timestamp by System A.<a href="#section-4.4.4.2-9.2" class="pilcrow">¶</a>
+</li>
+            </ol>
+<p id="section-4.4.4.2-10">
+ Scenario 1:<a href="#section-4.4.4.2-10" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.4.4.2-11">
+ <li id="section-4.4.4.2-11.1">System B parses the embedded timestamp with millisecond precision. (Less precision than the encoder)<a href="#section-4.4.4.2-11.1" class="pilcrow">¶</a>
+</li>
+              <li id="section-4.4.4.2-11.2">System B SHOULD return the correct millisecond value encoded by system A (truncated to milliseconds).<a href="#section-4.4.4.2-11.2" class="pilcrow">¶</a>
+</li>
+            </ol>
+<p id="section-4.4.4.2-12">
+ Scenario 2:<a href="#section-4.4.4.2-12" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.4.4.2-13">
+ <li id="section-4.4.4.2-13.1">System B parses the timestamp with nanosecond precision. (More precision than the encoder)<a href="#section-4.4.4.2-13.1" class="pilcrow">¶</a>
+</li>
+              <li id="section-4.4.4.2-13.2">System B's value returned SHOULD have the same microsecond level of precision provided by the encoder with the additional precision down to nanosecond level being essentially random as per the encoded random value at the end of the UUIDv7.<a href="#section-4.4.4.2-13.2" class="pilcrow">¶</a>
+</li>
+            </ol>
+</section>
+</div>
 </section>
 </div>
 </section>
@@ -1931,20 +2207,20 @@ dt+dd:empty::before{
 <p id="section-4.5-4">
         Roughly speaking a properly formatted UUIDv8 SHOULD contain
         the following sections adding up to a total of 128-bits.<a href="#section-4.5-4" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact">
-<li class="ulEmpty compact" id="section-4.5-5.1">
+<ul class="compact ulEmpty">
+<li class="compact ulEmpty" id="section-4.5-5.1">
             <p id="section-4.5-5.1.1">- Timestamp Bits (Variable Length)<a href="#section-4.5-5.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact" id="section-4.5-5.2">
+          <li class="compact ulEmpty" id="section-4.5-5.2">
             <p id="section-4.5-5.2.1">- Clock Sequence Bits (Variable Length)<a href="#section-4.5-5.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact" id="section-4.5-5.3">
+          <li class="compact ulEmpty" id="section-4.5-5.3">
             <p id="section-4.5-5.3.1">- Node Bits (Variable Length)<a href="#section-4.5-5.3.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact" id="section-4.5-5.4">
+          <li class="compact ulEmpty" id="section-4.5-5.4">
             <p id="section-4.5-5.4.1">- UUIDv8 Version Bits (4 bits)<a href="#section-4.5-5.4.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty compact" id="section-4.5-5.5">
+          <li class="compact ulEmpty" id="section-4.5-5.5">
             <p id="section-4.5-5.5.1">- UUID Variant Bits (2 Bits)<a href="#section-4.5-5.5.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
@@ -1957,9 +2233,9 @@ dt+dd:empty::before{
         significant bit position followed directly by a clock sequence counter
         and finally a node containing either random data or implementation specific data.<a href="#section-4.5-6" class="pilcrow">¶</a></p>
 <p id="section-4.5-7">
-        A sample format in Figure 3 is used to further illustrate the point
+        A sample format in Figure 6 is used to further illustrate the point
         for the 16-octet, 128-bit UUIDv8.<a href="#section-4.5-7" class="pilcrow">¶</a></p>
-<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-3">
+<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-6">
           <div class="artwork art-text alignLeft" id="section-4.5-8.1">
 <pre>
      0                   1                   2                   3
@@ -1975,7 +2251,7 @@ dt+dd:empty::before{
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-uuidv8-field-and-bit-layout" class="selfRef">UUIDv8 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-4.5-9">
@@ -2029,14 +2305,14 @@ dt+dd:empty::before{
             any monotonically stable timestamp source for UUIDv8.<a href="#section-4.5.1-1" class="pilcrow">¶</a></p>
 <p id="section-4.5.1-2">
             Some examples include:<a href="#section-4.5.1-2" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact">
-<li class="ulEmpty compact" id="section-4.5.1-3.1">
+<ul class="compact ulEmpty">
+<li class="compact ulEmpty" id="section-4.5.1-3.1">
               <p id="section-4.5.1-3.1.1">- Custom Epoch<a href="#section-4.5.1-3.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="ulEmpty compact" id="section-4.5.1-3.2">
+            <li class="compact ulEmpty" id="section-4.5.1-3.2">
               <p id="section-4.5.1-3.2.1">- NTP Timestamp<a href="#section-4.5.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li class="ulEmpty compact" id="section-4.5.1-3.3">
+            <li class="compact ulEmpty" id="section-4.5.1-3.3">
               <p id="section-4.5.1-3.3.1">- ISO 8601 timestamp<a href="#section-4.5.1-3.3.1" class="pilcrow">¶</a></p>
 </li>
           </ul>
@@ -2095,7 +2371,7 @@ dt+dd:empty::before{
             nanosecond precision will require less clock sequence bits than a timestamp
             source utilizing seconds for precision.<a href="#section-4.5.2-1" class="pilcrow">¶</a></p>
 <p id="section-4.5.2-2">
-            The UUIDv8 layout in Figure 3 generically defines two possible
+            The UUIDv8 layout in Figure 6 generically defines two possible
             clock sequence values that can leveraged:<a href="#section-4.5.2-2" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-4.5.2-3.1">
@@ -2132,7 +2408,7 @@ dt+dd:empty::before{
             the node MUST NOT be set to all 0s which does not ensure global uniqueness.
             In most scenarios the node will be filled with pseudo-random data.<a href="#section-4.5.3-1" class="pilcrow">¶</a></p>
 <p id="section-4.5.3-2">
-            The UUIDv8 layout in Figure 3 defines 2 sizes of Node
+            The UUIDv8 layout in Figure 6 defines 2 sizes of Node
             depending on the timestamp size:<a href="#section-4.5.3-2" class="pilcrow">¶</a></p>
 <ul class="compact">
 <li class="compact" id="section-4.5.3-3.1">
@@ -2162,7 +2438,7 @@ dt+dd:empty::before{
             specific application/language requirements.
             As such any UUIDv8 implementations will likely vary among applications.<a href="#section-4.5.4-1" class="pilcrow">¶</a></p>
 <p id="section-4.5.4-2">
-            The following algorithm is a generic implementation using Figure 3
+            The following algorithm is a generic implementation using Figure 6
             and the recommendations outlined in this specification.<a href="#section-4.5.4-2" class="pilcrow">¶</a></p>
 <p id="section-4.5.4-3">
             <strong>32-bit timestamp, 12-bit sequence counter, 62-bit node:</strong><a href="#section-4.5.4-3" class="pilcrow">¶</a></p>
@@ -2437,7 +2713,7 @@ dt+dd:empty::before{
 <dd class="break"></dd>
 <dt id="RFC4122">[RFC4122]</dt>
     <dd>
-<span class="refAuthor">Leach, P.</span><span class="refAuthor">, Mealling, M.</span><span class="refAuthor">, and R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>

--- a/draft-peabody-dispatch-new-uuid-format-01.txt
+++ b/draft-peabody-dispatch-new-uuid-format-01.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                        17 February 2021
-Expires: 21 August 2021
+Intended status: Standards Track                           22 April 2021
+Expires: 24 October 2021
 
 
                             New UUID Formats
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 21 August 2021.
+   This Internet-Draft will expire on 24 October 2021.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 1]
+Peabody & Davis          Expires 24 October 2021                [Page 1]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -80,24 +80,24 @@ Table of Contents
        4.3.2.  UUIDv6 Clock Sequence Usage . . . . . . . . . . . . .   8
        4.3.3.  UUIDv6 Node Usage . . . . . . . . . . . . . . . . . .   8
        4.3.4.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .   8
-     4.4.  UUIDv7 Layout and Bit Order . . . . . . . . . . . . . . .   9
-       4.4.1.  UUIDv7 Timestamp Usage  . . . . . . . . . . . . . . .  10
-       4.4.2.  UUIDv7 Clock Sequence Usage . . . . . . . . . . . . .  10
-       4.4.3.  UUIDv7 Node Usage . . . . . . . . . . . . . . . . . .  10
-       4.4.4.  UUIDv7 Basic Creation Algorithm . . . . . . . . . . .  10
-     4.5.  UUIDv8 Layout and Bit Order . . . . . . . . . . . . . . .  10
-       4.5.1.  UUIDv8 Timestamp Usage  . . . . . . . . . . . . . . .  12
-       4.5.2.  UUIDv8 Clock Sequence Usage . . . . . . . . . . . . .  13
-       4.5.3.  UUIDv8 Node Usage . . . . . . . . . . . . . . . . . .  14
-       4.5.4.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .  14
-   5.  Encoding and Storage  . . . . . . . . . . . . . . . . . . . .  17
-   6.  Global Uniqueness . . . . . . . . . . . . . . . . . . . . . .  18
-   7.  Distributed UUID Generation . . . . . . . . . . . . . . . . .  18
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  18
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  18
-   10. Normative References  . . . . . . . . . . . . . . . . . . . .  19
-   11. Informative References  . . . . . . . . . . . . . . . . . . .  19
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  20
+     4.4.  UUIDv7 Layout and Bit Order . . . . . . . . . . . . . . .  10
+       4.4.1.  UUIDv7 Timestamp Usage  . . . . . . . . . . . . . . .  11
+       4.4.2.  UUIDv7 Clock Sequence Usage . . . . . . . . . . . . .  11
+       4.4.3.  UUIDv7 Node Usage . . . . . . . . . . . . . . . . . .  11
+       4.4.4.  UUIDv7 Encoding and Decoding  . . . . . . . . . . . .  11
+     4.5.  UUIDv8 Layout and Bit Order . . . . . . . . . . . . . . .  16
+       4.5.1.  UUIDv8 Timestamp Usage  . . . . . . . . . . . . . . .  18
+       4.5.2.  UUIDv8 Clock Sequence Usage . . . . . . . . . . . . .  20
+       4.5.3.  UUIDv8 Node Usage . . . . . . . . . . . . . . . . . .  20
+       4.5.4.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .  21
+   5.  Encoding and Storage  . . . . . . . . . . . . . . . . . . . .  24
+   6.  Global Uniqueness . . . . . . . . . . . . . . . . . . . . . .  24
+   7.  Distributed UUID Generation . . . . . . . . . . . . . . . . .  24
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  25
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  25
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 2]
+Peabody & Davis          Expires 24 October 2021                [Page 2]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
 2.  Background
@@ -165,9 +165,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 3]
+Peabody & Davis          Expires 24 October 2021                [Page 3]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
    Furthermore, UUIDv1 utilizes a non-standard timestamp epoch derived
@@ -197,7 +197,7 @@ Internet-Draft               new-uuid-format               February 2021
    While preparing this specification the following 16 different
    implementations were analyzed for trends in total ID length, bit
    Layout, lexical formatting/encoding, timestamp type, timestamp
-   format, timestamp accurancy, node format/components, collision
+   format, timestamp accuracy, node format/components, collision
    handling and multi-timestamp tick generation sequencing.
 
    1.   [LexicalUUID] by Twitter
@@ -221,9 +221,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 4]
+Peabody & Davis          Expires 24 October 2021                [Page 4]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
    An inspection of these implementations details the following trends
@@ -277,9 +277,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 5]
+Peabody & Davis          Expires 24 October 2021                [Page 5]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
 4.  Format
@@ -333,9 +333,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 6]
+Peabody & Davis          Expires 24 October 2021                [Page 6]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
 4.3.  UUIDv6 Layout and Bit Order
@@ -389,9 +389,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 7]
+Peabody & Davis          Expires 24 October 2021                [Page 7]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
    clock_seq_low:
@@ -445,9 +445,9 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 8]
+Peabody & Davis          Expires 24 October 2021                [Page 8]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
 
 
    7.   Create the 16-bit time_low_and_version by concatenating the
@@ -496,37 +496,388 @@ Internet-Draft               new-uuid-format               February 2021
                      Table 3: UUIDv1 to UUIDv6 Field
                                  Mappings
 
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021                [Page 9]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
 4.4.  UUIDv7 Layout and Bit Order
 
+   The UUIDv7 format is designed to encode a Unix timestamp with
+   arbitrary sub-second precision.  The key property provided by UUIDv7
+   is that timestamp values generated by one system and parsed by
+   another are guaranteed to have sub-section precision of either the
+   generator or the parser, whichever is less.  Additionally, the system
+   parsing the UUIDv7 value does not need to know which precision was
+   used during encoding in order to function correctly.
+
+   The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 2
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            unixts                             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |unixts |       subsec_a        |  ver  |       subsec_b        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |var|                   subsec_seq_node                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                       subsec_seq_node                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                   Figure 2: UUIDv7 Field and Bit Layout
+
+   unixts:
+      36-bit big-endian unsigned Unix Timestamp value
+
+   subsec_a:
+      12-bits allocated to sub-section precision values.
+
+   ver:
+      The 4 bit UUIDv8 version (0111)
+
+   subsec_b:
+      12-bits allocated to sub-section precision values.
+
+   var:
+      2-bit UUID variant (10)
+
+   subsec_seq_node:
+      The remaining 62 bits which MAY be allocated to any combination of
+      additional sub-section precision, sequence counter, or pseudo-
+      random data.
 
 
 
-Peabody & Davis          Expires 21 August 2021                 [Page 9]
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 10]
 
-Internet-Draft               new-uuid-format               February 2021
+Internet-Draft               new-uuid-format                  April 2021
+
+
+4.4.1.  UUIDv7 Timestamp Usage
+
+   UUIDv7 utilizes a 36-bit big-endian unsigned Unix Timestamp value
+   (number of seconds since the epoch of 1 Jan 1970, leap seconds
+   excluded so each hour is exactly 3600 seconds long).
+
+   Additional sub-second precision (millisecond, nanosecond,
+   microsecond, etc) MAY be provided for encoding and decoding in the
+   remaining bits in the layout.
+
+4.4.2.  UUIDv7 Clock Sequence Usage
+
+   UUIDv7 SHOULD utilize a motonic sequence counter to provide
+   additional sequencing guarantees when multiple UUIDv7 values are
+   created in the same UNIXTS and SUBSEC timestamp.  The amount of bits
+   allocates to the sequence counter depend on the precision of the
+   timestamp.  For example, a more accurate timestamp source using
+   nanosecond precision will require less clock sequence bits than a
+   timestamp source utilizing seconds for precision.  For best
+   sequencing results the sequence counter SHOULD be placed immediately
+   after available sub-second bits.
+
+   The clock sequence MUST start at zero and increment monotonically for
+   each new UUID created on by the application on the same timestamp.
+   When the timestamp increments the clock sequence MUST be reset to
+   zero.  The clock sequence MUST NOT rollover or reset to zero unless
+   the timestamp has incremented.  Care MUST be given to ensure that an
+   adequate sized clock sequence is selected for a given application
+   based on expected timestamp precision and expected UUID generation
+   rates.
+
+4.4.3.  UUIDv7 Node Usage
+
+   UUIDv7 implementations, even with very detailed sub-second precision
+   and the optional sequence counter, MAY have leftover bits that will
+   be identified as the Node for this section.  The UUIDv7 Node MAY
+   contain any set of data an implementation desires however the node
+   MUST NOT be set to all 0s which does not ensure global uniqueness.
+   In most scenarios the node SHOULD be filled with pseudo-random data.
+
+4.4.4.  UUIDv7 Encoding and Decoding
+
+   The UUIDv7 bit layout for encoding and decoding are described
+   separately in this document.
+
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 11]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
+4.4.4.1.  UUIDv7 Encoding
+
+   Since the UUIDv7 Unix timestamp is fixed at 36 bits in length the
+   exact layout for encoding UUIDv7 depends on the precision (number of
+   bits) used for the sub-second portion and the sizes of the optionally
+   desired sequence counter and node bits.
+
+   Three examples of UUIDv7 encoding are given below as a general
+   guidelines but implementations are not limited to just these three
+   examples.
+
+   All of these fields are only used during encoding, and during
+   decoding the system is unaware of the bit layout used for them and
+   considers this information opaque.  As such, implementations
+   generating these values can assign whatever lengths to each field it
+   deems applicable, as long as it does not break decoding compatibility
+   (i.e.  Unix timestamp (unixts), version (ver) and variant (var) have
+   to stay where they are, and clock sequence counter (seq), random
+   (random) or other implementation specific values must follow the sub-
+   second encoding).
+
+   In Figure 3 the UUIDv7 has been created with millisecond precision
+   with the available sub-second precision bits.
+
+   Examining Figure 3 one can observe:
+
+   *  The first 36 bits have been dedicated to the Unix Timestamp
+      (unixts)
+
+   *  All 12 bits of scenario subsec_a is fully dedicated to millisecond
+      information (msec).
+
+   *  The 4 Version bits remain unchanged (ver).
+
+   *  All 12 bits of subsec_b have been dedicated to a motonic clock
+      sequence counter (seq).
+
+   *  The 2 Variant bits remain unchanged (var).
+
+   *  Finally the remaining 62 bits in the subsec_seq_node section are
+      layout is filled out with random data to pad the length and
+      provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 12]
+
+Internet-Draft               new-uuid-format                  April 2021
 
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       |                      unix_timestamp_sec                       |
+       |                            unixts                             |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       |       |       ms_time         |  ver  |      us_time          |
+       |unixts |         msec          |  ver  |          seq          |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       | var |    ns_time    |           node                          |
+       |var|                         rand                              |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-       |                                                               |
+       |                             rand                              |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 2: UUIDv7 Field and Bit Layout
+   Figure 3: UUIDv7 Field and Bit Layout - Encoding Example (Millisecond
+                                 Precision)
 
-4.4.1.  UUIDv7 Timestamp Usage
+   In Figure 4 the UUIDv7 has been created with Microsecond precision
+   with the available sub-second precision bits.
 
-4.4.2.  UUIDv7 Clock Sequence Usage
+   Examining Figure 4 one can observe:
 
-4.4.3.  UUIDv7 Node Usage
+   *  The first 36 bits have been dedicated to the Unix Timestamp
+      (unixts)
 
-4.4.4.  UUIDv7 Basic Creation Algorithm
+   *  All 12 bits of scenario subsec_a is fully dedicated to providing
+      sub-second encoding for the Microsecond precision (usec).
+
+   *  The 4 Version bits remain unchanged (ver).
+
+   *  All 12 bits of subsec_b have been dedicated to providing sub-
+      second encoding for the Microsecond precision (usec).
+
+   *  The 2 Variant bits remain unchanged (var).
+
+   *  A 14 bit motonic clock sequence counter (seq) has been embedded in
+      the most significant position of subsec_seq_node
+
+   *  Finally the remaining 48 bits in the subsec_seq_node section are
+      layout is filled out with random data to pad the length and
+      provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 13]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            unixts                             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |unixts |         usec          |  ver  |         usec          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |var|             seq           |            rand               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                             rand                              |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Figure 4: UUIDv7 Field and Bit Layout - Encoding Example (Microsecond
+                                 Precision)
+
+   In Figure 5 the UUIDv7 has been created with Nanosecond precision
+   with the available sub-second precision bits.
+
+   Examining Figure 5 one can observe:
+
+   *  The first 36 bits have been dedicated to the Unix Timestamp
+      (unixts)
+
+   *  All 12 bits of scenario subsec_a is fully dedicated to providing
+      sub-second encoding for the Nanosecond precision (nsec).
+
+   *  The 4 Version bits remain unchanged (ver).
+
+   *  All 12 bits of subsec_b have been dedicated to providing sub-
+      second encoding for the Nanosecond precision (nsec).
+
+   *  The 2 Variant bits remain unchanged (var).
+
+   *  The first 14 bit of the subsec_seq_node dedicated to providing
+      sub-second encoding for the Nanosecond precision (nsec).
+
+   *  The next 8 bits of subsec_seq_node dedicated a motonic clock
+      sequence counter (seq).
+
+   *  Finally the remaining 40 bits in the subsec_seq_node section are
+      layout is filled out with random data to pad the length and
+      provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 14]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            unixts                             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |unixts |         nsec          |  ver  |         nsec          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |var|             nsec          |      seq      |     rand      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                             rand                              |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+          Figure 5: UUIDv7 Field and Bit Layout - Encoding Example
+                           (Nanosecond Precision)
+
+4.4.4.2.  UUIDv7 Decoding
+
+   When decoding or parsing a UUIDv7 value there are only two values to
+   be considered:
+
+   1.  The unix timestamp defined as unixts
+
+   2.  The sub-second precision values defined as subsec_a, subsec_b,
+       and subsec_seq_node
+
+   As detailed in Figure 2 the unix timestamp (unixts) is always the
+   first 36 bits of the UUIDv7 layout.
+
+   Similarly as per Figure 2, the sub-second precision values lie within
+   subsec_a, subsec_b, and subsec_seq_node which are all interpreted as
+   sub-second information after skipping over the version (ver) and
+   (var) bits.  These concatenated sub-second information bits are
+   interpreted in a way where most to least significant bits represent a
+   further division by two.  This is the same normal place notation used
+   to express fractional numbers, except in binary.  For example, in
+   decimal ".1" means one tenth, and ".01" means one hundredth.  In this
+   subsec field, a 1 means one half, 01 means one quarter, 001 is one
+   eighth, etc.  This scheme can work for any number of bits up to the
+   maximum available, and keeps the most significant data leftmost in
+   the bit sequence.
+
+   To perform the sub-second math, simply take the first (most
+   significant/leftmost) N bits of subsec and divide it by 2^N.  Take
+   for example:
+
+   1.  To parse the first 16 bits, extract that value as an integer and
+       divide it by 65536 (2 to the 16th).
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 15]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
+   2.  If these 16 bits are 0101 0101 0101 0101, then treating that as
+       an integer gives 0x5555 or 21845 in decimal, and dividing by
+       65536 gives 0.3333282
+
+   This sub-second encoding scheme provides maximum interoperability
+   across systems where different levels of time precision are
+   required/feasible/available.  The timestamp value derived from a
+   UUIDv7 value SHOULD be "as close to the correct value as possible"
+   when parsed, even across disparate systems.
+
+   Take for example the starting point for our next two UUIDv7 parsing
+   scenarios:
+
+   1.  System A produces a UUIDv7 with a microsecond-precise timestamp
+       value.
+
+   2.  System B is unaware of the precision encoded in the UUIDv7
+       timestamp by System A.
+
+   Scenario 1:
+
+   1.  System B parses the embedded timestamp with millisecond
+       precision.  (Less precision than the encoder)
+
+   2.  System B SHOULD return the correct millisecond value encoded by
+       system A (truncated to milliseconds).
+
+   Scenario 2:
+
+   1.  System B parses the timestamp with nanosecond precision.  (More
+       precision than the encoder)
+
+   2.  System B's value returned SHOULD have the same microsecond level
+       of precision provided by the encoder with the additional
+       precision down to nanosecond level being essentially random as
+       per the encoded random value at the end of the UUIDv7.
 
 4.5.  UUIDv8 Layout and Bit Order
 
@@ -537,6 +888,15 @@ Internet-Draft               new-uuid-format               February 2021
    UUIDv8 SHOULD only be utilized if an implementation cannot utilize
    UUIDv1, UUIDv6, or UUIDv8.  Some situations in which UUIDv8 usage
    could occur:
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 16]
+
+Internet-Draft               new-uuid-format                  April 2021
+
 
    *  An implementation would like to utilize a timestamp source not
       defined by the current time-based UUIDs.
@@ -552,15 +912,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    *  An implementation has other application/language restrictions
       which inhibit the usage of one of the current time-based UUIDs.
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 10]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    Roughly speaking a properly formatted UUIDv8 SHOULD contain the
    following sections adding up to a total of 128-bits.
@@ -580,7 +931,7 @@ Internet-Draft               new-uuid-format               February 2021
    sequence counter and finally a node containing either random data or
    implementation specific data.
 
-   A sample format in Figure 3 is used to further illustrate the point
+   A sample format in Figure 6 is used to further illustrate the point
    for the 16-octet, 128-bit UUIDv8.
 
         0                   1                   2                   3
@@ -595,7 +946,15 @@ Internet-Draft               new-uuid-format               February 2021
        |                              node                             |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 3: UUIDv8 Field and Bit Layout
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 17]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
+                   Figure 6: UUIDv8 Field and Bit Layout
 
    timestamp_32:
       The most significant 32 bits of the desired timestamp source.
@@ -608,15 +967,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    ver:
       The 4 bit UUIDv8 version (1000).  Occupies bits 48 through 51.
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 11]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    time_or_seq:
       If a 60-bit, or larger, timestamp is used these 12-bits are used
@@ -651,6 +1001,15 @@ Internet-Draft               new-uuid-format               February 2021
       - NTP Timestamp
       - ISO 8601 timestamp
 
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 18]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
    The relaxed nature UUIDv8 timestamps also works to future proof this
    specification and allow implementations a method to create compliant
    time-based UUIDs using timestamp source that might not yet be
@@ -666,13 +1025,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    *  60-bit timestamp: using timestamp_32, timestamp_48, and
       time_or_seq
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 12]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    *  64-bit timestamp: using timestamp_32, timestamp_48, and
       time_or_seq and truncating the timestamp the 60 most significant
@@ -698,6 +1050,22 @@ Internet-Draft               new-uuid-format               February 2021
    existing knowledge of the source timestamp used by the UUIDv8
    implementation.
 
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 19]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
 4.5.2.  UUIDv8 Clock Sequence Usage
 
    A clock sequence MUST be used with UUIDv8 as added sequencing
@@ -708,7 +1076,7 @@ Internet-Draft               new-uuid-format               February 2021
    sequence bits than a timestamp source utilizing seconds for
    precision.
 
-   The UUIDv8 layout in Figure 3 generically defines two possible clock
+   The UUIDv8 layout in Figure 6 generically defines two possible clock
    sequence values that can leveraged:
 
    *  12-bit clock sequence using time_or_seq for use when the timestamp
@@ -721,14 +1089,6 @@ Internet-Draft               new-uuid-format               February 2021
    sequence are needed for a given clock tick.  Furthermore, more bits
    from the node MAY be used for clock sequencing in the event that
    8-bits is not sufficient.
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 13]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    The clock sequence MUST start at zero and increment monotonically for
    each new UUID created on by the application on the same timestamp.
@@ -746,13 +1106,21 @@ Internet-Draft               new-uuid-format               February 2021
    global uniqueness.  In most scenarios the node will be filled with
    pseudo-random data.
 
-   The UUIDv8 layout in Figure 3 defines 2 sizes of Node depending on
+   The UUIDv8 layout in Figure 6 defines 2 sizes of Node depending on
    the timestamp size:
 
    *  62-bit node encompassing seq_or_node and node Used when a
       timestamp of 48-bits or less is leveraged.
    *  54-bit node when all 60-bits of the timestamp are in use and the
       seq_or_node is used as clock sequencing.
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 20]
+
+Internet-Draft               new-uuid-format                  April 2021
+
 
    An implementation MAY choose to allocate bits from the node to the
    timestamp, clock sequence or application-specific embedded field.  It
@@ -766,7 +1134,7 @@ Internet-Draft               new-uuid-format               February 2021
    requirements.  As such any UUIDv8 implementations will likely vary
    among applications.
 
-   The following algorithm is a generic implementation using Figure 3
+   The following algorithm is a generic implementation using Figure 6
    and the recommendations outlined in this specification.
 
    *32-bit timestamp, 12-bit sequence counter, 62-bit node:*
@@ -777,14 +1145,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    2.   Obtain the current time from the selected clock source as 32
         bits.
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 14]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    3.   Set the 32-bit field timestamp_32 to the 32 bits from the
         timestamp
@@ -808,6 +1168,15 @@ Internet-Draft               new-uuid-format               February 2021
 
    10.  Format by concatenating the 128-bits as: timestamp_32|timestamp_
         48|version|time_or_node|variant|seq_or_node|node
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 21]
+
+Internet-Draft               new-uuid-format                  April 2021
+
 
    11.  Save the state (current timestamp and clock sequence) back to
         the stable store
@@ -835,13 +1204,6 @@ Internet-Draft               new-uuid-format               February 2021
         variable, read the UUID generator state: the values of the
         timestamp and clock sequence used to generate the last UUID.
 
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 15]
-
-Internet-Draft               new-uuid-format               February 2021
-
-
    2.   Obtain the current time from the selected clock source as 32
         bits.
 
@@ -864,6 +1226,13 @@ Internet-Draft               new-uuid-format               February 2021
    9.   If the state was available, but the saved timestamp is less than
         or equal to the current timestamp, increment the clock sequence
         value (seq_or_node).
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 22]
+
+Internet-Draft               new-uuid-format                  April 2021
+
 
    10.  Generate 54 random bits and fill in the node
 
@@ -888,15 +1257,6 @@ Internet-Draft               new-uuid-format               February 2021
    1.  From a system-wide shared stable store (e.g., a file) or global
        variable, read the UUID generator state: the values of the
        timestamp and clock sequence used to generate the last UUID.
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 16]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    2.  Obtain the current time from the selected clock source as desired
        bit total
@@ -923,6 +1283,13 @@ Internet-Draft               new-uuid-format               February 2021
 
    8.  Format by concatenating the 128-bits together
 
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 23]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
    9.  Save the state (current timestamp and clock sequence) back to the
        stable store
 
@@ -939,20 +1306,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    Where possible UUIDs SHOULD be stored within database applications as
    the underlying 128-bit binary value.
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 17]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
 6.  Global Uniqueness
 
@@ -982,6 +1335,17 @@ Internet-Draft               new-uuid-format               February 2021
    negotiation of the machineID among distributed nodes is out of scope
    for this specification.
 
+
+
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 24]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
 8.  IANA Considerations
 
    This document has no IANA actions.
@@ -1001,14 +1365,6 @@ Internet-Draft               new-uuid-format               February 2021
    a whole.  If UUIDs are required for use with any security operation
    within an application context in any shape or form then [RFC4122]
    UUIDv4 SHOULD be utilized.
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 18]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    The machineID portion of node, described in Section 7, does provide
    small unique identifier which could be used to determine which
@@ -1037,6 +1393,15 @@ Internet-Draft               new-uuid-format               February 2021
               November 2012,
               <https://github.com/twitter-archive/cassie>.
 
+
+
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 25]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
    [Snowflake]
               Twitter, "Snowflake is a network service for generating
               unique ID numbers at high scale with some simple
@@ -1055,16 +1420,6 @@ Internet-Draft               new-uuid-format               February 2021
 
    [KSUID]    Segment, "K-Sortable Globally Unique IDs", Commit bf376a7,
               July 2020, <https://github.com/segmentio/ksuid>.
-
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 19]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    [Elasticflake]
               Pearcy, P., "Sequential UUID / Flake ID generator pulled
@@ -1096,6 +1451,13 @@ Internet-Draft               new-uuid-format               February 2021
               Commit 660e947, June 2019,
               <https://github.com/chilts/sid>.
 
+
+
+Peabody & Davis          Expires 24 October 2021               [Page 26]
+
+Internet-Draft               new-uuid-format                  April 2021
+
+
    [pushID]   Google, "The 2^120 Ways to Ensure Unique Identifiers",
               February 2015, <https://firebase.googleblog.com/2015/02/
               the-2120-ways-to-ensure-unique_68.html>.
@@ -1112,15 +1474,6 @@ Internet-Draft               new-uuid-format               February 2021
               October 2020, <https://github.com/ericelliott/cuid>.
 
 Authors' Addresses
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 20]
-
-Internet-Draft               new-uuid-format               February 2021
-
 
    Brad G. Peabody
 
@@ -1156,21 +1509,4 @@ Internet-Draft               new-uuid-format               February 2021
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis          Expires 21 August 2021                [Page 21]
+Peabody & Davis          Expires 24 October 2021               [Page 27]

--- a/draft-peabody-dispatch-new-uuid-format-01.xml
+++ b/draft-peabody-dispatch-new-uuid-format-01.xml
@@ -119,7 +119,7 @@
 			over the past 10+ years solving the same problem in slightly different ways.
         </t>
 		<t>
-		   While preparing this specification the following 16 different implementations were analyzed for trends in total ID length, bit Layout, lexical formatting/encoding, timestamp type, timestamp format, timestamp accurancy, node format/components, collision handling and multi-timestamp tick generation sequencing.
+		   While preparing this specification the following 16 different implementations were analyzed for trends in total ID length, bit Layout, lexical formatting/encoding, timestamp type, timestamp format, timestamp accuracy, node format/components, collision handling and multi-timestamp tick generation sequencing.
 		</t>
 		   <ol spacing="compact">
 				<li><t><xref target="LexicalUUID"/> by Twitter</t></li>	
@@ -187,55 +187,55 @@
         In addition the position of both the Version and Variant bits remain unchanged in the layout.
         </t>
 		<section anchor="versions" title="Versions">
-		<t>
-		Table 1 defines the 4-bit version found in Bits 48 through 51 within a given UUID.
-		</t>
-		<table>
-		<name>UUID versions defined by this specification</name>
-		<thead>
-			<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
-		</thead>
-		<tbody>
-			<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6</td><td>Reordered Gregorian time-based UUID</td></tr>
-			<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7</td><td>Variable length Unix Epoch time-based UUID</td></tr>
-			<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8</td><td>Custom time-based UUID</td></tr>
-		</tbody>
-		</table>
+			<t>
+			Table 1 defines the 4-bit version found in Bits 48 through 51 within a given UUID.
+			</t>
+			<table>
+			<name>UUID versions defined by this specification</name>
+			<thead>
+				<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
+			</thead>
+			<tbody>
+				<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6</td><td>Reordered Gregorian time-based UUID</td></tr>
+				<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7</td><td>Variable length Unix Epoch time-based UUID</td></tr>
+				<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8</td><td>Custom time-based UUID</td></tr>
+			</tbody>
+			</table>
 		</section>
         <section anchor="variant" title="Variant">
-        <t>
-		The variant bits utilized by UUIDs in this specification 
-		remains the same as <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>. 
-		</t>
-		<t>
-        The Table 2 lists the contents of the variant field, bits 64 and 65,
-		where the letter "x" indicates a "don't-care" value. Common hex values of 
-		8 (1000), 9 (1001), A (1010), and B (1011) frequent the text representation.
-		</t>
-		<table>
-		<name>UUID Variant defined by this specification</name>
-		<thead>
-			<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Description</td></tr>
-		</thead>
-		<tbody>
-			<tr><td>1</td><td>0</td><td>x</td><td>The variant specified in this document.</td></tr>
-		</tbody>
-		</table>
+			<t>
+			The variant bits utilized by UUIDs in this specification 
+			remains the same as <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>. 
+			</t>
+			<t>
+			The Table 2 lists the contents of the variant field, bits 64 and 65,
+			where the letter "x" indicates a "don't-care" value. Common hex values of 
+			8 (1000), 9 (1001), A (1010), and B (1011) frequent the text representation.
+			</t>
+			<table>
+			<name>UUID Variant defined by this specification</name>
+			<thead>
+				<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Description</td></tr>
+			</thead>
+			<tbody>
+				<tr><td>1</td><td>0</td><td>x</td><td>The variant specified in this document.</td></tr>
+			</tbody>
+			</table>
         </section>
         <section anchor="uuidv6layout" title="UUIDv6 Layout and Bit Order">
-        <t>
-		UUIDv6 aims to be the easiest to implement by reusing most of the layout of bits
-        found in UUIDv1 but with changes to bit ordering for the timestamp.
-        Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
-        time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
-        from the timestamp intact and changes the order to time_high, time_mid, and time_low.
-        Incidentally this will match the original 60-bit Gregorian timestamp source.
-        The clock sequence bits remain unchanged from their usage and position in <xref target="RFC4122"/>.
-        The 48-bit node MUST be set to a pseudo-random value.
-		</t>
-		<t>
-        The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 1
-		</t>
+			<t>
+			UUIDv6 aims to be the easiest to implement by reusing most of the layout of bits
+			found in UUIDv1 but with changes to bit ordering for the timestamp.
+			Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
+			time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
+			from the timestamp intact and changes the order to time_high, time_mid, and time_low.
+			Incidentally this will match the original 60-bit Gregorian timestamp source.
+			The clock sequence bits remain unchanged from their usage and position in <xref target="RFC4122"/>.
+			The 48-bit node MUST be set to a pseudo-random value.
+			</t>
+			<t>
+			The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 1
+			</t>
 <figure>
 <name>UUIDv6 Field and Bit Layout</name>
 <artwork>
@@ -250,7 +250,8 @@
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                         node (2-5)                            |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</artwork></figure>
+</artwork>
+</figure>
 		<dl newline="true">
         <dt>time_high:</dt> <dd>The most significant 32 bits of the 60-bit starting timestamp.
             Occupies bits 0 through 31 (octets 0-3)</dd>
@@ -274,225 +275,174 @@
             Occupies bits 80 through 127 (octets 10-15)</dd>
 		</dl>
             <section anchor="uuidv6timestamp" title="UUIDv6 Timestamp Usage">
-            <t>
-			UUIDv6 reuses the 60-bit Gregorian timestamp with 100-nanosecond
-            precision defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.4"/>.
-            </t>
+				<t>
+				UUIDv6 reuses the 60-bit Gregorian timestamp with 100-nanosecond
+				precision defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.4"/>.
+				</t>
 			</section>
             <section anchor="uuidv6sequence" title="UUIDv6 Clock Sequence  Usage">
-            <t>
-			UUIDv6 makes no change to the Clock Sequence usage defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>.
-			</t>
+				<t>
+				UUIDv6 makes no change to the Clock Sequence usage defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>.
+				</t>
             </section>
             <section anchor="uuidv6node" title="UUIDv6 Node Usage">
-			<t>
-            UUIDv6 node bits SHOULD be set to a 48-bit random or pseudo-random number.
-            UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
-            <xref target="RFC4122" sectionFormat="comma" section="4.5"/> method of generating a random multicast IEEE 802 MAC address.
-			</t>
+				<t>
+				UUIDv6 node bits SHOULD be set to a 48-bit random or pseudo-random number.
+				UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
+				<xref target="RFC4122" sectionFormat="comma" section="4.5"/> method of generating a random multicast IEEE 802 MAC address.
+				</t>
             </section>
             <section anchor="uuidv6pseudo" title="UUIDv6 Basic Creation Algorithm">
-			<t>
-            The following implementation algorithm is based on <xref target="RFC4122"/>
-            but with changes specific to UUIDv6:
-			</t>
-			<ol>
-				<li><t>From a system-wide shared stable store (e.g., a file) or global variable, read the
-				  UUID generator state: the values of the timestamp and clock sequence
-				  used to generate the last UUID.</t></li>
-				<li><t>Obtain the current time as a 60-bit count of 100-nanosecond intervals
-				  since 00:00:00.00, 15 October 1582.</t></li>
-				<li><t>Set the time_low field to the 12 least significant bits
-				  of the starting 60-bit timestamp.</t></li>
-				<li><t>Truncate the timestamp to the 48 most significant bits
-				  in order to create time_high_and_time_mid.</t></li>
-				<li><t>Set the time_high field to the 32 most significant bits of the truncated timestamp.</t></li>
-				<li><t>Set the time_mid field to the 16 least significant bits of the truncated timestamp.</t></li>
-				<li><t>Create the 16-bit time_low_and_version by concatenating the 4-bit UUIDv6 version
-				  with the 12-bit time_low.</t></li>
-				<li><t>If the state was unavailable (e.g., non-existent or corrupted)
-				  or the timestamp is greater than the current timestamp generate
-				  a random 14-bit clock sequence value.</t></li>
-				<li><t>If the state was available, but the saved timestamp is less than or equal to the current
-				  timestamp, increment the clock sequence value.</t></li>
-				<li><t>Complete the 16-bit clock sequence high, low and reserved creation
-				  by concatenating the clock sequence onto UUID variant bits which take
-				  the most significant position in the 16-bit value.</t></li>
-				<li><t>Generate a 48-bit psuedo-random node.</t></li>
-				<li><t>Format by concatenating the 128 bits from each parts:
-				  time_high|time_mid|time_low_and_version|variant_clk_seq|node</t></li>
-				<li><t>Save the state (current timestamp and clock sequence)
-				  back to the stable store</t></li>
-			</ol>  	
-			<t>
-            The steps for splitting time_high_and_time_mid into time_high and time_mid are optional
-            since the 48-bits of time_high and time_mid will remain in the same order as time_high_and_time_mid
-            during the final concatenation. This extra step of splitting into the most significant
-            32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
-            In which the following logic can be applied to reshuffle the bits with minimal modifications.
-			</t>
-			<table>
-			<name>UUIDv1 to UUIDv6 Field Mappings</name>
-			<thead>
-				<tr><td>UUIDv1 Field</td><td>Bits</td><td>UUIDv6 Field</td></tr>
-			</thead>
-			<tbody>
-				<tr><td>time_low </td><td>32</td><td>time_high</td></tr>
-				<tr><td>time_mid </td><td>16</td><td>time_mid</td></tr>
-				<tr><td>time_high</td><td>12</td><td>time_low</td></tr>
-			</tbody>
-			</table>
+				<t>
+				The following implementation algorithm is based on <xref target="RFC4122"/>
+				but with changes specific to UUIDv6:
+				</t>
+				<ol>
+					<li><t>From a system-wide shared stable store (e.g., a file) or global variable, read the
+					  UUID generator state: the values of the timestamp and clock sequence
+					  used to generate the last UUID.</t></li>
+					<li><t>Obtain the current time as a 60-bit count of 100-nanosecond intervals
+					  since 00:00:00.00, 15 October 1582.</t></li>
+					<li><t>Set the time_low field to the 12 least significant bits
+					  of the starting 60-bit timestamp.</t></li>
+					<li><t>Truncate the timestamp to the 48 most significant bits
+					  in order to create time_high_and_time_mid.</t></li>
+					<li><t>Set the time_high field to the 32 most significant bits of the truncated timestamp.</t></li>
+					<li><t>Set the time_mid field to the 16 least significant bits of the truncated timestamp.</t></li>
+					<li><t>Create the 16-bit time_low_and_version by concatenating the 4-bit UUIDv6 version
+					  with the 12-bit time_low.</t></li>
+					<li><t>If the state was unavailable (e.g., non-existent or corrupted)
+					  or the timestamp is greater than the current timestamp generate
+					  a random 14-bit clock sequence value.</t></li>
+					<li><t>If the state was available, but the saved timestamp is less than or equal to the current
+					  timestamp, increment the clock sequence value.</t></li>
+					<li><t>Complete the 16-bit clock sequence high, low and reserved creation
+					  by concatenating the clock sequence onto UUID variant bits which take
+					  the most significant position in the 16-bit value.</t></li>
+					<li><t>Generate a 48-bit psuedo-random node.</t></li>
+					<li><t>Format by concatenating the 128 bits from each parts:
+					  time_high|time_mid|time_low_and_version|variant_clk_seq|node</t></li>
+					<li><t>Save the state (current timestamp and clock sequence)
+					  back to the stable store</t></li>
+				</ol>  	
+				<t>
+				The steps for splitting time_high_and_time_mid into time_high and time_mid are optional
+				since the 48-bits of time_high and time_mid will remain in the same order as time_high_and_time_mid
+				during the final concatenation. This extra step of splitting into the most significant
+				32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
+				In which the following logic can be applied to reshuffle the bits with minimal modifications.
+				</t>
+				<table>
+				<name>UUIDv1 to UUIDv6 Field Mappings</name>
+				<thead>
+					<tr><td>UUIDv1 Field</td><td>Bits</td><td>UUIDv6 Field</td></tr>
+				</thead>
+				<tbody>
+					<tr><td>time_low </td><td>32</td><td>time_high</td></tr>
+					<tr><td>time_mid </td><td>16</td><td>time_mid</td></tr>
+					<tr><td>time_high</td><td>12</td><td>time_low</td></tr>
+				</tbody>
+				</table>
             </section>
         </section>
 
-<section anchor="uuidv7layout" title="UUIDv7 Layout">
-<!-- To Do: Intro -->
-<t>
-The UUIDv7 format is designed to encode a timestamp with arbitrary sub-second precision.
-The key property provided by v7 is that values generated by one system and then parsed by
-another are guaranteed to have sub-section precision of either the generator or the parser,
-whichever is less.  And the system parsing the UUIDv7 value does not need to know which precision
-was used during encoding in order to function correctly.
-</t>
-<t>
-Example starting scenario:
-</t>
-<ul>
-<li>System A produces a UUIDv7 with microsecond-precise timestamp value.</li>
-<li>System B is unaware of the precision encoded in the UUIDv7 timestamp by System A.</li>
-</ul>
-<t>
-Goal: The time value SHOULD be "as close to the correct value as possible" when parsed, even across disparate systems.
-</t>
-
-<t>
-Scenario 1: System B parses the timestamp with millisecond precision. (Less precision than the encoder)
-</t>
-<t>
-Result: System B will return the correct millisecond value encoded by system A (truncated to milliseconds).
-</t>
-
-<t>
-Scenario 2: System B parses the timestamp with nanosecond precision. (More precision than the encoder)
-</t>
-<t>
-Result: System B's value returned will have the same microsecond level of precision provided by the encoder with the additional precision down to nanosecond level being essentially random as per the encoded random value at the end of the UUIDv7.
-</t>
-
-<t>
-This scheme provides maximum interoperability across systems where
-different levels of time precision are required/feasible/available.  And these values continue
-to have the same properties as the other UUID formats in this document: values from the same
-system are monotonic (including their interpretation as a raw set of bytes), values across
-different systems are in sequence by time.
-</t>
-
-<section anchor="uuidv7encodingdecoding" title="UUIDv7 Encoding and Decoding">
-<t>
-    The UUIDv7 bit layout for encoding and decoding are described separately in this document.
-</t>
-<t>
-    For the purposes of decoding, only the time portions are decoded, and in such a way that allows for useful interpretation of the sub-second portion without knowing the level of precision used by the caller.
-</t>
-<t>
-    When encoding, in addition to the sub-second portion, a sequence, random value, and optional node value can all be included, but these are opaque and cannot be reliably read when parsing.  (Although if individual implementations wish to provide guarantees about these fields that is okay and does not violate the specification.)
-</t>
-<t>
-    These properties allow for maximum interoperability between systems while preserving the other useful UUID properties (inter-system monotonicity and sorting, intra-system time parsing and sorting).
-</t>
-</section>
-
-<section anchor="uuidv7vervar" title="UUIDv7 Version and Variant fields">
-<t>
-    The Version (ver) and Variant (var) fields, as with the other UUID versions, must remain where they are. UUIDv7 values always contain the number 7 (bits: 0111) in the ver field, and the var field is always set to 2 (bits: 10).
-</t>
-<!--
-<t>
-    These two fields always have the exact same place and occupy 6 bits.  The remaining 122 bits are the contents
-    (see next section) and are calculated separately and then filled in into UUIDv7 value skipping over ver and var.  The exact bit ranges are:
-</t>
--->
-
-<!--
-<ul>
-    <li>uuid[0..47]   = unixts</li>
-    <li>uuid[48..51]  = bits:0111 (version)</li>
-    <li>uuid[52..63]  = contents[48..59]</li>
-    <li>uuid[64..65]  = bits:10 (variant)</li>
-    <li>uuid[66..127] = contents[60..121]</li>
-<ul>
--->
-
-</section>
-
-<section anchor="uuidv7decoding" title="UUIDv7 Layout for Decoding">
-
+		<section anchor="uuidv7layout" title="UUIDv7 Layout and Bit Order">
+			<t>
+			The UUIDv7 format is designed to encode a Unix timestamp with arbitrary sub-second precision.
+			The key property provided by UUIDv7 is that timestamp values generated by one system and parsed by
+			another are guaranteed to have sub-section precision of either the generator or the parser,
+			whichever is less. Additionally, the system parsing the UUIDv7 value does not need to know which precision
+			was used during encoding in order to function correctly.
+			</t>
+			
+			<t>
+			The format for the 16-octet, 128-bit UUIDv6 is shown in Figure 2
+			</t>
 <figure>
-<name>UUIDv7 Field and Bit Layout - Decoding</name>
+<name>UUIDv7 Field and Bit Layout</name>
 <artwork>
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                            unixts                             |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |unixts |        subsec         |  ver  |         subsec        |
+    |unixts |       subsec_a        |  ver  |       subsec_b        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |var|                        subsec                             |
+    |var|                   subsec_seq_node                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                            subsec                             |
+    |                       subsec_seq_node                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</artwork></figure>
+</artwork>
+</figure>
+		<dl newline="true">
+			<dt>unixts:</dt> <dd>36-bit big-endian unsigned Unix Timestamp value</dd>
+			<dt>subsec_a:</dt> <dd>12-bits allocated to sub-section precision values.</dd>
+			<dt>ver:</dt> <dd>The 4 bit UUIDv8 version (0111)</dd>
+			<dt>subsec_b:</dt> <dd>12-bits allocated to sub-section precision values.</dd>
+			<dt>var:</dt> <dd>2-bit UUID variant (10)</dd>
+			<dt>subsec_seq_node:</dt> <dd>The remaining 62 bits which MAY be allocated to any combination of additional sub-section precision, sequence counter, or pseudo-random data.</dd>
+		</dl>
 
-<t>
-    When decoding there are only two fields considered. unixts and subsec.
-</t>
-<t>
-    The unixts field is a 36-bit big-endian unsigned Unix Timestamp value (number of seconds since the epoch of 1 Jan 1970, leap seconds excluded so each hour is exactly 3600 seconds long).
-</t>
-<t>
-    The subsec field the values with all remaining bits (skipping over ver and var) which is interpreted as sub-second information where bits from most to least significant represent a further division by two.  This is the same normal place notation used to express fractional numbers, except in binary. E.g. in decimal ".1" means one tenth, and ".01" means one hundredth.  In this subsec field, a 1 means one half, 01 means one quarter, 001 is one eighth, etc.
-    This scheme can work for any number of bits up to the maximum available, and keeps the most significant data leftmost in the bit sequence.
-</t>
-<t>
-    To perform the sub-second math, simply take the first (most significant/leftmost) N bits of subsec and divide it by 2^N.  Example: To parse the first 16 bits, extract that value as an integer and divide it by 65536 (2 to the 16th).  If these 16 bits are 0101 0101 0101 0101, then treating that as an integer gives 0x5555 or 21845 in decimal, and dividing by 65536 gives 0.3333282
-</t>
-<t>
-    With the decoding layout specified, the encoding layout is defined as any layout which decodes correctly with the above.  Specifically it means the time portion should contain as much precision as provided by either the encoding or decoding system, whichever is less.
-</t>
-</section>
+			<section anchor="uuidv7timestamp" title="UUIDv7 Timestamp Usage">
+				<t>UUIDv7 utilizes a 36-bit big-endian unsigned Unix Timestamp value (number of seconds since the epoch of 1 Jan 1970, leap seconds excluded so each hour is exactly 3600 seconds long).</t>
+				<t>Additional sub-second precision (millisecond, nanosecond, microsecond, etc) MAY be provided for encoding and decoding in the remaining bits in the layout.</t>
+			</section>
+			
+			<section anchor="uuidv7sequence" title="UUIDv7 Clock Sequence Usage">
+				<t>
+				UUIDv7 SHOULD utilize a motonic sequence counter to provide additional sequencing guarantees when multiple UUIDv7 values are created in the same UNIXTS and SUBSEC timestamp.
+				The amount of bits allocates to the sequence counter depend on the precision of the timestamp. For example, a more accurate timestamp source using nanosecond precision will require less clock sequence bits than a timestamp source utilizing seconds for precision.
+				For best sequencing results the sequence counter SHOULD be placed immediately after available sub-second bits.
+				</t>
+				<t>
+				The clock sequence MUST start at zero and increment monotonically
+				for each new UUID created on by the application on the same timestamp.
+				When the timestamp increments the clock sequence MUST be reset to zero.
+				The clock sequence MUST NOT rollover or reset to zero unless the timestamp
+				has incremented. Care MUST be given to ensure that an adequate sized
+				clock sequence is selected for a given application based on expected
+				timestamp precision and expected UUID generation rates.
+				</t>
+			</section>
+			
+			<section anchor="uuidv7node" title="UUIDv7 Node Usage">
+				<t>
+				UUIDv7 implementations, even with very detailed sub-second precision and the optional sequence counter, MAY have leftover bits that will be identified as the Node for this section.
+				The UUIDv7 Node MAY contain any set of data an implementation desires however the node MUST NOT be set to all 0s which does not ensure global uniqueness. In most scenarios the node SHOULD be filled with pseudo-random data.
+				</t>
+			</section>
 
-<section anchor="uuidv7sequence" title="UUIDv7 Encoding">
-<t>
-    The exact layout for encoding UUIDv7 depends on the precision (number of bits) used for the sub-second portion and the sizes of the seq, node and rand fields.
-</t>
-<t>
-    Examples of specific UUIDv7 encodings are given below.  Implementations are not limited to these examples.
-</t>
-<t>
-    In addition to unixts, subsec, var and var, the following field definitions apply:
-</t>
-<ul>
-    <li>seq: A sequence which must be monotic (count up) for each new value produced with the same timestamp (unixts and subsec).  The purpose is to ensure that UUID values are monotic within the same system.</li>
-    <li>node: Optional, can be used to indicate a node number or other predermined and implementation-specific source of uniqueness.  For example, in a cluster of systems with numbers associated with them, this number can be used to ensure uniqueness accross systems with 100% certainty (which is not possible if only using random data).  Implementations must take into account the possible liability of leaking the information about which machine produced a particular value and implementors must make the decision if this is an acceptable risk for guaranteed uniqueness.</li>
-    <li>rand: Random data produced from an applicable source. CSPRNG random data from existing OS or other source is recommended.  The purpose is to help ensure uniqueness accross disparate systems (in the case that the node field cannot provide this) as well as to make values harder to predict/guess.  Systems which have a strong need to produce unguessable values should allocate more bits to this field accordingly.</li>
-</ul>
-<t>
-    All of these fields are only used during encoding, and during decoding the system is unaware of the bit layout used for them and considers this information opaque.  As such, implementations generating these values can assign whatever lengths to each field it deems applicable, as long as it does not break decoding compatibility (i.e. unixts, ver and var have to stay where they are, and seq, node and rand must follow the subsec portion).
-</t>
-<t>
-    In the examples below, the subsec field is called with different names according to the precision, e.g. "msec" for millisecond precision, in order to help with clarity.
-    </t>
-<!--
-<t>
-    Several useful examples of valid encoding layouts are shown above.  They are valid because they decode properly as described in UUIDv7 Layout for Decoding (TODO: link).
-</t>
-<t>
-    (explain: the important thing is to encode sub-second time portion in the right format [wip trying to find a name for this] in order to allow different precisions during encode/decode, followed by the sequence (to provide intra-system monotonicity), and then after that whatever is random and node doesn't matter for the purposes of decoding - whatever scheme for uniqueness/unguessability/entropy that is sufficient for the application is fine and has no bearing on interoperability)
-</t>
--->
-</section>
-
-
+			<section anchor="uuidv7encodingdecoding" title="UUIDv7 Encoding and Decoding">
+				<t>
+					The UUIDv7 bit layout for encoding and decoding are described separately in this document.
+				</t>
+				<section anchor="uuidv7encoding" title="UUIDv7 Encoding">
+					<t>
+					 Since the UUIDv7 Unix timestamp is fixed at 36 bits in length the exact layout for encoding UUIDv7 depends on the precision (number of bits)
+					 used for the sub-second portion and the sizes of the optionally desired sequence counter and node bits.
+					</t>
+					<t>
+						Three examples of UUIDv7 encoding are given below as a general guidelines but implementations are not limited to just these three examples.
+					</t>
+					<t>
+						All of these fields are only used during encoding, and during decoding the system is unaware of the bit layout used for them and considers this information opaque.
+						As such, implementations generating these values can assign whatever lengths to each field it deems applicable, as long as it does not break decoding compatibility
+						(i.e. Unix timestamp (unixts), version (ver) and variant (var) have to stay where they are, and clock sequence counter (seq), random (random) or other implementation specific values must follow the sub-second encoding).
+					</t>
+					<t>
+						In Figure 3 the UUIDv7 has been created with millisecond precision with the available sub-second precision bits.
+					</t>
+					<t>
+						Examining Figure 3 one can observe: 
+					</t>
+					<ul>
+						<li><t>The first 36 bits have been dedicated to the Unix Timestamp (unixts)</t></li>
+						<li><t>All 12 bits of scenario subsec_a is fully dedicated to millisecond information (msec).</t></li>
+						<li><t>The 4 Version bits remain unchanged (ver).</t></li>
+						<li><t>All 12 bits of subsec_b have been dedicated to a motonic clock sequence counter (seq).</t></li>
+						<li><t>The 2 Variant bits remain unchanged (var).</t></li>
+						<li><t>Finally the remaining 62 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).</t></li>
+					</ul>
 <figure>
 <name>UUIDv7 Field and Bit Layout - Encoding Example (Millisecond Precision)</name>
 <artwork>
@@ -503,11 +453,28 @@ different systems are in sequence by time.
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |unixts |         msec          |  ver  |          seq          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |var|             node          |            rand               |
+    |var|                         rand                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                             rand                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</artwork></figure>
+</artwork>
+</figure>
+
+					<t>
+						In Figure 4 the UUIDv7 has been created with Microsecond precision with the available sub-second precision bits.
+					</t>
+					<t>
+						Examining Figure 4 one can observe: 
+					</t>
+					<ul>
+						<li><t>The first 36 bits have been dedicated to the Unix Timestamp (unixts)</t></li>
+						<li><t>All 12 bits of scenario subsec_a is fully dedicated to providing sub-second encoding for the Microsecond precision (usec).</t></li>
+						<li><t>The 4 Version bits remain unchanged (ver).</t></li>
+						<li><t>All 12 bits of subsec_b have been dedicated to providing sub-second encoding for the Microsecond precision (usec).</t></li>
+						<li><t>The 2 Variant bits remain unchanged (var).</t></li>
+						<li><t>A 14 bit motonic clock sequence counter (seq) has been embedded in the most significant position of subsec_seq_node </t></li>
+						<li><t>Finally the remaining 48 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).</t></li>
+					</ul>
 
 <figure>
 <name>UUIDv7 Field and Bit Layout - Encoding Example (Microsecond Precision)</name>
@@ -519,11 +486,29 @@ different systems are in sequence by time.
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |unixts |         usec          |  ver  |         usec          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |var|             seq           |            node               |
+    |var|             seq           |            rand               |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                             rand                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</artwork></figure>
+</artwork>
+</figure>
+
+					<t>
+						In Figure 5 the UUIDv7 has been created with Nanosecond precision with the available sub-second precision bits.
+					</t>
+					<t>
+						Examining Figure 5 one can observe: 
+					</t>
+					<ul>
+						<li><t>The first 36 bits have been dedicated to the Unix Timestamp (unixts)</t></li>
+						<li><t>All 12 bits of scenario subsec_a is fully dedicated to providing sub-second encoding for the Nanosecond precision (nsec).</t></li>
+						<li><t>The 4 Version bits remain unchanged (ver).</t></li>
+						<li><t>All 12 bits of subsec_b have been dedicated to providing sub-second encoding for the Nanosecond precision (nsec).</t></li>
+						<li><t>The 2 Variant bits remain unchanged (var).</t></li>
+						<li><t>The first 14 bit of the subsec_seq_node dedicated to providing sub-second encoding for the Nanosecond precision (nsec).</t></li>
+						<li><t>The next 8 bits of subsec_seq_node dedicated a motonic clock sequence counter (seq).</t></li>
+						<li><t>Finally the remaining 40 bits in the subsec_seq_node section are layout is filled out with random data to pad the length and provide guaranteed uniqueness (rand).</t></li>
+					</ul>
 
 <figure>
 <name>UUIDv7 Field and Bit Layout - Encoding Example (Nanosecond Precision)</name>
@@ -535,39 +520,66 @@ different systems are in sequence by time.
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |unixts |         nsec          |  ver  |         nsec          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |var|             nsec          |      seq      |     node      |
+    |var|             nsec          |      seq      |     rand      |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                             rand                              |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</artwork></figure>
+</artwork>
+</figure>
 
-<!--
-<section anchor="uuidv7sequence" title="UUIDv7 Unix Timestamp">
-<t>
-    For UUIDv7, the value of the contents field is computed separately and then filled in around the version and variant fields.  When parsing, the process is reversed and the contents should be extracted into one value where its bits can be accessed directly without any regard to the version and variant fields.
-</t>
-<t>
-    The purpose of the contents field is to allow 
-</t>
-</section>
+			</section>
+			<section anchor="uuidv7decoding" title="UUIDv7 Decoding">
+				<t>
+					When decoding or parsing a UUIDv7 value there are only two values to be considered:
+				</t>
+				<ol>
+					<li><t>The unix timestamp defined as unixts</t></li>
+					<li><t>The sub-second precision values defined as subsec_a, subsec_b, and subsec_seq_node</t></li>
+				</ol>
+				<t>As detailed in Figure 2 the unix timestamp (unixts) is always the first 36 bits of the UUIDv7 layout.</t>
+				<t>
+					Similarly as per Figure 2, the sub-second precision values lie within subsec_a, subsec_b, and subsec_seq_node which are all interpreted as sub-second information after skipping over the version (ver) and (var) bits.  
+					These concatenated sub-second information bits are interpreted in a way where most to least significant bits represent a further division by two.
+					This is the same normal place notation used to express fractional numbers, except in binary. For example, in decimal ".1" means one tenth, and ".01" means one hundredth.
+					In this subsec field, a 1 means one half, 01 means one quarter, 001 is one eighth, etc.
+					This scheme can work for any number of bits up to the maximum available, and keeps the most significant data leftmost in the bit sequence.
+				</t>
+				<t>
+					To perform the sub-second math, simply take the first (most significant/leftmost) N bits of subsec and divide it by 2^N. Take for example:
+				</t>
+				<ol>
+						<li><t>To parse the first 16 bits, extract that value as an integer and divide it by 65536 (2 to the 16th).</t></li>
+						<li><t>If these 16 bits are 0101 0101 0101 0101, then treating that as an integer gives 0x5555 or 21845 in decimal, and dividing by 65536 gives 0.3333282</t></li>
+				</ol>		
+				<t>
+				This sub-second encoding scheme provides maximum interoperability across systems where different levels of time precision are required/feasible/available.
+				The timestamp value derived from a UUIDv7 value SHOULD be "as close to the correct value as possible" when parsed, even across disparate systems. 
+				</t>
+				<t>
+				Take for example the starting point for our next two UUIDv7 parsing scenarios:
+				</t>
+				<ol>
+					<li>System A produces a UUIDv7 with a microsecond-precise timestamp value.</li>
+					<li>System B is unaware of the precision encoded in the UUIDv7 timestamp by System A.</li>
+				</ol>
+				<t>
+				Scenario 1:
+				</t>
+				<ol>
+					<li>System B parses the embedded timestamp with millisecond precision. (Less precision than the encoder)</li>
+					<li>System B SHOULD return the correct millisecond value encoded by system A (truncated to milliseconds).</li>
+				</ol>
+				<t>
+				Scenario 2:
+				</t>
+				<ol>
+					<li>System B parses the timestamp with nanosecond precision. (More precision than the encoder)</li>
+					<li>System B's value returned SHOULD have the same microsecond level of precision provided by the encoder with the additional precision down to nanosecond level being essentially random as per the encoded random value at the end of the UUIDv7.</li>
+				</ol>
 
-<section anchor="uuidv7sequence" title="UUIDv7 Sub-second, Sequence, Random/Node (ssrn)">
-<t>
-</t>
-</section>
--->
-
-<!-- <section anchor="uuidv7pseudocreate" title="UUIDv7 Basic Creation and Encoding Algorithm"> -->
-<!-- To Do: Define ordered list of steps used to craft a UUIDv7 -->
-<!-- </section>-->
-
-<!--
-<section anchor="uuidv7pseudoparse" title="UUIDv7 Basic Decoding/Parsing Algorithm">
-</section>
--->
-
-</section>
-
+			</section>
+		</section>
+	</section>
         <section anchor="uuidv8layout" title="UUIDv8 Layout and Bit Order">
 		<t>
         UUIDv8 offers variable-size timestamp, clock sequence, and node values
@@ -610,7 +622,7 @@ different systems are in sequence by time.
         and finally a node containing either random data or implementation specific data.
 		</t>
 		<t>
-        A sample format in Figure 3 is used to further illustrate the point
+        A sample format in Figure 6 is used to further illustrate the point
         for the 16-octet, 128-bit UUIDv8.
 		</t>
 <figure>
@@ -709,7 +721,7 @@ different systems are in sequence by time.
             source utilizing seconds for precision.
 			</t>
 			<t>
-            The UUIDv8 layout in Figure 3 generically defines two possible
+            The UUIDv8 layout in Figure 6 generically defines two possible
             clock sequence values that can leveraged:
 			</t>
 			<ul spacing="compact">
@@ -741,7 +753,7 @@ different systems are in sequence by time.
             In most scenarios the node will be filled with pseudo-random data.
 			</t>
 			<t>
-            The UUIDv8 layout in Figure 3 defines 2 sizes of Node
+            The UUIDv8 layout in Figure 6 defines 2 sizes of Node
             depending on the timestamp size:
 			</t>
 			<ul spacing="compact">
@@ -765,7 +777,7 @@ different systems are in sequence by time.
             As such any UUIDv8 implementations will likely vary among applications.
 			</t>
 			<t>
-            The following algorithm is a generic implementation using Figure 3
+            The following algorithm is a generic implementation using Figure 6
             and the recommendations outlined in this specification.
 			</t>
 			<t>


### PR DESCRIPTION
Updates:
- Fixed layout encoding error breaking xml2rfc conversion tool (Sorry for all the whitespace changes. I had to indent a bunch to find the syntax error!)
- Re-added + Detailed UUIDv7 Timestamp Usage,  UUIDv7 Clock Sequence Usage, and UUIDv7 Node Usage sections to flow with the same as UUIDv6 and UUIDv8
- Moved Figure from UUIDv7 Decoding section up to UUIDv7 Layout and Bit Order and provided the proper figure description.
- Modified 4x subsec values into subsec_a, subsec_b, and subsec_seq_node to ease bit layout descriptions throughout the section.
- Flipped UUIDv7 Encoding and UUIDv7 Decoding sections to follow larger section naming convention e.g "UUIDv7 Encoding and Decoding" and to promote readability.
- Provided "Examinations" of the three encoding figures to provide more readability and to map these bit layouts back to the bit layout in Figure 2 of UUIDv7 Layout and Bit Order
- Moved some Intro text to UUIDv7 Decoding to promote readability
- Renamed Figure references in UUIDv8 section which were modified due to UUIDv7 figure additions
- Removed UUIDv7 references to distributed node generation which is brought up later in section 7
- Removed TO DO and unneeded/old commented out sections from the XML file
- Provided .txt and .html file for this current draft version.
- Fixed misc typos