### PR TITLE
Updating repo with Draft 02 IETF submission .txt/.html and diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Update
 
-A new draft was submitted 26 April 2021: https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01 Feedback welcome :)
+A new draft was submitted 07 October 2021: 
+Text: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-02.txt
+HTML: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-02.html
+Feedback welcome :)
 
 # New UUID Formats
 This is the github repo for the IETF draft surrounding the topic of new time-based UUID formats.

--- a/draft-peabody-dispatch-new-uuid-format-02.txt
+++ b/draft-peabody-dispatch-new-uuid-format-02.txt
@@ -5,12 +5,12 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                          26 August 2021
-Expires: 27 February 2022
+Intended status: Standards Track                          7 October 2021
+Expires: 10 April 2022
 
 
                             New UUID Formats
-               draft-peabody-dispatch-new-uuid-format-01
+               draft-peabody-dispatch-new-uuid-format-02
 
 Abstract
 
@@ -43,7 +43,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 27 February 2022.
+   This Internet-Draft will expire on 10 April 2022.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 1]
+Peabody & Davis           Expires 10 April 2022                 [Page 1]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 2]
+Peabody & Davis           Expires 10 April 2022                 [Page 2]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 2.  Background
@@ -165,9 +165,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 3]
+Peabody & Davis           Expires 10 April 2022                 [Page 3]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    Furthermore, UUIDv1 utilizes a non-standard timestamp epoch derived
@@ -221,9 +221,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 4]
+Peabody & Davis           Expires 10 April 2022                 [Page 4]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    An inspection of these implementations details the following trends
@@ -277,9 +277,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 5]
+Peabody & Davis           Expires 10 April 2022                 [Page 5]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 3.1.  changelog
@@ -333,9 +333,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 6]
+Peabody & Davis           Expires 10 April 2022                 [Page 6]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 4.1.  Versions
@@ -389,9 +389,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 7]
+Peabody & Davis           Expires 10 April 2022                 [Page 7]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    Section 4.1.4 The clock sequence bits remain unchanged from their
@@ -445,9 +445,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 8]
+Peabody & Davis           Expires 10 April 2022                 [Page 8]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 4.3.1.  UUIDv6 Basic Creation Algorithm
@@ -501,9 +501,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022                [Page 9]
+Peabody & Davis           Expires 10 April 2022                 [Page 9]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    The steps for splitting time_high_and_time_mid into time_high and
@@ -557,9 +557,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 10]
+Peabody & Davis           Expires 10 April 2022                [Page 10]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    unixts:
@@ -613,9 +613,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 11]
+Peabody & Davis           Expires 10 April 2022                [Page 11]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 4.4.2.  UUIDv7 Clock Sequence Usage
@@ -669,9 +669,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 12]
+Peabody & Davis           Expires 10 April 2022                [Page 12]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    All of these fields are only used during encoding, and during
@@ -725,9 +725,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 13]
+Peabody & Davis           Expires 10 April 2022                [Page 13]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    In Figure 4 the UUIDv7 has been created with Microsecond precision
@@ -781,9 +781,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 14]
+Peabody & Davis           Expires 10 April 2022                [Page 14]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    *  All 12 bits of scenario subsec_a is fully dedicated to providing
@@ -837,9 +837,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 15]
+Peabody & Davis           Expires 10 April 2022                [Page 15]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    Similarly as per Figure 2, the sub-second precision values lie within
@@ -893,9 +893,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 16]
+Peabody & Davis           Expires 10 April 2022                [Page 16]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    1.  System B parses the timestamp with nanosecond precision.  (More
@@ -949,9 +949,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 17]
+Peabody & Davis           Expires 10 April 2022                [Page 17]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    filled with random data.  UUIDv8's 128 bits (including the version
@@ -1005,9 +1005,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 18]
+Peabody & Davis           Expires 10 April 2022                [Page 18]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    seq_or_node:
@@ -1061,9 +1061,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 19]
+Peabody & Davis           Expires 10 April 2022                [Page 19]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    extra care must be taken to ensure the Variant bits are properly
@@ -1117,9 +1117,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 20]
+Peabody & Davis           Expires 10 April 2022                [Page 20]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    The clock sequence MUST start at zero and increment monotonically for
@@ -1173,9 +1173,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 21]
+Peabody & Davis           Expires 10 April 2022                [Page 21]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    3.   Set the 32 bit field timestamp_32 to the 32 bits from the
@@ -1229,9 +1229,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 22]
+Peabody & Davis           Expires 10 April 2022                [Page 22]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    2.   Obtain the current time from the selected clock source as 32
@@ -1285,9 +1285,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 23]
+Peabody & Davis           Expires 10 April 2022                [Page 23]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    2.  Obtain the current time from the selected clock source as desired
@@ -1341,9 +1341,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 24]
+Peabody & Davis           Expires 10 April 2022                [Page 24]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
 6.  Global Uniqueness
