### PR TITLE
UUIDv6 Draft 02 Fixes

### DIFF
--- a/draft-peabody-dispatch-new-uuid-format-02.html
+++ b/draft-peabody-dispatch-new-uuid-format-02.html
@@ -40,7 +40,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/VyfTigWegF.dir/draft-peabody-dispatch-new-uuid-format-02.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/jCLaCO80fa.dir/draft-peabody-dispatch-new-uuid-format-02.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1285,108 +1285,99 @@ li > p:last-of-type {
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
 <a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+<nav class="toc"><ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.1">
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.2">
             <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-background" class="xref">Background</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-summary-of-changes" class="xref">Summary of Changes</a></p>
-<ul class="compact toc ulEmpty ulBare">
-<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.3.2.1">
+<ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.3.2.1">
                 <p id="section-toc.1-1.3.2.1.1" class="keepWithNext"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-changelog" class="xref">changelog</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a></p>
-<ul class="compact toc ulEmpty ulBare">
-<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.1">
+<ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.1">
                 <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-versions" class="xref">Versions</a></p>
 </li>
-              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.2">
+              <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.2">
                 <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-variant" class="xref">Variant</a></p>
 </li>
-              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3">
+              <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.3">
                 <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuidv6-layout-and-bit-order" class="xref">UUIDv6 Layout and Bit Order</a></p>
-<ul class="compact toc ulEmpty ulBare">
-<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.1">
-                    <p id="section-toc.1-1.4.2.3.2.1.1"><a href="#section-4.3.1" class="xref">4.3.1</a>.  <a href="#name-uuidv6-timestamp-usage" class="xref">UUIDv6 Timestamp Usage</a></p>
-</li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.2">
-                    <p id="section-toc.1-1.4.2.3.2.2.1"><a href="#section-4.3.2" class="xref">4.3.2</a>.  <a href="#name-uuidv6-clock-sequence-usage" class="xref">UUIDv6 Clock Sequence  Usage</a></p>
-</li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.3">
-                    <p id="section-toc.1-1.4.2.3.2.3.1"><a href="#section-4.3.3" class="xref">4.3.3</a>.  <a href="#name-uuidv6-node-usage" class="xref">UUIDv6 Node Usage</a></p>
-</li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.4">
-                    <p id="section-toc.1-1.4.2.3.2.4.1"><a href="#section-4.3.4" class="xref">4.3.4</a>.  <a href="#name-uuidv6-basic-creation-algor" class="xref">UUIDv6 Basic Creation Algorithm</a></p>
+<ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.3.2.1">
+                    <p id="section-toc.1-1.4.2.3.2.1.1"><a href="#section-4.3.1" class="xref">4.3.1</a>.  <a href="#name-uuidv6-basic-creation-algor" class="xref">UUIDv6 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
 </li>
-              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4">
+              <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.4">
                 <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuidv7-layout-and-bit-order" class="xref">UUIDv7 Layout and Bit Order</a></p>
-<ul class="compact toc ulEmpty ulBare">
-<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.1">
+<ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.4.2.1">
                     <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-uuidv7-timestamp-usage" class="xref">UUIDv7 Timestamp Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.2">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.4.2.2">
                     <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-uuidv7-clock-sequence-usage" class="xref">UUIDv7 Clock Sequence Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.3">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.4.2.3">
                     <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-uuidv7-node-usage" class="xref">UUIDv7 Node Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.4">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.4.2.4">
                     <p id="section-toc.1-1.4.2.4.2.4.1"><a href="#section-4.4.4" class="xref">4.4.4</a>.  <a href="#name-uuidv7-encoding-and-decodin" class="xref">UUIDv7 Encoding and Decoding</a></p>
 </li>
                 </ul>
 </li>
-              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5">
+              <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.5">
                 <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-uuidv8-layout-and-bit-order" class="xref">UUIDv8 Layout and Bit Order</a></p>
-<ul class="compact toc ulEmpty ulBare">
-<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.1">
+<ul class="ulBare toc compact ulEmpty">
+<li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.5.2.1">
                     <p id="section-toc.1-1.4.2.5.2.1.1"><a href="#section-4.5.1" class="xref">4.5.1</a>.  <a href="#name-uuidv8-timestamp-usage" class="xref">UUIDv8 Timestamp Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.2">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.5.2.2">
                     <p id="section-toc.1-1.4.2.5.2.2.1"><a href="#section-4.5.2" class="xref">4.5.2</a>.  <a href="#name-uuidv8-clock-sequence-usage" class="xref">UUIDv8 Clock Sequence Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.3">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.5.2.3">
                     <p id="section-toc.1-1.4.2.5.2.3.1"><a href="#section-4.5.3" class="xref">4.5.3</a>.  <a href="#name-uuidv8-node-usage" class="xref">UUIDv8 Node Usage</a></p>
 </li>
-                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.4">
+                  <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.4.2.5.2.4">
                     <p id="section-toc.1-1.4.2.5.2.4.1"><a href="#section-4.5.4" class="xref">4.5.4</a>.  <a href="#name-uuidv8-basic-creation-algor" class="xref">UUIDv8 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.5">
             <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-encoding-and-storage" class="xref">Encoding and Storage</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.6">
             <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-global-uniqueness" class="xref">Global Uniqueness</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.7">
             <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.8">
             <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.9">
             <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.10">
             <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.11">
             <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.12">
             <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
+          <li class="ulBare toc compact ulEmpty" id="section-toc.1-1.13">
             <p id="section-toc.1-1.13.1"><a href="#appendix-A" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
@@ -1731,9 +1722,9 @@ li > p:last-of-type {
  Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
  time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
  from the timestamp intact and changes the order to time_high, time_mid, and time_low.
- Incidentally this will match the original 60 bit Gregorian timestamp source.
- The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
- The 48 bit node MUST be set to a pseudo-random value.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
+ Incidentally this will match the original 60 bit Gregorian timestamp source with 100-nanosecond precision defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span> 
+ The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.
+ The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span><a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <p id="section-4.3-2">
  The format for the 16-octet, 128 bit UUIDv6 is shown in Figure 1<a href="#section-4.3-2" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-1">
@@ -1785,109 +1776,79 @@ li > p:last-of-type {
 </dd>
           <dd class="break"></dd>
 <dt id="section-4.3-4.11">node:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-4.12">48 bit pseudo-random number used as a spatially unique identifier
+          <dd style="margin-left: 1.5em" id="section-4.3-4.12">48 bit spatially unique identifier
             Occupies bits 80 through 127 (octets 10-15)<a href="#section-4.3-4.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<div id="uuidv6timestamp">
+<div id="uuidv6pseudo">
 <section id="section-4.3.1">
-          <h4 id="name-uuidv6-timestamp-usage">
-<a href="#section-4.3.1" class="section-number selfRef">4.3.1. </a><a href="#name-uuidv6-timestamp-usage" class="section-name selfRef">UUIDv6 Timestamp Usage</a>
+          <h4 id="name-uuidv6-basic-creation-algor">
+<a href="#section-4.3.1" class="section-number selfRef">4.3.1. </a><a href="#name-uuidv6-basic-creation-algor" class="section-name selfRef">UUIDv6 Basic Creation Algorithm</a>
           </h4>
 <p id="section-4.3.1-1">
- UUIDv6 reuses the 60 bit Gregorian timestamp with 100-nanosecond
- precision defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>.<a href="#section-4.3.1-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="uuidv6sequence">
-<section id="section-4.3.2">
-          <h4 id="name-uuidv6-clock-sequence-usage">
-<a href="#section-4.3.2" class="section-number selfRef">4.3.2. </a><a href="#name-uuidv6-clock-sequence-usage" class="section-name selfRef">UUIDv6 Clock Sequence  Usage</a>
-          </h4>
-<p id="section-4.3.2-1">
- UUIDv6 makes no change to the Clock Sequence usage defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-4.3.2-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="uuidv6node">
-<section id="section-4.3.3">
-          <h4 id="name-uuidv6-node-usage">
-<a href="#section-4.3.3" class="section-number selfRef">4.3.3. </a><a href="#name-uuidv6-node-usage" class="section-name selfRef">UUIDv6 Node Usage</a>
-          </h4>
-<p id="section-4.3.3-1">
- UUIDv6 node bits SHOULD be set to a 48 bit random or pseudo-random number.
- UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
- <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span> method of generating a random multicast IEEE 802 MAC address.<a href="#section-4.3.3-1" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="uuidv6pseudo">
-<section id="section-4.3.4">
-          <h4 id="name-uuidv6-basic-creation-algor">
-<a href="#section-4.3.4" class="section-number selfRef">4.3.4. </a><a href="#name-uuidv6-basic-creation-algor" class="section-name selfRef">UUIDv6 Basic Creation Algorithm</a>
-          </h4>
-<p id="section-4.3.4-1">
  The following implementation algorithm is based on <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>
- but with changes specific to UUIDv6:<a href="#section-4.3.4-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="normal type-1" id="section-4.3.4-2">
- <li id="section-4.3.4-2.1">
-              <p id="section-4.3.4-2.1.1">From a system-wide shared stable store (e.g., a file) or global variable, read the
+ but with changes specific to UUIDv6:<a href="#section-4.3.1-1" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="normal type-1" id="section-4.3.1-2">
+ <li id="section-4.3.1-2.1">
+              <p id="section-4.3.1-2.1.1">From a system-wide shared stable store (e.g., a file) or global variable, read the
    UUID generator state: the values of the timestamp and clock sequence
-   used to generate the last UUID.<a href="#section-4.3.4-2.1.1" class="pilcrow">¶</a></p>
+   used to generate the last UUID.<a href="#section-4.3.1-2.1.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.2">
-              <p id="section-4.3.4-2.2.1">Obtain the current time as a 60 bit count of 100-nanosecond intervals
-   since 00:00:00.00, 15 October 1582.<a href="#section-4.3.4-2.2.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.2">
+              <p id="section-4.3.1-2.2.1">Obtain the current time as a 60 bit count of 100-nanosecond intervals
+   since 00:00:00.00, 15 October 1582.<a href="#section-4.3.1-2.2.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.3">
-              <p id="section-4.3.4-2.3.1">Set the time_low field to the 12 least significant bits
-   of the starting 60 bit timestamp.<a href="#section-4.3.4-2.3.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.3">
+              <p id="section-4.3.1-2.3.1">Set the time_low field to the 12 least significant bits
+   of the starting 60 bit timestamp.<a href="#section-4.3.1-2.3.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.4">
-              <p id="section-4.3.4-2.4.1">Truncate the timestamp to the 48 most significant bits
-   in order to create time_high_and_time_mid.<a href="#section-4.3.4-2.4.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.4">
+              <p id="section-4.3.1-2.4.1">Truncate the timestamp to the 48 most significant bits
+   in order to create time_high_and_time_mid.<a href="#section-4.3.1-2.4.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.5">
-              <p id="section-4.3.4-2.5.1">Set the time_high field to the 32 most significant bits of the truncated timestamp.<a href="#section-4.3.4-2.5.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.5">
+              <p id="section-4.3.1-2.5.1">Set the time_high field to the 32 most significant bits of the truncated timestamp.<a href="#section-4.3.1-2.5.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.6">
-              <p id="section-4.3.4-2.6.1">Set the time_mid field to the 16 least significant bits of the truncated timestamp.<a href="#section-4.3.4-2.6.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.6">
+              <p id="section-4.3.1-2.6.1">Set the time_mid field to the 16 least significant bits of the truncated timestamp.<a href="#section-4.3.1-2.6.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.7">
-              <p id="section-4.3.4-2.7.1">Create the 16 bit time_low_and_version by concatenating the 4 bit UUIDv6 version
-   with the 12 bit time_low.<a href="#section-4.3.4-2.7.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.7">
+              <p id="section-4.3.1-2.7.1">Create the 16 bit time_low_and_version by concatenating the 4 bit UUIDv6 version
+   with the 12 bit time_low.<a href="#section-4.3.1-2.7.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.8">
-              <p id="section-4.3.4-2.8.1">If the state was unavailable (e.g., non-existent or corrupted)
+            <li id="section-4.3.1-2.8">
+              <p id="section-4.3.1-2.8.1">If the state was unavailable (e.g., non-existent or corrupted)
    or the timestamp is greater than the current timestamp generate
-   a random 14 bit clock sequence value.<a href="#section-4.3.4-2.8.1" class="pilcrow">¶</a></p>
+   a random 14 bit clock sequence value.<a href="#section-4.3.1-2.8.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.9">
-              <p id="section-4.3.4-2.9.1">If the state was available, but the saved timestamp is less than or equal to the current
-   timestamp, increment the clock sequence value.<a href="#section-4.3.4-2.9.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.9">
+              <p id="section-4.3.1-2.9.1">If the state was available, but the saved timestamp is less than or equal to the current
+   timestamp, increment the clock sequence value.<a href="#section-4.3.1-2.9.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.10">
-              <p id="section-4.3.4-2.10.1">Complete the 16 bit clock sequence high, low and reserved creation
+            <li id="section-4.3.1-2.10">
+              <p id="section-4.3.1-2.10.1">Complete the 16 bit clock sequence high, low and reserved creation
    by concatenating the clock sequence onto UUID variant bits which take
-   the most significant position in the 16 bit value.<a href="#section-4.3.4-2.10.1" class="pilcrow">¶</a></p>
+   the most significant position in the 16 bit value.<a href="#section-4.3.1-2.10.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.11">
-              <p id="section-4.3.4-2.11.1">Generate a 48 bit pseudo-random node.<a href="#section-4.3.4-2.11.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.11">
+              <p id="section-4.3.1-2.11.1">Generate a 48 bit pseudo-random node.<a href="#section-4.3.1-2.11.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.12">
-              <p id="section-4.3.4-2.12.1">Format by concatenating the 128 bits from each parts:
-   time_high|time_mid|time_low_and_version|variant_clk_seq|node<a href="#section-4.3.4-2.12.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.12">
+              <p id="section-4.3.1-2.12.1">Format by concatenating the 128 bits from each parts:
+   time_high|time_mid|time_low_and_version|variant_clk_seq|node<a href="#section-4.3.1-2.12.1" class="pilcrow">¶</a></p>
 </li>
-            <li id="section-4.3.4-2.13">
-              <p id="section-4.3.4-2.13.1">Save the state (current timestamp and clock sequence)
-   back to the stable store<a href="#section-4.3.4-2.13.1" class="pilcrow">¶</a></p>
+            <li id="section-4.3.1-2.13">
+              <p id="section-4.3.1-2.13.1">Save the state (current timestamp and clock sequence)
+   back to the stable store<a href="#section-4.3.1-2.13.1" class="pilcrow">¶</a></p>
 </li>
           </ol>
-<p id="section-4.3.4-3">
+<p id="section-4.3.1-3">
  The steps for splitting time_high_and_time_mid into time_high and time_mid are optional
  since the 48 bits of time_high and time_mid will remain in the same order as time_high_and_time_mid
  during the final concatenation. This extra step of splitting into the most significant
  32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
- In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.3.4-3" class="pilcrow">¶</a></p>
+ In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.3.1-3" class="pilcrow">¶</a></p>
 <span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-3">
             <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:

--- a/draft-peabody-dispatch-new-uuid-format-02.html
+++ b/draft-peabody-dispatch-new-uuid-format-02.html
@@ -40,7 +40,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/OmzfaF0mEx.dir/draft-peabody-dispatch-new-uuid-format-02.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/VyfTigWegF.dir/draft-peabody-dispatch-new-uuid-format-02.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1193,7 +1193,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 11 February 2022</td>
+<td class="center">Expires 27 February 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1209,12 +1209,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-08-10" class="published">10 August 2021</time>
+<time datetime="2021-08-26" class="published">26 August 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-02-11">11 February 2022</time></dd>
+<dd class="expires"><time datetime="2022-02-27">27 February 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1257,7 +1257,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 11 February 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 27 February 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1294,68 +1294,68 @@ li > p:last-of-type {
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-summary-of-changes" class="xref">Summary of Changes</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
+<ul class="compact toc ulEmpty ulBare">
+<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.3.2.1">
                 <p id="section-toc.1-1.3.2.1.1" class="keepWithNext"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-changelog" class="xref">changelog</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
+<ul class="compact toc ulEmpty ulBare">
+<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.1">
                 <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-versions" class="xref">Versions</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
+              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.2">
                 <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-variant" class="xref">Variant</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3">
+              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3">
                 <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuidv6-layout-and-bit-order" class="xref">UUIDv6 Layout and Bit Order</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3.2.1">
+<ul class="compact toc ulEmpty ulBare">
+<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.1">
                     <p id="section-toc.1-1.4.2.3.2.1.1"><a href="#section-4.3.1" class="xref">4.3.1</a>.  <a href="#name-uuidv6-timestamp-usage" class="xref">UUIDv6 Timestamp Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3.2.2">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.2">
                     <p id="section-toc.1-1.4.2.3.2.2.1"><a href="#section-4.3.2" class="xref">4.3.2</a>.  <a href="#name-uuidv6-clock-sequence-usage" class="xref">UUIDv6 Clock Sequence  Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3.2.3">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.3">
                     <p id="section-toc.1-1.4.2.3.2.3.1"><a href="#section-4.3.3" class="xref">4.3.3</a>.  <a href="#name-uuidv6-node-usage" class="xref">UUIDv6 Node Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3.2.4">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.3.2.4">
                     <p id="section-toc.1-1.4.2.3.2.4.1"><a href="#section-4.3.4" class="xref">4.3.4</a>.  <a href="#name-uuidv6-basic-creation-algor" class="xref">UUIDv6 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4">
+              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4">
                 <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuidv7-layout-and-bit-order" class="xref">UUIDv7 Layout and Bit Order</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4.2.1">
+<ul class="compact toc ulEmpty ulBare">
+<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.1">
                     <p id="section-toc.1-1.4.2.4.2.1.1"><a href="#section-4.4.1" class="xref">4.4.1</a>.  <a href="#name-uuidv7-timestamp-usage" class="xref">UUIDv7 Timestamp Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4.2.2">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.2">
                     <p id="section-toc.1-1.4.2.4.2.2.1"><a href="#section-4.4.2" class="xref">4.4.2</a>.  <a href="#name-uuidv7-clock-sequence-usage" class="xref">UUIDv7 Clock Sequence Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4.2.3">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.3">
                     <p id="section-toc.1-1.4.2.4.2.3.1"><a href="#section-4.4.3" class="xref">4.4.3</a>.  <a href="#name-uuidv7-node-usage" class="xref">UUIDv7 Node Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4.2.4">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.4.2.4">
                     <p id="section-toc.1-1.4.2.4.2.4.1"><a href="#section-4.4.4" class="xref">4.4.4</a>.  <a href="#name-uuidv7-encoding-and-decodin" class="xref">UUIDv7 Encoding and Decoding</a></p>
 </li>
                 </ul>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5">
+              <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5">
                 <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-uuidv8-layout-and-bit-order" class="xref">UUIDv8 Layout and Bit Order</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5.2.1">
+<ul class="compact toc ulEmpty ulBare">
+<li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.1">
                     <p id="section-toc.1-1.4.2.5.2.1.1"><a href="#section-4.5.1" class="xref">4.5.1</a>.  <a href="#name-uuidv8-timestamp-usage" class="xref">UUIDv8 Timestamp Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5.2.2">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.2">
                     <p id="section-toc.1-1.4.2.5.2.2.1"><a href="#section-4.5.2" class="xref">4.5.2</a>.  <a href="#name-uuidv8-clock-sequence-usage" class="xref">UUIDv8 Clock Sequence Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5.2.3">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.3">
                     <p id="section-toc.1-1.4.2.5.2.3.1"><a href="#section-4.5.3" class="xref">4.5.3</a>.  <a href="#name-uuidv8-node-usage" class="xref">UUIDv8 Node Usage</a></p>
 </li>
-                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5.2.4">
+                  <li class="compact toc ulEmpty ulBare" id="section-toc.1-1.4.2.5.2.4">
                     <p id="section-toc.1-1.4.2.5.2.4.1"><a href="#section-4.5.4" class="xref">4.5.4</a>.  <a href="#name-uuidv8-basic-creation-algor" class="xref">UUIDv8 Basic Creation Algorithm</a></p>
 </li>
                 </ul>
@@ -1587,22 +1587,19 @@ li > p:last-of-type {
             <p id="section-3.1-3.6.1">- Changed all instances of "#-bit" to "# bit"<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.7">
-            <p id="section-3.1-3.7.1">- Revised UUIDv6 Clock Sequence Usage from random start to monotonic increment starting at 0<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.7.1">- Changed "proceeding" veriage to "after" in section 7<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.8">
-            <p id="section-3.1-3.8.1">- Changed "proceeding" veriage to "after" in section 7<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.8.1">- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.9">
-            <p id="section-3.1-3.9.1">- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.9.1">- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.10">
-            <p id="section-3.1-3.10.1">- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.10.1">- Added forward reference and bullet to UUIDv8 if truncating 64 bit Unix Epoch is not an option.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.11">
-            <p id="section-3.1-3.11.1">- Added forward reference and bullet to UUIDv8 if truncating 64 bit Unix Epoch is not an option.<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.12">
-            <p id="section-3.1-3.12.1">- Fixed bad reference to non-existent "time_or_node" in section 4.5.4<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.11.1">- Fixed bad reference to non-existent "time_or_node" in section 4.5.4<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="section-3.1-4">draft-01<a href="#section-3.1-4" class="pilcrow">¶</a></p>
@@ -1735,7 +1732,7 @@ li > p:last-of-type {
  time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
  from the timestamp intact and changes the order to time_high, time_mid, and time_low.
  Incidentally this will match the original 60 bit Gregorian timestamp source.
- The 14 bit clock sequence has been altered slightly to start at zero and increase monotonically for each UUID created on a given timestamp but remain in the position as <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
+ The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
  The 48 bit node MUST be set to a pseudo-random value.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <p id="section-4.3-2">
  The format for the 16-octet, 128 bit UUIDv6 is shown in Figure 1<a href="#section-4.3-2" class="pilcrow">¶</a></p>
@@ -1809,19 +1806,7 @@ li > p:last-of-type {
 <a href="#section-4.3.2" class="section-number selfRef">4.3.2. </a><a href="#name-uuidv6-clock-sequence-usage" class="section-name selfRef">UUIDv6 Clock Sequence  Usage</a>
           </h4>
 <p id="section-4.3.2-1">
- Historically UUIDv1 Clock Sequence usage, defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>, is used for a few purposes.
- Firstly as collision avoidance mechanism by ensuring that when a timestamp is reused during UUIDv1 creation the clock sequence is incremented.
- Secondly as added random data to help ensure global uniqueness. This is achieved by starting the clock sequence at random value.
- This added random is a needed due to the node ID possibly utilizing a static MAC address which could be similar across systems.<a href="#section-4.3.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.3.2-2">
- With UUIDv6 the aggregate 14 bits of clk_seq_hi_res (lower 6 bits) and clock_seq_low (all 8 bits) MUST be treated as one clock sequence value and references as the "UUIDv6 Clock Sequence" for this section.
- The UUIDv6 clock sequence MUST start at zero and increment monotonically for each new UUID created on by the application on the same timestamp. 
- When the timestamp increments the UUIDv6 clock sequence MUST be reset to zero.
- The UUIDv6 clock sequence MUST NOT rollover or reset to zero unless the timestamp has incremented.<a href="#section-4.3.2-2" class="pilcrow">¶</a></p>
-<p id="section-4.3.2-3">
- The 48 bit pseudo-random node defined in the next section provides enough random data to ensure global uniqueness such that the extra random provided by a randomized starting UUIDv6 clock sequence is not required.
- Additionally, the current 14 bit length of both clk_seq_hi_res and clock_seq_low maximizes the usage of these bits and ensures up to 16383 UUIDv6 values can be created for a given timestamp and then ordered by explicitly by creation sequence.
- Furthermore, 16383 total values for UUIDv6 clock sequence is sufficiently high for the given UUIDv6 timestamp accuracy resulting in a very low chance of a clock sequence rollover event.<a href="#section-4.3.2-3" class="pilcrow">¶</a></p>
+ UUIDv6 makes no change to the Clock Sequence usage defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-4.3.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="uuidv6node">

--- a/draft-peabody-dispatch-new-uuid-format-02.txt
+++ b/draft-peabody-dispatch-new-uuid-format-02.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                          10 August 2021
-Expires: 11 February 2022
+Intended status: Standards Track                          26 August 2021
+Expires: 27 February 2022
 
 
                             New UUID Formats
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 11 February 2022.
+   This Internet-Draft will expire on 27 February 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 1]
+Peabody & Davis         Expires 27 February 2022                [Page 1]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -81,25 +81,25 @@ Table of Contents
        4.3.2.  UUIDv6 Clock Sequence Usage . . . . . . . . . . . . .   9
        4.3.3.  UUIDv6 Node Usage . . . . . . . . . . . . . . . . . .   9
        4.3.4.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .   9
-     4.4.  UUIDv7 Layout and Bit Order . . . . . . . . . . . . . . .  11
-       4.4.1.  UUIDv7 Timestamp Usage  . . . . . . . . . . . . . . .  12
+     4.4.  UUIDv7 Layout and Bit Order . . . . . . . . . . . . . . .  10
+       4.4.1.  UUIDv7 Timestamp Usage  . . . . . . . . . . . . . . .  11
        4.4.2.  UUIDv7 Clock Sequence Usage . . . . . . . . . . . . .  12
-       4.4.3.  UUIDv7 Node Usage . . . . . . . . . . . . . . . . . .  13
-       4.4.4.  UUIDv7 Encoding and Decoding  . . . . . . . . . . . .  13
-     4.5.  UUIDv8 Layout and Bit Order . . . . . . . . . . . . . . .  18
+       4.4.3.  UUIDv7 Node Usage . . . . . . . . . . . . . . . . . .  12
+       4.4.4.  UUIDv7 Encoding and Decoding  . . . . . . . . . . . .  12
+     4.5.  UUIDv8 Layout and Bit Order . . . . . . . . . . . . . . .  17
        4.5.1.  UUIDv8 Timestamp Usage  . . . . . . . . . . . . . . .  20
        4.5.2.  UUIDv8 Clock Sequence Usage . . . . . . . . . . . . .  21
-       4.5.3.  UUIDv8 Node Usage . . . . . . . . . . . . . . . . . .  22
+       4.5.3.  UUIDv8 Node Usage . . . . . . . . . . . . . . . . . .  21
        4.5.4.  UUIDv8 Basic Creation Algorithm . . . . . . . . . . .  22
    5.  Encoding and Storage  . . . . . . . . . . . . . . . . . . . .  25
-   6.  Global Uniqueness . . . . . . . . . . . . . . . . . . . . . .  26
-   7.  Distributed UUID Generation . . . . . . . . . . . . . . . . .  26
+   6.  Global Uniqueness . . . . . . . . . . . . . . . . . . . . . .  25
+   7.  Distributed UUID Generation . . . . . . . . . . . . . . . . .  25
    8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  26
-   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  27
-   11. Normative References  . . . . . . . . . . . . . . . . . . . .  27
+   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
+   11. Normative References  . . . . . . . . . . . . . . . . . . . .  26
    12. Informative References  . . . . . . . . . . . . . . . . . . .  27
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  29
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
 1.  Introduction
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 2]
+Peabody & Davis         Expires 27 February 2022                [Page 2]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -165,7 +165,7 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 3]
+Peabody & Davis         Expires 27 February 2022                [Page 3]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -221,7 +221,7 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 4]
+Peabody & Davis         Expires 27 February 2022                [Page 4]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -277,7 +277,7 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 5]
+Peabody & Davis         Expires 27 February 2022                [Page 5]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -294,8 +294,6 @@ Internet-Draft               new-uuid-format                 August 2021
       - Fixed some UUIDvX reference issues
       - Changed all instances of "motonic" to "monotonic"
       - Changed all instances of "#-bit" to "# bit"
-      - Revised UUIDv6 Clock Sequence Usage from random start to
-      monotonic increment starting at 0
       - Changed "proceeding" veriage to "after" in section 7
       - Added details on how to pad 32 bit unix timestamp to 36 bits in
       UUIDv7
@@ -333,7 +331,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 6]
+
+
+Peabody & Davis         Expires 27 February 2022                [Page 6]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -385,18 +385,17 @@ Internet-Draft               new-uuid-format                 August 2021
    time_high_and_version.  UUIDv6 instead keeps the source bits from the
    timestamp intact and changes the order to time_high, time_mid, and
    time_low.  Incidentally this will match the original 60 bit Gregorian
-   timestamp source.  The 14 bit clock sequence has been altered
+   timestamp source.  The clock sequence bits remain unchanged from
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 7]
+Peabody & Davis         Expires 27 February 2022                [Page 7]
 
 Internet-Draft               new-uuid-format                 August 2021
 
 
