### PR TITLE
build script for running lint and render using ietf API

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# ietf-tools API docs at https://author-tools.ietf.org/doc/
+API_ORIGIN="https://author-tools.ietf.org/api2" 
+
+SRC="draft-peabody-dispatch-new-uuid-format-02.xml"
+
+DST_HTML="draft-peabody-dispatch-new-uuid-format-02.html"
+DST_TEXT="draft-peabody-dispatch-new-uuid-format-02.txt"
+
+# Note: Passing referer circumvents the need for an API key
+REFERER="Referer: https://author-tools.ietf.org/"
+
+function usage() {
+  echo "Usage: build [command]
+
+Available commands:  
+  lint - validate document
+  html - render html format
+  text - render text format
+  all - lint (then render all formats)"
+}
+
+
+case $1 in 
+  lint)
+    if ! command -v jq &> /dev/null; then
+      echo "\`jq\` command not found. See https://stedolan.github.io/jq/download/"
+      exit 1
+    fi
+    curl -s -X POST -H "${REFERER}" -F "file=@${SRC}" "${API_ORIGIN}/validate" | jq '.errors'
+    ;;
+
+  text)
+    curl -s -X POST -H "${REFERER}" -F "file=@${SRC}" "${API_ORIGIN}/render/text" > ${DST_TEXT}
+    ;;
+
+  html)
+    curl -s -X POST -H "${REFERER}" -F "file=@${SRC}" "${API_ORIGIN}/render/html" > ${DST_HTML}
+    ;;
+
+  all)
+    build lint && build text && build html
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/build
+++ b/build
@@ -3,10 +3,10 @@
 # ietf-tools API docs at https://author-tools.ietf.org/doc/
 API_ORIGIN="https://author-tools.ietf.org/api2" 
 
-SRC="draft-peabody-dispatch-new-uuid-format-02.xml"
+SRC="draft-peabody-dispatch-new-uuid-format-03.xml"
 
-DST_HTML="draft-peabody-dispatch-new-uuid-format-02.html"
-DST_TEXT="draft-peabody-dispatch-new-uuid-format-02.txt"
+DST_HTML=${SRC/xml/html}
+DST_TEXT==${SRC/xml/txt}
 
 # Note: Passing referer circumvents the need for an API key
 REFERER="Referer: https://author-tools.ietf.org/"
@@ -21,6 +21,11 @@ Available commands:
   all - lint (then render all formats)"
 }
 
+if ! test -f "${SRC}"; then
+    echo "${SRC} not found"
+    exit 1
+fi
+
 
 case $1 in 
   lint)
@@ -28,7 +33,24 @@ case $1 in
       echo "\`jq\` command not found. See https://stedolan.github.io/jq/download/"
       exit 1
     fi
-    curl -s -X POST -H "${REFERER}" -F "file=@${SRC}" "${API_ORIGIN}/validate" | jq '.errors'
+
+    results=$(curl -s -X POST -H "${REFERER}" -F "file=@${SRC}" "${API_ORIGIN}/validate")
+
+    errors=$(echo $results | jq '.errors')
+    if [[ $errors != "[]" ]]; then
+      echo "Lint errors: $errors"
+    fi
+
+    warnings=$(echo $results | jq '.warnings')
+    if [[ $warnings != "[]" ]]; then
+      echo "Lint warnings: $warnings"
+    fi
+
+    if [[ $errors != "[]" || $warnings != "[]" ]]; then
+      exit 1
+    fi
+
+    echo "No lint issues"
     ;;
 
   text)


### PR DESCRIPTION
Found myself trying to figure out how to contribute and ended up going off on a tangent trying to make the `xml2rfc` step... well... usable.  This is what I ended up with.  Just a simple CLI for linting and building spec documents from the command line using the IETF tools API.  Not sure how helpful this will be, but figured I'd put this up in case it was deemed useful.

Note: The IETF API uses `xml2rfc@3.12` while the current version of documents on `master` was generated with `xml2rfc@3.9`.  This results in various minor formatting changes to the rendered documents (not included in this PR, but you'll notice this as soon as you run the tool).

```
$ build
Usage: build [command]

Available commands:
  lint - validate document
  html - render html format
  text - render text format
  all - lint (then render all formats)
```

Aside: It'd be nice if there were a CONTRIBUTING.md document that laid out the process expected for anyone wanting to contribute a PR.