@@ -1397,9 +1397,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 25]
+Peabody & Davis           Expires 10 April 2022                [Page 25]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    The machineID portion of node, described in Section 7, does provide
@@ -1453,9 +1453,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 26]
+Peabody & Davis           Expires 10 April 2022                [Page 26]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    [ShardingID]
@@ -1509,9 +1509,9 @@ Internet-Draft               new-uuid-format                 August 2021
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 27]
+Peabody & Davis           Expires 10 April 2022                [Page 27]
 
-Internet-Draft               new-uuid-format                 August 2021
+Internet-Draft               new-uuid-format                October 2021
 
 
    [CUID]     Elliott, E., "Collision-resistant ids optimized for
@@ -1565,4 +1565,4 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 27 February 2022               [Page 28]
+Peabody & Davis           Expires 10 April 2022                [Page 28]

--- a/draft-peabody-dispatch-new-uuid-format-02.xml
+++ b/draft-peabody-dispatch-new-uuid-format-02.xml
@@ -16,12 +16,12 @@
 <!-- end of popular PIs -->
 <!--
     <rfc version="3" category="std" updates="4122" submissionType="IETF" consensus="true" ipr="trust200902"
-    docName="draft-peabody-dispatch-new-uuid-format-01">
+    docName="draft-peabody-dispatch-new-uuid-format-02">
 -->
-<rfc version="3" category="std" updates="4122" submissionType="IETF" consensus="true" ipr="trust200902" docName="draft-peabody-dispatch-new-uuid-format-01">
+<rfc version="3" category="std" updates="4122" submissionType="IETF" consensus="true" ipr="trust200902" docName="draft-peabody-dispatch-new-uuid-format-02">
   <front>
     <title abbrev="new-uuid-format">New UUID Formats</title>
-    <seriesInfo name="Internet-Draft" value="draft-peabody-dispatch-new-uuid-format-01" stream="IETF"/>
+    <seriesInfo name="Internet-Draft" value="draft-peabody-dispatch-new-uuid-format-02" stream="IETF"/>
     <author fullname="Brad G. Peabody" initials="BGP" surname="Peabody">
 <!-- <organization/> -->
       <address>


### PR DESCRIPTION
The deadline for IETF Draft 01 expiry was fast approaching. After a quick conversation with Brad and Gonzalo Salgueiro it was decided to publish what we have completed in Draft 02. This will extend the date of the next draft expiration through April 2022.

Ongoing technical changes from the community feedback in the GitHub Issue tracker will now be part of Draft 03.

Updates to the repo in this PR:
- Fixed some 01 references in the XML file to fully submit 02 to IETF.
- Pulled a copy of the Draft 02 IETF .txt file and replaced the XML2RFC .txt file
- Modified README to include .txt and .html file

IETF diffs located here: https://www.ietf.org/rfcdiff?url2=draft-peabody-dispatch-new-uuid-format-02