-   slightly to start at zero and increase monotonically for each UUID
-   created on a given timestamp but remain in the position as [RFC4122].
-   The 48 bit node MUST be set to a pseudo-random value.
+   their usage and position in [RFC4122].  The 48 bit node MUST be set
+   to a pseudo-random value.
 
    The format for the 16-octet, 128 bit UUIDv6 is shown in Figure 1
 
@@ -445,7 +444,8 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 11 February 2022                [Page 8]
+
+Peabody & Davis         Expires 27 February 2022                [Page 8]
 
 Internet-Draft               new-uuid-format                 August 2021
 
@@ -457,34 +457,8 @@ Internet-Draft               new-uuid-format                 August 2021
 
 4.3.2.  UUIDv6 Clock Sequence Usage
 
-   Historically UUIDv1 Clock Sequence usage, defined by [RFC4122],
-   Section 4.1.5, is used for a few purposes.  Firstly as collision
-   avoidance mechanism by ensuring that when a timestamp is reused
-   during UUIDv1 creation the clock sequence is incremented.  Secondly
-   as added random data to help ensure global uniqueness.  This is
-   achieved by starting the clock sequence at random value.  This added
-   random is a needed due to the node ID possibly utilizing a static MAC
-   address which could be similar across systems.
-
-   With UUIDv6 the aggregate 14 bits of clk_seq_hi_res (lower 6 bits)
-   and clock_seq_low (all 8 bits) MUST be treated as one clock sequence
-   value and references as the "UUIDv6 Clock Sequence" for this section.
-   The UUIDv6 clock sequence MUST start at zero and increment
-   monotonically for each new UUID created on by the application on the
-   same timestamp.  When the timestamp increments the UUIDv6 clock
-   sequence MUST be reset to zero.  The UUIDv6 clock sequence MUST NOT
-   rollover or reset to zero unless the timestamp has incremented.
-
-   The 48 bit pseudo-random node defined in the next section provides
-   enough random data to ensure global uniqueness such that the extra
-   random provided by a randomized starting UUIDv6 clock sequence is not
-   required.  Additionally, the current 14 bit length of both
-   clk_seq_hi_res and clock_seq_low maximizes the usage of these bits
-   and ensures up to 16383 UUIDv6 values can be created for a given
-   timestamp and then ordered by explicitly by creation sequence.
-   Furthermore, 16383 total values for UUIDv6 clock sequence is
-   sufficiently high for the given UUIDv6 timestamp accuracy resulting
-   in a very low chance of a clock sequence rollover event.
+   UUIDv6 makes no change to the Clock Sequence usage defined by
+   [RFC4122], Section 4.1.5.
 
 4.3.3.  UUIDv6 Node Usage
 
@@ -497,14 +471,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    The following implementation algorithm is based on [RFC4122] but with
    changes specific to UUIDv6:
-
-
-
-
-Peabody & Davis         Expires 11 February 2022                [Page 9]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    1.   From a system-wide shared stable store (e.g., a file) or global
         variable, read the UUID generator state: the values of the
@@ -532,6 +498,14 @@ Internet-Draft               new-uuid-format                 August 2021
         or the timestamp is greater than the current timestamp generate
         a random 14 bit clock sequence value.
 
+
+
+
+Peabody & Davis         Expires 27 February 2022                [Page 9]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    9.   If the state was available, but the saved timestamp is less than
         or equal to the current timestamp, increment the clock sequence
         value.
@@ -554,14 +528,6 @@ Internet-Draft               new-uuid-format                 August 2021
    will remain in the same order as time_high_and_time_mid during the
    final concatenation.  This extra step of splitting into the most
    significant 32 bits and least significant 16 bits proves useful when
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 10]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    reusing an existing UUIDv1 implementation.  In which the following
    logic can be applied to reshuffle the bits with minimal
    modifications.
@@ -589,6 +555,13 @@ Internet-Draft               new-uuid-format                 August 2021
    parsing the UUIDv7 value does not need to know which precision was
    used during encoding in order to function correctly.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 10]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    The format for the 16-octet, 128 bit UUIDv7 is shown in Figure 2
 
         0                   1                   2                   3
@@ -610,13 +583,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    subsec_a:
       12 bits allocated to sub-second precision values.
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 11]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    ver:
       The 4 bit UUIDv7 version (0111)
@@ -644,6 +610,14 @@ Internet-Draft               new-uuid-format                 August 2021
    To achieve a 36 bit UUIDv7 timestamp, the lower 36 bits of a 64 bit
    unix time are extracted verbatim into UUIDv7
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 11]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    In the event that 32 bit Unix Timestamp are in use; four zeros MUST
    be appended at the start in the most significant (left-most) bits of
    the 32 bit Unix timestamp creating the 36 bit Unix timestamp.  This
@@ -666,14 +640,6 @@ Internet-Draft               new-uuid-format                 August 2021
    allocates to the sequence counter depend on the precision of the
    timestamp.  For example, a more accurate timestamp source using
    nanosecond precision will require less clock sequence bits than a
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 12]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    timestamp source utilizing seconds for precision.  For best
    sequencing results the sequence counter SHOULD be placed immediately
    after available sub-second bits.
@@ -701,6 +667,13 @@ Internet-Draft               new-uuid-format                 August 2021
    The UUIDv7 bit layout for encoding and decoding are described
    separately in this document.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 12]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
 4.4.4.1.  UUIDv7 Encoding
 
    Since the UUIDv7 Unix timestamp is fixed at 36 bits in length the
@@ -721,14 +694,6 @@ Internet-Draft               new-uuid-format                 August 2021
    to stay where they are, and clock sequence counter (seq), random
    (random) or other implementation specific values must follow the sub-
    second encoding).
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 13]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    In Figure 3 the UUIDv7 has been created with millisecond precision
    with the available sub-second precision bits.
@@ -751,6 +716,19 @@ Internet-Draft               new-uuid-format                 August 2021
    *  Finally the remaining 62 bits in the subsec_seq_node section are
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 13]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -778,14 +756,6 @@ Internet-Draft               new-uuid-format                 August 2021
    *  All 12 bits of scenario subsec_a is fully dedicated to providing
       sub-second encoding for the Microsecond precision (usec).
 
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 14]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    *  The 4 Version bits remain unchanged (ver).
 
    *  All 12 bits of subsec_b have been dedicated to providing sub-
@@ -799,6 +769,22 @@ Internet-Draft               new-uuid-format                 August 2021
    *  Finally the remaining 48 bits in the subsec_seq_node section are
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 14]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -833,15 +819,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    *  The 2 Variant bits remain unchanged (var).
 
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 15]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    *  The first 14 bit of the subsec_seq_node dedicated to providing
       sub-second encoding for the Nanosecond precision (nsec).
 
@@ -851,6 +828,19 @@ Internet-Draft               new-uuid-format                 August 2021
    *  Finally the remaining 40 bits in the subsec_seq_node section are
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 15]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -880,24 +870,6 @@ Internet-Draft               new-uuid-format                 August 2021
    As detailed in Figure 2 the unix timestamp (unixts) is always the
    first 36 bits of the UUIDv7 layout.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 16]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    Similarly as per Figure 2, the sub-second precision values lie within
    subsec_a, subsec_b, and subsec_seq_node which are all interpreted as
    sub-second information after skipping over the version (ver) and
@@ -917,6 +889,14 @@ Internet-Draft               new-uuid-format                 August 2021
 
    1.  To parse the first 16 bits, extract that value as an integer and
        divide it by 65536 (2 to the 16th).
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 16]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    2.  If these 16 bits are 0101 0101 0101 0101, then treating that as
        an integer gives 0x5555 or 21845 in decimal, and dividing by
@@ -947,13 +927,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    Scenario 2:
 
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 17]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    1.  System B parses the timestamp with nanosecond precision.  (More
        precision than the encoder)
 
@@ -971,6 +944,15 @@ Internet-Draft               new-uuid-format                 August 2021
    UUIDv8 SHOULD only be utilized if an implementation cannot utilize
    UUIDv1, UUIDv6, or UUIDv7.  Some situations in which UUIDv8 usage
    could occur:
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 17]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    *  An implementation would like to utilize a timestamp source not
       defined by the current time-based UUIDs.
@@ -1002,14 +984,6 @@ Internet-Draft               new-uuid-format                 August 2021
    The only explicitly defined bits are the Version and Variant leaving
    122 bits for implementation specific time-based UUIDs.  To be clear:
    UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 18]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    filled with random data.  UUIDv8's 128 bits (including the version
    and variant) SHOULD contain at the minimum a timestamp of some format
    in the most significant bit position followed directly by a clock
@@ -1018,6 +992,23 @@ Internet-Draft               new-uuid-format                 August 2021
 
    A sample format in Figure 6 is used to further illustrate the point
    for the 16-octet, 128 bit UUIDv8.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 18]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1054,18 +1045,6 @@ Internet-Draft               new-uuid-format                 August 2021
    var:
       2 bit UUID variant (10)
 
-
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 19]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    seq_or_node:
       If a 60 bit, or larger, timestamp source is leverages these 8 bits
       SHOULD be allocated for an 8 bit clock sequence counter.  If a 32
@@ -1077,6 +1056,15 @@ Internet-Draft               new-uuid-format                 August 2021
       random data.  However, implementations utilize the node as they
       see fit.  Together var, seq_or_node, and node occupy Bits 64
       through 127 (octets 8-15)
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 19]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
 4.5.1.  UUIDv8 Timestamp Usage
 
@@ -1114,14 +1102,6 @@ Internet-Draft               new-uuid-format                 August 2021
    Although it is possible to create a timestamp larger than 64 bits in
    size The usage and bit layout of that timestamp format is up to the
    implementation.  When a timestamp exceeds the 64th bit (octet 7),
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 20]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    extra care must be taken to ensure the Variant bits are properly
    inserted at their respective location in the UUID.  Likewise, the
    Version MUST always be implemented at the appropriate location.
@@ -1132,6 +1112,15 @@ Internet-Draft               new-uuid-format                 August 2021
    bit timestamp source would fully utilize timestamp_32 and 4 bits of
    timestamp_48.  The remaining 12 bits in timestamp_48 MUST be set to
    0.
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 20]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    By using implementation-specific timestamp sources it is not
    guaranteed that devices outside of the application context are able
@@ -1163,21 +1152,6 @@ Internet-Draft               new-uuid-format                 August 2021
    from the node MAY be used for clock sequencing in the event that 8
    bits is not sufficient.
 
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 21]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    The clock sequence MUST start at zero and increment monotonically for
    each new UUIDv8 created on by the application on the same timestamp.
    When the timestamp increments the clock sequence MUST be reset to
@@ -1196,6 +1170,13 @@ Internet-Draft               new-uuid-format                 August 2021
 
    The UUIDv8 layout in Figure 6 defines 2 sizes of Node depending on
    the timestamp size:
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 21]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    *  62 bit node encompassing seq_or_node and node Used when a
       timestamp of 48 bits or less is leveraged.
@@ -1226,14 +1207,6 @@ Internet-Draft               new-uuid-format                 August 2021
    2.   Obtain the current time from the selected clock source as 32
         bits.
 
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 22]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    3.   Set the 32 bit field timestamp_32 to the 32 bits from the
         timestamp
 
@@ -1253,6 +1226,13 @@ Internet-Draft               new-uuid-format                 August 2021
 
    9.   Generate 62 random bits and fill in 8 bits for seq_or_node and
         54 bits for the node.
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 22]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    10.  Format by concatenating the 128 bits as: timestamp_32|timestamp_
         48|version|time_or_seq|variant|seq_or_node|node
@@ -1283,13 +1263,6 @@ Internet-Draft               new-uuid-format                 August 2021
         variable, read the UUID generator state: the values of the
         timestamp and clock sequence used to generate the last UUID.
 
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 23]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    2.   Obtain the current time from the selected clock source as 32
         bits.
 
@@ -1308,6 +1281,14 @@ Internet-Draft               new-uuid-format                 August 2021
    8.   If the state was unavailable (e.g., non-existent or corrupted)
         or the timestamp is greater than the current timestamp; set the
         12 bit clock sequence value (seq_or_node) to 0
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 23]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    9.   If the state was available, but the saved timestamp is less than
         or equal to the current timestamp, increment the clock sequence
@@ -1337,15 +1318,6 @@ Internet-Draft               new-uuid-format                 August 2021
        variable, read the UUID generator state: the values of the
        timestamp and clock sequence used to generate the last UUID.
 
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 24]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    2.  Obtain the current time from the selected clock source as desired
        bit total
 
@@ -1367,6 +1339,13 @@ Internet-Draft               new-uuid-format                 August 2021
        or equal to the current timestamp, increment the clock sequence
        value.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 24]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    7.  Set the remaining bits to the node as pseudo-random data
 
    8.  Format by concatenating the 128 bits together
@@ -1387,20 +1366,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    Where possible UUIDs SHOULD be stored within database applications as
    the underlying 128 bit binary value.
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 25]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
 6.  Global Uniqueness
 
@@ -1430,6 +1395,13 @@ Internet-Draft               new-uuid-format                 August 2021
    negotiation of the machineID among distributed nodes is out of scope
    for this specification.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 25]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
 8.  IANA Considerations
 
    This document has no IANA actions.
@@ -1449,14 +1421,6 @@ Internet-Draft               new-uuid-format                 August 2021
    a whole.  If UUIDs are required for use with any security operation
    within an application context in any shape or form then [RFC4122]
    UUIDv4 SHOULD be utilized.
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 26]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    The machineID portion of node, described in Section 7, does provide
    small unique identifier which could be used to determine which
@@ -1486,6 +1450,14 @@ Internet-Draft               new-uuid-format                 August 2021
               DOI 10.17487/RFC4122, July 2005,
               <https://www.rfc-editor.org/info/rfc4122>.
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 26]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
 12.  Informative References
 
    [LexicalUUID]
@@ -1503,16 +1475,6 @@ Internet-Draft               new-uuid-format                 August 2021
    [Flake]    Boundary, "Flake: A decentralized, k-ordered id generation
               service in Erlang", Commit 15c933a, February 2017,
               <https://github.com/boundary/flake>.
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 27]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    [ShardingID]
               Instagram Engineering, "Sharding & IDs at Instagram",
@@ -1544,6 +1506,14 @@ Internet-Draft               new-uuid-format                 August 2021
               PostgreSql", Commit 2759820, December 2020,
               <https://github.com/richardtallent/RT.Comb>.
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 27]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    [ULID]     Feerasta, A., "Universally Unique Lexicographically
               Sortable Identifier", Commit d0c7170, May 2019,
               <https://github.com/ulid/spec>.
@@ -1562,13 +1532,6 @@ Internet-Draft               new-uuid-format                 August 2021
    [ObjectID] MongoDB, "ObjectId - MongoDB Manual",
               <https://docs.mongodb.com/manual/reference/method/
               ObjectId/>.
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 28]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    [CUID]     Elliott, E., "Collision-resistant ids optimized for
               horizontal scaling and performance.", Commit 215b27b,
@@ -1602,23 +1565,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 11 February 2022               [Page 29]
+Peabody & Davis         Expires 27 February 2022               [Page 28]

--- a/draft-peabody-dispatch-new-uuid-format-02.txt
+++ b/draft-peabody-dispatch-new-uuid-format-02.txt
@@ -77,28 +77,25 @@ Table of Contents
      4.1.  Versions  . . . . . . . . . . . . . . . . . . . . . . . .   7
      4.2.  Variant . . . . . . . . . . . . . . . . . . . . . . . . .   7
      4.3.  UUIDv6 Layout and Bit Order . . . . . . . . . . . . . . .   7
-       4.3.1.  UUIDv6 Timestamp Usage  . . . . . . . . . . . . . . .   9
-       4.3.2.  UUIDv6 Clock Sequence Usage . . . . . . . . . . . . .   9
-       4.3.3.  UUIDv6 Node Usage . . . . . . . . . . . . . . . . . .   9
-       4.3.4.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .   9
+       4.3.1.  UUIDv6 Basic Creation Algorithm . . . . . . . . . . .   9
      4.4.  UUIDv7 Layout and Bit Order . . . . . . . . . . . . . . .  10
        4.4.1.  UUIDv7 Timestamp Usage  . . . . . . . . . . . . . . .  11
        4.4.2.  UUIDv7 Clock Sequence Usage . . . . . . . . . . . . .  12
        4.4.3.  UUIDv7 Node Usage . . . . . . . . . . . . . . . . . .  12
        4.4.4.  UUIDv7 Encoding and Decoding  . . . . . . . . . . . .  12
      4.5.  UUIDv8 Layout and Bit Order . . . . . . . . . . . . . . .  17
-       4.5.1.  UUIDv8 Timestamp Usage  . . . . . . . . . . . . . . .  20
-       4.5.2.  UUIDv8 Clock Sequence Usage . . . . . . . . . . . . .  21
+       4.5.1.  UUIDv8 Timestamp Usage  . . . . . . . . . . . . . . .  19
+       4.5.2.  UUIDv8 Clock Sequence Usage . . . . . . . . . . . . .  20
        4.5.3.  UUIDv8 Node Usage . . . . . . . . . . . . . . . . . .  21
-       4.5.4.  UUIDv8 Basic Creation Algorithm . . . . . . . . . . .  22
-   5.  Encoding and Storage  . . . . . . . . . . . . . . . . . . . .  25
+       4.5.4.  UUIDv8 Basic Creation Algorithm . . . . . . . . . . .  21
+   5.  Encoding and Storage  . . . . . . . . . . . . . . . . . . . .  24
    6.  Global Uniqueness . . . . . . . . . . . . . . . . . . . . . .  25
    7.  Distributed UUID Generation . . . . . . . . . . . . . . . . .  25
-   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  26
+   8.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  25
    10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  26
    11. Normative References  . . . . . . . . . . . . . . . . . . . .  26
-   12. Informative References  . . . . . . . . . . . . . . . . . . .  27
+   12. Informative References  . . . . . . . . . . . . . . . . . . .  26
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
 1.  Introduction
@@ -106,6 +103,9 @@ Table of Contents
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
+
+
+
 
 
 
@@ -385,7 +385,7 @@ Internet-Draft               new-uuid-format                 August 2021
    time_high_and_version.  UUIDv6 instead keeps the source bits from the
    timestamp intact and changes the order to time_high, time_mid, and
    time_low.  Incidentally this will match the original 60 bit Gregorian
-   timestamp source.  The clock sequence bits remain unchanged from
+   timestamp source with 100-nanosecond precision defined in [RFC4122],
 
 
 
@@ -394,8 +394,11 @@ Peabody & Davis         Expires 27 February 2022                [Page 7]
 Internet-Draft               new-uuid-format                 August 2021
 
 
-   their usage and position in [RFC4122].  The 48 bit node MUST be set
-   to a pseudo-random value.
+   Section 4.1.4 The clock sequence bits remain unchanged from their
+   usage and position in [RFC4122], Section 4.1.5.  The 48 bit node
+   SHOULD be set to a pseudo-random value however implementations MAY
+   choose retain the old MAC address behavior from [RFC4122],
+   Section 4.1.6 and [RFC4122], Section 4.5
 
    The format for the 16-octet, 128 bit UUIDv6 is shown in Figure 1
 
@@ -437,11 +440,8 @@ Internet-Draft               new-uuid-format                 August 2021
       through 79 (octet 9)
 
    node:
-      48 bit pseudo-random number used as a spatially unique identifier
-      Occupies bits 80 through 127 (octets 10-15)
-
-
-
+      48 bit spatially unique identifier Occupies bits 80 through 127
+      (octets 10-15)
 
 
 
@@ -450,24 +450,7 @@ Peabody & Davis         Expires 27 February 2022                [Page 8]
 Internet-Draft               new-uuid-format                 August 2021
 
 
-4.3.1.  UUIDv6 Timestamp Usage
-
-   UUIDv6 reuses the 60 bit Gregorian timestamp with 100-nanosecond
-   precision defined in [RFC4122], Section 4.1.4.
-
-4.3.2.  UUIDv6 Clock Sequence Usage
-
-   UUIDv6 makes no change to the Clock Sequence usage defined by
-   [RFC4122], Section 4.1.5.
-
-4.3.3.  UUIDv6 Node Usage
-
-   UUIDv6 node bits SHOULD be set to a 48 bit random or pseudo-random
-   number.  UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or
-   the [RFC4122], Section 4.5 method of generating a random multicast
-   IEEE 802 MAC address.
-
-4.3.4.  UUIDv6 Basic Creation Algorithm
+4.3.1.  UUIDv6 Basic Creation Algorithm
 
    The following implementation algorithm is based on [RFC4122] but with
    changes specific to UUIDv6:
@@ -498,14 +481,6 @@ Internet-Draft               new-uuid-format                 August 2021
         or the timestamp is greater than the current timestamp generate
         a random 14 bit clock sequence value.
 
-
-
-
-Peabody & Davis         Expires 27 February 2022                [Page 9]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    9.   If the state was available, but the saved timestamp is less than
         or equal to the current timestamp, increment the clock sequence
         value.
@@ -522,6 +497,14 @@ Internet-Draft               new-uuid-format                 August 2021
 
    13.  Save the state (current timestamp and clock sequence) back to
         the stable store
+
+
+
+
+Peabody & Davis         Expires 27 February 2022                [Page 9]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    The steps for splitting time_high_and_time_mid into time_high and
    time_mid are optional since the 48 bits of time_high and time_mid
@@ -555,13 +538,6 @@ Internet-Draft               new-uuid-format                 August 2021
    parsing the UUIDv7 value does not need to know which precision was
    used during encoding in order to function correctly.
 
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 10]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    The format for the 16-octet, 128 bit UUIDv7 is shown in Figure 2
 
         0                   1                   2                   3
@@ -577,6 +553,14 @@ Internet-Draft               new-uuid-format                 August 2021
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
                    Figure 2: UUIDv7 Field and Bit Layout
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 10]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    unixts:
       36 bit big-endian unsigned Unix Timestamp value
@@ -610,14 +594,6 @@ Internet-Draft               new-uuid-format                 August 2021
    To achieve a 36 bit UUIDv7 timestamp, the lower 36 bits of a 64 bit
    unix time are extracted verbatim into UUIDv7
 
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 11]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    In the event that 32 bit Unix Timestamp are in use; four zeros MUST
    be appended at the start in the most significant (left-most) bits of
    the 32 bit Unix timestamp creating the 36 bit Unix timestamp.  This
@@ -631,6 +607,16 @@ Internet-Draft               new-uuid-format                 August 2021
    UUIDv8 SHOULD be used in place of UUIDv7 if an application or
    implementation does not want to truncate a 64 bit Unix Epoch to the
    lower 36 bits.
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 11]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
 4.4.2.  UUIDv7 Clock Sequence Usage
 
@@ -667,13 +653,6 @@ Internet-Draft               new-uuid-format                 August 2021
    The UUIDv7 bit layout for encoding and decoding are described
    separately in this document.
 
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 12]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
 4.4.4.1.  UUIDv7 Encoding
 
    Since the UUIDv7 Unix timestamp is fixed at 36 bits in length the
@@ -684,6 +663,16 @@ Internet-Draft               new-uuid-format                 August 2021
    Three examples of UUIDv7 encoding are given below as a general
    guidelines but implementations are not limited to just these three
    examples.
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 12]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    All of these fields are only used during encoding, and during
    decoding the system is unaware of the bit layout used for them and
@@ -717,19 +706,6 @@ Internet-Draft               new-uuid-format                 August 2021
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
 
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 13]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -744,6 +720,15 @@ Internet-Draft               new-uuid-format                 August 2021
 
    Figure 3: UUIDv7 Field and Bit Layout - Encoding Example (Millisecond
                                  Precision)
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 13]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    In Figure 4 the UUIDv7 has been created with Microsecond precision
    with the available sub-second precision bits.
@@ -770,22 +755,6 @@ Internet-Draft               new-uuid-format                 August 2021
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
 
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 14]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -809,6 +778,14 @@ Internet-Draft               new-uuid-format                 August 2021
    *  The first 36 bits have been dedicated to the Unix Timestamp
       (unixts)
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 14]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    *  All 12 bits of scenario subsec_a is fully dedicated to providing
       sub-second encoding for the Nanosecond precision (nsec).
 
@@ -828,19 +805,6 @@ Internet-Draft               new-uuid-format                 August 2021
    *  Finally the remaining 40 bits in the subsec_seq_node section are
       layout is filled out with random data to pad the length and
       provide guaranteed uniqueness (rand).
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 15]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -870,6 +834,14 @@ Internet-Draft               new-uuid-format                 August 2021
    As detailed in Figure 2 the unix timestamp (unixts) is always the
    first 36 bits of the UUIDv7 layout.
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 15]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    Similarly as per Figure 2, the sub-second precision values lie within
    subsec_a, subsec_b, and subsec_seq_node which are all interpreted as
    sub-second information after skipping over the version (ver) and
@@ -889,14 +861,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    1.  To parse the first 16 bits, extract that value as an integer and
        divide it by 65536 (2 to the 16th).
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 16]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    2.  If these 16 bits are 0101 0101 0101 0101, then treating that as
        an integer gives 0x5555 or 21845 in decimal, and dividing by
@@ -927,6 +891,13 @@ Internet-Draft               new-uuid-format                 August 2021
 
    Scenario 2:
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 16]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    1.  System B parses the timestamp with nanosecond precision.  (More
        precision than the encoder)
 
@@ -944,15 +915,6 @@ Internet-Draft               new-uuid-format                 August 2021
    UUIDv8 SHOULD only be utilized if an implementation cannot utilize
    UUIDv1, UUIDv6, or UUIDv7.  Some situations in which UUIDv8 usage
    could occur:
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 17]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    *  An implementation would like to utilize a timestamp source not
       defined by the current time-based UUIDs.
@@ -984,6 +946,14 @@ Internet-Draft               new-uuid-format                 August 2021
    The only explicitly defined bits are the Version and Variant leaving
    122 bits for implementation specific time-based UUIDs.  To be clear:
    UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 17]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    filled with random data.  UUIDv8's 128 bits (including the version
    and variant) SHOULD contain at the minimum a timestamp of some format
    in the most significant bit position followed directly by a clock
@@ -992,23 +962,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    A sample format in Figure 6 is used to further illustrate the point
    for the 16-octet, 128 bit UUIDv8.
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 18]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1045,6 +998,18 @@ Internet-Draft               new-uuid-format                 August 2021
    var:
       2 bit UUID variant (10)
 
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 18]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    seq_or_node:
       If a 60 bit, or larger, timestamp source is leverages these 8 bits
       SHOULD be allocated for an 8 bit clock sequence counter.  If a 32
@@ -1056,15 +1021,6 @@ Internet-Draft               new-uuid-format                 August 2021
       random data.  However, implementations utilize the node as they
       see fit.  Together var, seq_or_node, and node occupy Bits 64
       through 127 (octets 8-15)
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 19]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
 4.5.1.  UUIDv8 Timestamp Usage
 
@@ -1102,6 +1058,14 @@ Internet-Draft               new-uuid-format                 August 2021
    Although it is possible to create a timestamp larger than 64 bits in
    size The usage and bit layout of that timestamp format is up to the
    implementation.  When a timestamp exceeds the 64th bit (octet 7),
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 19]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    extra care must be taken to ensure the Variant bits are properly
    inserted at their respective location in the UUID.  Likewise, the
    Version MUST always be implemented at the appropriate location.
@@ -1112,15 +1076,6 @@ Internet-Draft               new-uuid-format                 August 2021
    bit timestamp source would fully utilize timestamp_32 and 4 bits of
    timestamp_48.  The remaining 12 bits in timestamp_48 MUST be set to
    0.
-
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 20]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    By using implementation-specific timestamp sources it is not
    guaranteed that devices outside of the application context are able
@@ -1152,6 +1107,21 @@ Internet-Draft               new-uuid-format                 August 2021
    from the node MAY be used for clock sequencing in the event that 8
    bits is not sufficient.
 
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 20]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    The clock sequence MUST start at zero and increment monotonically for
    each new UUIDv8 created on by the application on the same timestamp.
    When the timestamp increments the clock sequence MUST be reset to
@@ -1170,13 +1140,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    The UUIDv8 layout in Figure 6 defines 2 sizes of Node depending on
    the timestamp size:
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 21]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    *  62 bit node encompassing seq_or_node and node Used when a
       timestamp of 48 bits or less is leveraged.
@@ -1207,6 +1170,14 @@ Internet-Draft               new-uuid-format                 August 2021
    2.   Obtain the current time from the selected clock source as 32
         bits.
 
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 21]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    3.   Set the 32 bit field timestamp_32 to the 32 bits from the
         timestamp
 
@@ -1226,13 +1197,6 @@ Internet-Draft               new-uuid-format                 August 2021
 
    9.   Generate 62 random bits and fill in 8 bits for seq_or_node and
         54 bits for the node.
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 22]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    10.  Format by concatenating the 128 bits as: timestamp_32|timestamp_
         48|version|time_or_seq|variant|seq_or_node|node
@@ -1263,6 +1227,13 @@ Internet-Draft               new-uuid-format                 August 2021
         variable, read the UUID generator state: the values of the
         timestamp and clock sequence used to generate the last UUID.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 22]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    2.   Obtain the current time from the selected clock source as 32
         bits.
 
@@ -1281,14 +1252,6 @@ Internet-Draft               new-uuid-format                 August 2021
    8.   If the state was unavailable (e.g., non-existent or corrupted)
         or the timestamp is greater than the current timestamp; set the
         12 bit clock sequence value (seq_or_node) to 0
-
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 23]
-
-Internet-Draft               new-uuid-format                 August 2021
-
 
    9.   If the state was available, but the saved timestamp is less than
         or equal to the current timestamp, increment the clock sequence
@@ -1318,6 +1281,15 @@ Internet-Draft               new-uuid-format                 August 2021
        variable, read the UUID generator state: the values of the
        timestamp and clock sequence used to generate the last UUID.
 
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 23]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    2.  Obtain the current time from the selected clock source as desired
        bit total
 
@@ -1339,13 +1311,6 @@ Internet-Draft               new-uuid-format                 August 2021
        or equal to the current timestamp, increment the clock sequence
        value.
 
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 24]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    7.  Set the remaining bits to the node as pseudo-random data
 
    8.  Format by concatenating the 128 bits together
@@ -1366,6 +1331,20 @@ Internet-Draft               new-uuid-format                 August 2021
 
    Where possible UUIDs SHOULD be stored within database applications as
    the underlying 128 bit binary value.
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 24]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
 6.  Global Uniqueness
 
@@ -1395,13 +1374,6 @@ Internet-Draft               new-uuid-format                 August 2021
    negotiation of the machineID among distributed nodes is out of scope
    for this specification.
 
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 25]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
 8.  IANA Considerations
 
    This document has no IANA actions.
@@ -1421,6 +1393,14 @@ Internet-Draft               new-uuid-format                 August 2021
    a whole.  If UUIDs are required for use with any security operation
    within an application context in any shape or form then [RFC4122]
    UUIDv4 SHOULD be utilized.
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 25]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    The machineID portion of node, described in Section 7, does provide
    small unique identifier which could be used to determine which
@@ -1450,14 +1430,6 @@ Internet-Draft               new-uuid-format                 August 2021
               DOI 10.17487/RFC4122, July 2005,
               <https://www.rfc-editor.org/info/rfc4122>.
 
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 26]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
 12.  Informative References
 
    [LexicalUUID]
@@ -1475,6 +1447,16 @@ Internet-Draft               new-uuid-format                 August 2021
    [Flake]    Boundary, "Flake: A decentralized, k-ordered id generation
               service in Erlang", Commit 15c933a, February 2017,
               <https://github.com/boundary/flake>.
+
+
+
+
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 26]
+
+Internet-Draft               new-uuid-format                 August 2021
+
 
    [ShardingID]
               Instagram Engineering, "Sharding & IDs at Instagram",
@@ -1506,14 +1488,6 @@ Internet-Draft               new-uuid-format                 August 2021
               PostgreSql", Commit 2759820, December 2020,
               <https://github.com/richardtallent/RT.Comb>.
 
-
-
-
-Peabody & Davis         Expires 27 February 2022               [Page 27]
-
-Internet-Draft               new-uuid-format                 August 2021
-
-
    [ULID]     Feerasta, A., "Universally Unique Lexicographically
               Sortable Identifier", Commit d0c7170, May 2019,
               <https://github.com/ulid/spec>.
@@ -1533,6 +1507,13 @@ Internet-Draft               new-uuid-format                 August 2021
               <https://docs.mongodb.com/manual/reference/method/
               ObjectId/>.
 
+
+
+Peabody & Davis         Expires 27 February 2022               [Page 27]
+
+Internet-Draft               new-uuid-format                 August 2021
+
+
    [CUID]     Elliott, E., "Collision-resistant ids optimized for
               horizontal scaling and performance.", Commit 215b27b,
               October 2020, <https://github.com/ericelliott/cuid>.
@@ -1547,6 +1528,25 @@ Authors' Addresses
    Kyzer R. Davis
 
    Email: kydavis@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/draft-peabody-dispatch-new-uuid-format-02.xml
+++ b/draft-peabody-dispatch-new-uuid-format-02.xml
@@ -258,9 +258,9 @@
 			Where UUIDv1 splits the timestamp bits into three distinct parts and orders them as
 			time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
 			from the timestamp intact and changes the order to time_high, time_mid, and time_low.
-			Incidentally this will match the original 60 bit Gregorian timestamp source.
-			The clock sequence bits remain unchanged from their usage and position in <xref target="RFC4122"/>.
-			The 48 bit node MUST be set to a pseudo-random value.
+			Incidentally this will match the original 60 bit Gregorian timestamp source with 100-nanosecond precision defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.4"/> 
+			The clock sequence bits remain unchanged from their usage and position in <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>.
+			The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <xref target="RFC4122" sectionFormat="comma" section="4.1.6"/> and <xref target="RFC4122" sectionFormat="comma" section="4.5"/>
 			</t>
 			<t>
 			The format for the 16-octet, 128 bit UUIDv6 is shown in Figure 1
@@ -300,27 +300,9 @@
         <dt>clock_seq_low:</dt> <dd>The 8 bit low portion of the clock sequence.
             Occupies bits 72 through 79 (octet 9)</dd>
 			
-        <dt>node:</dt> <dd>48 bit pseudo-random number used as a spatially unique identifier
+        <dt>node:</dt> <dd>48 bit spatially unique identifier
             Occupies bits 80 through 127 (octets 10-15)</dd>
 		</dl>
-            <section anchor="uuidv6timestamp" title="UUIDv6 Timestamp Usage">
-				<t>
-				UUIDv6 reuses the 60 bit Gregorian timestamp with 100-nanosecond
-				precision defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.4"/>.
-				</t>
-			</section>
-            <section anchor="uuidv6sequence" title="UUIDv6 Clock Sequence  Usage">
-				<t>
-				UUIDv6 makes no change to the Clock Sequence usage defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>.
-				</t>
-            </section>
-            <section anchor="uuidv6node" title="UUIDv6 Node Usage">
-				<t>
-				UUIDv6 node bits SHOULD be set to a 48 bit random or pseudo-random number.
-				UUIDv6 nodes SHOULD NOT utilize an IEEE 802 MAC address or the
-				<xref target="RFC4122" sectionFormat="comma" section="4.5"/> method of generating a random multicast IEEE 802 MAC address.
-				</t>
-            </section>
             <section anchor="uuidv6pseudo" title="UUIDv6 Basic Creation Algorithm">
 				<t>
 				The following implementation algorithm is based on <xref target="RFC4122"/>

--- a/draft-peabody-dispatch-new-uuid-format-02.xml
+++ b/draft-peabody-dispatch-new-uuid-format-02.xml
@@ -193,7 +193,6 @@
 				<li><t>- Fixed some UUIDvX reference issues</t></li>
 				<li><t>- Changed all instances of "motonic" to "monotonic"</t></li>
 				<li><t>- Changed all instances of "#-bit" to "# bit"</t></li>
-				<li><t>- Revised UUIDv6 Clock Sequence Usage from random start to monotonic increment starting at 0</t></li>
 				<li><t>- Changed "proceeding" veriage to "after" in section 7</t></li>
 				<li><t>- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7</t></li>
 				<li><t>- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7</t></li>
@@ -260,7 +259,7 @@
 			time_low, time_mid, time_high_and_version. UUIDv6 instead keeps the source bits
 			from the timestamp intact and changes the order to time_high, time_mid, and time_low.
 			Incidentally this will match the original 60 bit Gregorian timestamp source.
-			The 14 bit clock sequence has been altered slightly to start at zero and increase monotonically for each UUID created on a given timestamp but remain in the position as <xref target="RFC4122"/>.
+			The clock sequence bits remain unchanged from their usage and position in <xref target="RFC4122"/>.
 			The 48 bit node MUST be set to a pseudo-random value.
 			</t>
 			<t>
@@ -312,21 +311,7 @@
 			</section>
             <section anchor="uuidv6sequence" title="UUIDv6 Clock Sequence  Usage">
 				<t>
-				Historically UUIDv1 Clock Sequence usage, defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>, is used for a few purposes.
-				Firstly as collision avoidance mechanism by ensuring that when a timestamp is reused during UUIDv1 creation the clock sequence is incremented.
-				Secondly as added random data to help ensure global uniqueness. This is achieved by starting the clock sequence at random value.
-				This added random is a needed due to the node ID possibly utilizing a static MAC address which could be similar across systems.
-				</t>
-				<t>
-				With UUIDv6 the aggregate 14 bits of clk_seq_hi_res (lower 6 bits) and clock_seq_low (all 8 bits) MUST be treated as one clock sequence value and references as the "UUIDv6 Clock Sequence" for this section.
-				The UUIDv6 clock sequence MUST start at zero and increment monotonically for each new UUID created on by the application on the same timestamp. 
-				When the timestamp increments the UUIDv6 clock sequence MUST be reset to zero.
-				The UUIDv6 clock sequence MUST NOT rollover or reset to zero unless the timestamp has incremented.
-				</t>
-				<t>
-				The 48 bit pseudo-random node defined in the next section provides enough random data to ensure global uniqueness such that the extra random provided by a randomized starting UUIDv6 clock sequence is not required.
-				Additionally, the current 14 bit length of both clk_seq_hi_res and clock_seq_low maximizes the usage of these bits and ensures up to 16383 UUIDv6 values can be created for a given timestamp and then ordered by explicitly by creation sequence.
-				Furthermore, 16383 total values for UUIDv6 clock sequence is sufficiently high for the given UUIDv6 timestamp accuracy resulting in a very low chance of a clock sequence rollover event.
+				UUIDv6 makes no change to the Clock Sequence usage defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.5"/>.
 				</t>
             </section>
             <section anchor="uuidv6node" title="UUIDv6 Node Usage">


### PR DESCRIPTION
As per #38
- I have undone the explicit start to the clock sequence in UUIDv6 merged in #14 
- I have relaxed the Node usage in UUIDv6 to a SHOULD with a MAY comment about IEEE MAC
- Removed redundant sections `4.3.1`, `4.3.2`, `4.3.3`  which are no longer required since Section `4.3` sufficiently covers the topics.