### PR TITLE
Draft 03, Phase 4 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,14 @@ Various discussion will need to occur to arrive at a standard and this repo will
 2. **UUID version 7**: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source.
 
     `unix_ts_ms|ver|rand_a|var|rand_b`
-3. **UUID version 7E**: An alternate variant for UUIDv7.
 
-    `unix_ts_ms|rand_a|var_ver|rand_b`
-4. **UUID version 8**: A free-form UUID format which has no explicit requirements except maintaining backward compatibility.
+3. **UUID version 8**: A free-form UUID format which has no explicit requirements except maintaining backward compatibility.
 
     `custom_a|ver|custom_b|var|custom_c`
-5. **UUID version 8E**: An alternate variant for UUIDv8.
 
-    `custom_a|var_ver|custom_b`
-6. **Max UUID**: A specialized UUID which is the inverse of the Nil UUID from RFC4122.
+5. **Max UUID**: A specialized UUID which is the inverse of the Nil UUID from RFC4122.
 
     `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF`
-7. **UUID Long**: A generalized name for any variable length UUID longer than 128-bits.
-
-    `8-4-4-4-12-<any_number_of_hex_characters>`
-	
-8. **Alternate Encodings**: The technique of encoding a UUID value as something other than binary, decimal, text 8-4-4-4-12 hex-dashes.
-
-    `urn:uuid:<alternate_encoded_uuid>`
 
 ---
 
@@ -53,7 +42,6 @@ For more information on any of these items refer to the XML, TXT, HTML draft, re
 - [Monotonicity and Counters for same Timestamp-tick collision avoidance during batch UUID creation](https://github.com/uuid6/uuid6-ietf-draft/issues/60)
    - Sub-Topics: Counter position, length, rollover handling and seeding.
 - [Pseudo-random formatting, length and generation methods](https://github.com/uuid6/uuid6-ietf-draft/issues/55)
-- [Version and Variant Bit Usage](https://github.com/uuid6/uuid6-ietf-draft/issues/26)
 - Distributed UUID Generation best practices
   - Sub-Topics: [Shared Knowledge Schemes and embedded nondescript node identifiers](https://github.com/uuid6/uuid6-ietf-draft/issues/36) 
 - [Max UUID Usage](https://github.com/uuid6/uuid6-ietf-draft/issues/62)
@@ -67,7 +55,11 @@ For more information on any of these items refer to the XML, TXT, HTML draft, re
 - Any and all UUID security concerns!
   - Sub-Topics: [MAC address usage in next-generation UUIDs](https://github.com/uuid6/uuid6-ietf-draft/issues/13)
 
-### Other Topics
+
+---
+
+### Out of Scope Topics (being rolled into a new Draft)
+- [Variant Bit E Usage](https://github.com/uuid6/uuid6-ietf-draft/issues/26)
 - [Alternative text encoding techniques (Crockfords Base32, Base64, etc)](https://github.com/uuid6/uuid6-ietf-draft/issues/2)
 - [Variable length UUIDs](https://github.com/uuid6/uuid6-ietf-draft/issues/59)
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,28 @@ Various discussion will need to occur to arrive at a standard and this repo will
 1. **UUID version 6**: A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes. Easy to implement given an existing UUIDv1 implementation.
 
     `time_high|time_mid|time_low_and_version|clk_seq_hi_res|clk_seq_low|node`
-2. **UUID version 7E**: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source.
+2. **UUID version 7**: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source.
+
+    `unix_ts_ms|ver|rand_a|var|rand_b`
+3. **UUID version 7E**: An alternate variant for UUIDv7.
 
     `unix_ts_ms|rand_a|var_ver|rand_b`
-3. **UUID version 8E**: A free-form UUID format which has no explicit requirements except maintaining backward compatibility.
+4. **UUID version 8**: A free-form UUID format which has no explicit requirements except maintaining backward compatibility.
+
+    `custom_a|ver|custom_b|var|custom_c`
+5. **UUID version 8E**: An alternate variant for UUIDv8.
 
     `custom_a|var_ver|custom_b`
-4. **Max UUID**: A specialized UUID which is the inverse of the Nil UUID from RFC4122.
+6. **Max UUID**: A specialized UUID which is the inverse of the Nil UUID from RFC4122.
 
     `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF`
+7. **UUID Long**: A generalized name for any variable length UUID longer than 128-bits.
+
+    `8-4-4-4-12-<any_number_of_hex_characters>`
+	
+8. **Alternate Encodings**: The technique of encoding a UUID value as something other than binary, decimal, text 8-4-4-4-12 hex-dashes.
+
+    `urn:uuid:<alternate_encoded_uuid>`
 
 ---
 
@@ -54,9 +67,7 @@ For more information on any of these items refer to the XML, TXT, HTML draft, re
 - Any and all UUID security concerns!
   - Sub-Topics: [MAC address usage in next-generation UUIDs](https://github.com/uuid6/uuid6-ietf-draft/issues/13)
 
----
-
-### Topics being scoped
+### Other Topics
 - [Alternative text encoding techniques (Crockfords Base32, Base64, etc)](https://github.com/uuid6/uuid6-ietf-draft/issues/2)
 - [Variable length UUIDs](https://github.com/uuid6/uuid6-ietf-draft/issues/59)
 

--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -9,7 +9,7 @@
 <meta content="Kyzer R. Davis" name="author">
 <meta content="
        
- This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
+ This document presents new Universally Unique Identifier (UUID) formats for use in modern applications and databases.
        
     " name="description">
 <meta content="xml2rfc 3.12.2" name="generator">
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/K22ubvQGu0.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/y9xSTrScnA.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 15 September 2022</td>
+<td class="center">Expires 17 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-14" class="published">14 March 2022</time>
+<time datetime="2022-03-16" class="published">16 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-15">15 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-17">17 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1229,7 +1229,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
- This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+ This document presents new Universally Unique Identifier (UUID) formats for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 15 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 17 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1316,127 +1316,96 @@ li > p:last-of-type {
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
                 <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-uuid-version-8" class="xref">UUID Version 8</a></p>
 </li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
+</li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-alternate-variants" class="xref">Alternate Variants</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4">
+                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.5">
+                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.6">
+                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.7">
+                <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.8">
+                <p id="section-toc.1-1.6.2.8.1"><a href="#section-6.8" class="xref">6.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.9">
+                <p id="section-toc.1-1.6.2.9.1"><a href="#section-6.9" class="xref">6.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-alternate-formats" class="xref">Alternate Formats</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
-                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
-                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7-value" class="xref">Creating a UUIDv7 Value</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.3">
-                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.4">
-                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.5">
-                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.6">
-                <p id="section-toc.1-1.8.2.6.1"><a href="#section-8.6" class="xref">8.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.7">
-                <p id="section-toc.1-1.8.2.7.1"><a href="#section-8.7" class="xref">8.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.8">
-                <p id="section-toc.1-1.8.2.8.1"><a href="#section-8.8" class="xref">8.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.9">
-                <p id="section-toc.1-1.8.2.9.1"><a href="#section-8.9" class="xref">8.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8-value" class="xref">Creating a UUIDv8 Value</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
-</li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-13" class="xref">13</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
+                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
+                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.3">
+                <p id="section-toc.1-1.13.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
-                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
-                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.1">
-                <p id="section-toc.1-1.15.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.2">
-                <p id="section-toc.1-1.15.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.3">
-                <p id="section-toc.1-1.15.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.4">
-                <p id="section-toc.1-1.15.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.5">
-                <p id="section-toc.1-1.15.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
-</li>
-            </ul>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.1">
-                <p id="section-toc.1-1.16.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.2">
-                <p id="section-toc.1-1.16.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
-</li>
-            </ul>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1481,25 +1450,17 @@ li > p:last-of-type {
 </li>
         <li id="section-1-4.4">
           <p id="section-1-4.4.1">
- The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
+ Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
+ Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
+ information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.5">
           <p id="section-1-4.5.1">
- The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
+ Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.6">
           <p id="section-1-4.6.1">
- Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
- Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
- information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-1-4.7">
-          <p id="section-1-4.7.1">
- Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.7.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-1-4.8">
-          <p id="section-1-4.8.1">
- <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.8.1" class="pilcrow">¶</a></p>
+ <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-1-5">
@@ -1623,24 +1584,12 @@ li > p:last-of-type {
         <dd style="margin-left: 1.5em" id="section-3-2.4">An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#v7" class="xref">Section 5.2</a><a href="#section-3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate variant for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+<dt id="section-3-2.5">UUID version 8 (UUIDv8)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.8">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.8" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate variant for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.11">Max UUID</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.12">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 7.1</a><a href="#section-3-2.12" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.13">UUID Long</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.14">An extension of the base UUID with variable length beyond 128 bits. See <a href="#uuid_long" class="xref">Section 7.2</a><a href="#section-3-2.14" class="pilcrow">¶</a>
+<dt id="section-3-2.7">Max UUID</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.8">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 5.4</a><a href="#section-3-2.8" class="pilcrow">¶</a>
 </dd>
       <dd class="break"></dd>
 </dl>
@@ -1665,52 +1614,43 @@ li > p:last-of-type {
             <p id="section-3.1-3.4.1">- UUIDv8 relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.5">
-            <p id="section-3.1-3.5.1">- Changed UUIDv7E and UUIDv8E to use Variant 111.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.5.1">- Introduced Max UUID.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.6">
-            <p id="section-3.1-3.6.1">- Introduced Max UUID.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.6.1">- Added C code samples in Appendix.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.7">
-            <p id="section-3.1-3.7.1">- Re-introduced variable length UUIDs as UUID Long.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.7.1">- Added test vectors in Appendix.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.8">
-            <p id="section-3.1-3.8.1">- Re-introduced alternate encoding techniques for all UUIDs.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.8.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.9">
-            <p id="section-3.1-3.9.1">- Added C code samples in Appendix.<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.9.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.10">
-            <p id="section-3.1-3.10.1">- Added test vectors in Appendix.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.10.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.11">
-            <p id="section-3.1-3.11.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.11.1">- Split Encoding and Storage into Opacity and DBMS and Database Considerations<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.12">
-            <p id="section-3.1-3.12.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.12.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.13">
-            <p id="section-3.1-3.13.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.13.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.14">
-            <p id="section-3.1-3.14.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.14.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.15">
-            <p id="section-3.1-3.15.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.15.1">- Added Abbreviations section<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.16">
-            <p id="section-3.1-3.16.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.16.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.17">
-            <p id="section-3.1-3.17.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.18">
-            <p id="section-3.1-3.18.1">- Added Abbreviations section<a href="#section-3.1-3.18.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.19">
-            <p id="section-3.1-3.19.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.19.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.20">
-            <p id="section-3.1-3.20.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.20.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.17.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="section-3.1-4">draft-02<a href="#section-3.1-4" class="pilcrow">¶</a></p>
@@ -1780,70 +1720,11 @@ li > p:last-of-type {
  The variant bits utilized by UUIDs in this specification 
  remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4-1" class="pilcrow">¶</a></p>
 <p id="section-4-2">
- This specification makes use of the unused variant bits of 111 defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.
- This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
- All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
- The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4-2" class="pilcrow">¶</a></p>
-<ul class="compact">
-<li class="compact" id="section-4-3.1">
-          <p id="section-4-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4-3.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="compact" id="section-4-3.2">
-          <p id="section-4-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4-3.2.1" class="pilcrow">¶</a></p>
-</li>
-      </ul>
-<p id="section-4-4">
- The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4-4" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-defined-by-thi"></span><table class="center" id="table-1">
+ The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
+ A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-1">
         <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
-<a href="#name-uuid-variant-defined-by-thi" class="selfRef">UUID Variant defined by this specification</a>
-        </caption>
-<thead>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-            <td class="text-left" rowspan="1" colspan="1">Hex</td>
-            <td class="text-left" rowspan="1" colspan="1">Description</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">x</td>
-            <td class="text-left" rowspan="1" colspan="1">x</td>
-            <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
-            <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">E</td>
-            <td class="text-left" rowspan="1" colspan="1">The new variant specified in this document.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">F</td>
-            <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-          </tr>
-        </tbody>
-      </table>
-<p id="section-4-6">
- UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4-6" class="pilcrow">¶</a></p>
-<p id="section-4-7">
- The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
- A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-7" class="pilcrow">¶</a></p>
-<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
-        <caption>
-<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-new-uuid-variant-10xx-8-9-a" class="selfRef">New UUID variant 10xx (8/9/A/B) versions defined by this specification</a>
         </caption>
 <thead>
@@ -1883,11 +1764,11 @@ li > p:last-of-type {
           </tr>
         </tbody>
       </table>
-<p id="section-4-9">
+<p id="section-4-4">
  For UUID version 6, 7 and 8 the variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged.
- An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-9" class="pilcrow">¶</a></p>
+ An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-4" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-variant-examples"></span><figure id="figure-1">
-        <div class="alignLeft art-text artwork" id="section-4-10.1">
+        <div class="alignLeft art-text artwork" id="section-4-5.1">
 <pre>
 00000000-0000-6000-8000-000000000000
 00000000-0000-6000-9000-000000000000
@@ -1899,60 +1780,6 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
 <a href="#name-uuidv6-variant-examples" class="selfRef">UUIDv6 Variant Examples</a>
         </figcaption></figure>
-<p id="section-4-11">
- The next table details Variant 1110 (E) and the new versions defined by this specification.
- A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4-11" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-1110-e-version"></span><table class="center" id="table-3">
-        <caption>
-<a href="#table-3" class="selfRef">Table 3</a>:
-<a href="#name-uuid-variant-1110-e-version" class="selfRef">UUID variant 1110 (E) versions defined by this specification</a>
-        </caption>
-<thead>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-            <td class="text-left" rowspan="1" colspan="1">Version</td>
-            <td class="text-left" rowspan="1" colspan="1">Description</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">7E</td>
-            <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">8E</td>
-            <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
-          </tr>
-        </tbody>
-      </table>
-<p id="section-4-13">
-                    For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
- Since the bits of the variant remain in the same place as described in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
- An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4-13" class="pilcrow">¶</a></p>
-<span id="name-uuid-version-7e-and-8e-vari"></span><figure id="figure-2">
-        <div class="alignLeft art-text artwork" id="section-4-14.1">
-<pre>
-00000000-0000-0000-E700-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-
-00000000-0000-0000-E800-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-</pre>
-</div>
-<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
-<a href="#name-uuid-version-7e-and-8e-vari" class="selfRef">UUID version 7E and 8E Variant Examples</a>
-        </figcaption></figure>
 </section>
 </div>
 <div id="format">
@@ -1961,7 +1788,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <a href="#section-5" class="section-number selfRef">5. </a><a href="#name-new-formats" class="section-name selfRef">New Formats</a>
       </h2>
 <p id="section-5-1">
- The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
+ The UUID format is 16 octets; the variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <div id="uuidv6">
 <section id="section-5.1">
         <h3 id="name-uuid-version-6">
@@ -1970,7 +1797,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <p id="section-5.1-1">
  UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
  It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
- Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+ Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
 <p id="section-5.1-2">
  Instead of splitting the timestamp into the low, mid and high sections from UUIDv1, UUIDv6 changes this sequence so timestamp bytes are stored from most to least significant.  
  That is, given a 60 bit timestamp value as specified for UUIDv1 in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>,
@@ -1979,10 +1806,10 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <p id="section-5.1-3">
  The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
 <p id="section-5.1-4">
- The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 10</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
+ The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 8</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
 <p id="section-5.1-5">
  The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-5.1-5" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-3">
+<span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-2">
           <div class="alignLeft art-text artwork" id="section-5.1-6.1">
 <pre>
      0                   1                   2                   3
@@ -1998,7 +1825,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
 <a href="#name-uuidv6-field-and-bit-layout" class="selfRef">UUIDv6 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.1-7">
@@ -2042,9 +1869,9 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
  32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
  In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
-<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-4">
+<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-2">
           <caption>
-<a href="#table-4" class="selfRef">Table 4</a>:
+<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-uuidv1-to-uuidv6-field-mapp" class="selfRef">UUIDv1 to UUIDv6 Field Mappings</a>
           </caption>
 <thead>
@@ -2083,7 +1910,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
  UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <p id="section-5.2-2">
  Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-4">
+<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-3">
           <div class="alignLeft art-text artwork" id="section-5.2-3.1">
 <pre>
  0                   1                   2                   3
@@ -2099,12 +1926,12 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
 <a href="#name-uuidv7-field-and-bit-layout" class="selfRef">UUIDv7 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.2-4">
           <dt id="section-5.2-4.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 6.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.3">ver:</dt>
@@ -2112,7 +1939,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.5">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 6.2</a> and <a href="#unguessability" class="xref">Section 6.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.7">var:</dt>
@@ -2120,7 +1947,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.9">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 6.2</a> and <a href="#unguessability" class="xref">Section 6.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -2152,7 +1979,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
    inhibit the use of one of the current UUIDs.<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-5">
+<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-4">
           <div class="alignLeft art-text artwork" id="section-5.3-5.1">
 <pre>
  0                   1                   2                   3
@@ -2168,7 +1995,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
 <a href="#name-uuidv8-field-and-bit-layout" class="selfRef">UUIDv8 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.3-6">
@@ -2189,488 +2016,311 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.3-6.9">custom_c:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
-</section>
-</div>
-<div id="alternate_uuid_variants">
-<section id="section-6">
-      <h2 id="name-alternate-variants">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-alternate-variants" class="section-name selfRef">Alternate Variants</a>
-      </h2>
-<p id="section-6-1">
- This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.<a href="#section-6-1" class="pilcrow">¶</a></p>
-<div id="uuidv7">
-<section id="section-6.1">
-        <h3 id="name-uuid-version-7e">
-<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
-        </h3>
-<p id="section-6.1-1">
- UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.1-2">
- With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-6">
-          <div class="alignLeft art-text artwork" id="section-6.1-3.1">
-<pre>
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           unix_ts_ms                          |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|          unix_ts_ms           |            rand_a             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</pre>
-</div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
-<a href="#name-uuidv7e-field-and-bit-layou" class="selfRef">UUIDv7E Field and Bit Layout</a>
-          </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-6.1-4">
-          <dt id="section-6.1-4.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-6.1-4.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.3">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.5">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.1-4.6" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.7">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.8" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-</section>
-</div>
-<div id="uuidv8">
-<section id="section-6.2">
-        <h3 id="name-uuid-version-8e">
-<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
-        </h3>
-<p id="section-6.2-1">
- UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.2-2">
- With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-7">
-          <div class="alignLeft art-text artwork" id="section-6.2-3.1">
-<pre>
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</pre>
-</div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
-<a href="#name-uuidv8e-field-and-bit-layou" class="selfRef">UUIDv8E Field and Bit Layout</a>
-          </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-6.2-4">
-          <dt id="section-6.2-4.1">custom_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-6.2-4.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-4.3">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.2-4.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-4.5">custom_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-6.2-4.6" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-</section>
-</div>
-</section>
-</div>
-<div id="alternate_uuid_formats">
-<section id="section-7">
-      <h2 id="name-alternate-formats">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-alternate-formats" class="section-name selfRef">Alternate Formats</a>
-      </h2>
-<p id="section-7-1">
- This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-7-1" class="pilcrow">¶</a></p>
 <div id="maxuuid">
-<section id="section-7.1">
+<section id="section-5.4">
         <h3 id="name-max-uuid">
-<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
         </h3>
-<p id="section-7.1-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-7.1-1" class="pilcrow">¶</a></p>
-<span id="name-max-uuid-format"></span><figure id="figure-8">
-          <div class="alignLeft art-text artwork" id="section-7.1-2.1">
+<p id="section-5.4-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<span id="name-max-uuid-format"></span><figure id="figure-5">
+          <div class="alignLeft art-text artwork" id="section-5.4-2.1">
 <pre>
 FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
 <a href="#name-max-uuid-format" class="selfRef">Max UUID Format</a>
           </figcaption></figure>
-</section>
-</div>
-<div id="uuid_long">
-<section id="section-7.2">
-        <h3 id="name-uuid-long">
-<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
-        </h3>
-<p id="section-7.2-1">
- UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-7.2-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-7.2-2">
-          <dt id="section-7.2-2.1">Increased Entropy:</dt>
-          <dd style="margin-left: 1.5em" id="section-7.2-2.2">While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<a href="#collision_resistance" class="xref">Section 8.4</a>) or guessability (<a href="#unguessability" class="xref">Section 8.6</a>).<a href="#section-7.2-2.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-7.2-2.3">Requirements for additional embedded items:</dt>
-          <dd style="margin-left: 1.5em" id="section-7.2-2.4">Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-7.2-2.4" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-<p id="section-7.2-3">
- UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuid-long-examples"></span><figure id="figure-9">
-          <div class="alignLeft art-text artwork" id="section-7.2-4.1">
-<pre>
-UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
-   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
-  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
-</pre>
-</div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
-<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
-          </figcaption></figure>
-<p id="section-7.2-5">
- Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-7.2-5" class="pilcrow">¶</a></p>
-<p id="section-7.2-6">
- When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="uuid_encoding">
-<section id="section-7.3">
-        <h3 id="name-alternate-encodings">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
-        </h3>
-<p id="section-7.3-1">
- The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
-<p id="section-7.3-2">
- Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.<a href="#section-7.3-2" class="pilcrow">¶</a></p>
-<p id="section-7.3-3">
- When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.<a href="#section-7.3-3" class="pilcrow">¶</a></p>
-<p id="section-7.3-4">
- The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
-<span id="name-alternate-encoding-examples"></span><figure id="figure-10">
-          <div class="alignLeft art-text artwork" id="section-7.3-5.1">
-<pre>
-UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-UUIDv4 Int: 154072644812979270675542139334331768221
-UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
-UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
-UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
-</pre>
-</div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
-<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
-          </figcaption></figure>
-<p id="section-7.3-6">
- For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="uuid_best_practices">
-<section id="section-8">
+<section id="section-6">
       <h2 id="name-uuid-best-practices">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
       </h2>
-<p id="section-8-1">
+<p id="section-6-1">
  The minimum requirements for generating UUIDs are 
  described in this document for each version.
  Everything else is an implementation detail and 
  up to the implementer to decide what is appropriate for a given 
  implementation. That being said, various relevant factors are covered
- below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-8-1" class="pilcrow">¶</a></p>
+ below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-6-1" class="pilcrow">¶</a></p>
 <div id="timestamp_granularity">
-<section id="section-8.1">
+<section id="section-6.1">
         <h3 id="name-timestamp-granularity">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
         </h3>
-<p id="section-8.1-1">
- UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.1-2">
-          <dt id="section-8.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-8.1-2.2" class="pilcrow">¶</a>
+<p id="section-6.1-1">
+ UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.1-2">
+          <dt id="section-6.1-2.1">Reliability:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-6.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.3">Source:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.<a href="#section-8.1-2.4" class="pilcrow">¶</a>
+<dt id="section-6.1-2.3">Source:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 SHOULD be leveraged.<a href="#section-6.1-2.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.<a href="#section-8.1-2.6" class="pilcrow">¶</a>
+<dt id="section-6.1-2.5">Sub-second Precision and Accuracy:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.7">Length:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.<a href="#section-8.1-2.8" class="pilcrow">¶</a>
+<dt id="section-6.1-2.7">Length:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 features a 48 bit timestamp.<a href="#section-6.1-2.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.9">Fuzzing:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-8.1-2.10" class="pilcrow">¶</a>
+<dt id="section-6.1-2.9">Fuzzing:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-6.1-2.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.11">Padding:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.<a href="#section-8.1-2.12" class="pilcrow">¶</a>
+<dt id="section-6.1-2.11">Padding:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7.<a href="#section-6.1-2.12" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.13">Truncating:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-8.1-2.14" class="pilcrow">¶</a>
+<dt id="section-6.1-2.13">Truncating:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7.<a href="#section-6.1-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="monotonicity_counters">
-<section id="section-8.2">
+<section id="section-6.2">
         <h3 id="name-monotonicity-and-counters">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
         </h3>
-<p id="section-8.2-1">
- Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
-<p id="section-8.2-2">
+<p id="section-6.2-1">
+ Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation of order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
-<p id="section-8.2-3">
- For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a><a href="#section-8.2-3" class="pilcrow">¶</a></p>
-<p id="section-8.2-4">
- Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-8.2-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.2-5">
-          <dt id="section-8.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-5.2">
+ For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">
+ For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a><a href="#section-6.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2-4">
+ Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-6.2-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-5">
+          <dt id="section-6.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.2">
  This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
- Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.<a href="#section-8.2-5.2" class="pilcrow">¶</a>
+ Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits.<a href="#section-6.2-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-5.3">Monotonic Random (Method 2):</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-5.4">
- With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-8.2-5.4" class="pilcrow">¶</a>
+<dt id="section-6.2-5.3">Monotonic Random (Method 2):</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.4">
+ With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 SHOULD utilize this method to handle batch UUID generation during a single timestamp tick. Furthermore, with this method the actual increment of the counter MAY be a random integer of any desired length instead of using simplistic "plus one" logic found with Fixed Length Dedicated Counters. This random increment of the counter ensures the UUIDs retain the required level of unguessability characters provided by the underlying entropy.<a href="#section-6.2-5.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.2-6">
- The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-8.2-6" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.2-7">
-          <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.2">
+<p id="section-6.2-6">
+ The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-6.2-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-7">
+          <dt id="section-6.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.2">
  Implementations utilizing fixed-length counter method SHOULD randomly initialize the counter with each new timestamp tick. 
  However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. 
  When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. 
- Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+ Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-6.2-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+<dt id="section-6.2-7.3">Fixed-Length Dedicated Counter Length</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-6.2-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+<dt id="section-6.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.6">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-6.2-7.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.2-8">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-8.2-8" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-8.2-9">
- <li id="section-8.2-9.1">
-            <p id="section-8.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-8.2-9.1.1" class="pilcrow">¶</a></p>
+<p id="section-6.2-8">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-6.2-9">
+ <li id="section-6.2-9.1">
+            <p id="section-6.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-8.2-9.2">
-            <p id="section-8.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-8.2-9.2.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-9.2">
+            <p id="section-6.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-6.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-8.2-9.3">
-            <p id="section-8.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-8.2-9.3.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-9.3">
+            <p id="section-6.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-9.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-8.2-10">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-8.2-10" class="pilcrow">¶</a></p>
-<p id="section-8.2-11">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-8.2-11" class="pilcrow">¶</a></p>
+<p id="section-6.2-10">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-10" class="pilcrow">¶</a></p>
+<p id="section-6.2-11">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
-<section id="section-8.3">
+<section id="section-6.3">
         <h3 id="name-distributed-uuid-generation">
-<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
         </h3>
-<p id="section-8.3-1">
+<p id="section-6.3-1">
  Some implementations MAY desire to utilize multi-node, clustered, applications which involve two or more 
  applications independently generating UUIDs that will be stored in a common location. 
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
- This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.3-2">
-          <dt id="section-8.3-2.1">Shared Knowledge System:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-8.3-2.2" class="pilcrow">¶</a>
+ This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.3-2">
+          <dt id="section-6.3-2.1">Shared Knowledge System:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-6.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.3-2.3">Node IDs:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 10</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-8.3-2.4" class="pilcrow">¶</a>
+<dt id="section-6.3-2.3">Node IDs:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 8</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-6.3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-8.3-3" class="pilcrow">¶</a></p>
+<p id="section-6.3-3">
+ Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
-<section id="section-8.4">
+<section id="section-6.4">
         <h3 id="name-collision-resistance">
-<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
+<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
-<p id="section-8.4-1">
- Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 8.1</a> and <a href="#monotonicity_counters" class="xref">Section 8.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
-<p id="section-8.4-2">
- There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.4-3">
-          <dt id="section-8.4-3.1">Low Impact</dt>
-          <dd style="margin-left: 1.5em" id="section-8.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-8.4-3.2" class="pilcrow">¶</a>
+<p id="section-6.4-1">
+ Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a>.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
+<p id="section-6.4-2">
+ There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-6.4-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.4-3">
+          <dt id="section-6.4-3.1">Low Impact</dt>
+          <dd style="margin-left: 1.5em" id="section-6.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-6.4-3.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.4-3.3">High Impact:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-8.4-3.4" class="pilcrow">¶</a>
+<dt id="section-6.4-3.3">High Impact:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-6.4-3.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="global_local_uniqueness">
-<section id="section-8.5">
+<section id="section-6.5">
         <h3 id="name-global-and-local-uniqueness">
-<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
+<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
         </h3>
-<p id="section-8.5-1">
+<p id="section-6.5-1">
  UUIDs created by this specification MAY be used to provide local uniqueness guarantees. 
- For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
-<p id="section-8.5-2">
+ For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+<p id="section-6.5-2">
  Although true global uniqueness is impossible to guarantee without shared knowledge scheme; a shared knowledge scheme is not required by UUID to provide uniqueness guarantees.
- Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
+ Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-6.5-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="unguessability">
-<section id="section-8.6">
+<section id="section-6.6">
         <h3 id="name-unguessability">
-<a href="#section-8.6" class="section-number selfRef">8.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
+<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
         </h3>
-<p id="section-8.6-1">
+<p id="section-6.6-1">
  Implementations SHOULD utilize a cryptographically secure pseudo-random number generator (CSPRNG) to provide values that are both difficult to predict ("unguessable") and have a low likelihood of collision ("unique").
- CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 8.4</a> and <a href="#Security" class="xref">Section 10</a> are present in modern UUIDs.<a href="#section-8.6-1" class="pilcrow">¶</a></p>
-<p id="section-8.6-2">
- Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-8.6-2" class="pilcrow">¶</a></p>
+ CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 6.4</a> and <a href="#Security" class="xref">Section 8</a> are present in modern UUIDs.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+<p id="section-6.6-2">
+ Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-6.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sorting">
-<section id="section-8.7">
+<section id="section-6.7">
         <h3 id="name-sorting">
-<a href="#section-8.7" class="section-number selfRef">8.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
+<a href="#section-6.7" class="section-number selfRef">6.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
         </h3>
-<p id="section-8.7-1">
- UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-8.7-1" class="pilcrow">¶</a></p>
-<p id="section-8.7-2">
+<p id="section-6.7-1">
+ UUIDv6 and UUIDv7 are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
+<p id="section-6.7-2">
  Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
  As a result objects can much more easily be clustered together for better performance.  
- The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-8.7-2" class="pilcrow">¶</a></p>
-<p id="section-8.7-3">
- UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-8.7-3" class="pilcrow">¶</a></p>
-<p id="section-8.7-4">
- UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-8.7-4" class="pilcrow">¶</a></p>
+ The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-6.7-2" class="pilcrow">¶</a></p>
+<p id="section-6.7-3">
+ UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-6.7-3" class="pilcrow">¶</a></p>
+<p id="section-6.7-4">
+ UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8.<a href="#section-6.7-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="opacity">
-<section id="section-8.8">
+<section id="section-6.8">
         <h3 id="name-opacity">
-<a href="#section-8.8" class="section-number selfRef">8.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
+<a href="#section-6.8" class="section-number selfRef">6.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
         </h3>
-<p id="section-8.8-1">
- UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-8.8-1" class="pilcrow">¶</a></p>
+<p id="section-6.8-1">
+ UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-6.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="database_considerations">
-<section id="section-8.9">
+<section id="section-6.9">
         <h3 id="name-dbms-and-database-considera">
-<a href="#section-8.9" class="section-number selfRef">8.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
+<a href="#section-6.9" class="section-number selfRef">6.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
         </h3>
-<p id="section-8.9-1">
+<p id="section-6.9-1">
  For many applications, such as databases, storing UUIDs as the text is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID value.
- Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-8.9-1" class="pilcrow">¶</a></p>
+ Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-6.9-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-8.9-2.1">
-            <p id="section-8.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-8.9-2.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-6.9-2.1">
+            <p id="section-6.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-6.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-8.9-2.2">
-            <p id="section-8.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-8.9-2.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-6.9-2.2">
+            <p id="section-6.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-6.9-2.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-8.9-3">
+<p id="section-6.9-3">
  
  For other systems, UUIDs MAY be stored in binary form or as text, as appropriate. 
- The trade offs to both approaches are as such:<a href="#section-8.9-3" class="pilcrow">¶</a></p>
+ The trade offs to both approaches are as such:<a href="#section-6.9-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-8.9-4.1">
-            <p id="section-8.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-8.9-4.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-6.9-4.1">
+            <p id="section-6.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-6.9-4.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-8.9-4.2">
-            <p id="section-8.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-8.9-4.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-6.9-4.2">
+            <p id="section-6.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-6.9-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-8.9-5">
+<p id="section-6.9-5">
  DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
  If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
- In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-8.9-5" class="pilcrow">¶</a></p>
+ In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-6.9-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="IANA">
-<section id="section-9">
+<section id="section-7">
       <h2 id="name-iana-considerations">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-9-1">This document has no IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-7-1">This document has no IANA actions.<a href="#section-7-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Security">
-<section id="section-10">
+<section id="section-8">
       <h2 id="name-security-considerations">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-10-1"> 
+<p id="section-8-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
  Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
- uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 8.6</a> for more information.<a href="#section-10-1" class="pilcrow">¶</a></p>
-<p id="section-10-2">
+ uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 6.6</a> for more information.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-8-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 
  an embedded counter does signal the order of creation for a given UUID and it's corresponding data but 
  does not define anything about the data itself or the application as a whole. If UUIDs are required for
- use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-10-2" class="pilcrow">¶</a></p>
+ use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-8-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Acknowledgements">
-<section id="section-11">
+<section id="section-9">
       <h2 id="name-acknowledgements">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-11-1">The authors gratefully acknowledge the contributions of 
+<p id="section-9-1">The authors gratefully acknowledge the contributions of 
  Ben Campbell,
  Ben Ramsey,
  Fabio Lima,
@@ -2684,12 +2334,12 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
  Robert Kieffer,
  sergeyprokhorenko,
  LiosK
- As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-11-1" class="pilcrow">¶</a></p>
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-12">
+<section id="section-10">
       <h2 id="name-normative-references">
-<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
       </h2>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -2714,9 +2364,9 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-13">
+<section id="section-11">
       <h2 id="name-informative-references">
-<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
       </h2>
 <dl class="references">
 <dt id="LexicalUUID">[LexicalUUID]</dt>
@@ -2800,7 +2450,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-creating-a-uuidv6-value" class="section-name selfRef">Creating a UUIDv6 Value</a>
         </h3>
 <p id="appendix-A.1-1">This section details a function in C which converts from a UUID version 1 to version 6:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-function-in-c"></span><figure id="figure-11">
+<span id="name-uuidv6-function-in-c"></span><figure id="figure-6">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2834,76 +2484,34 @@ void uuidv1tov6(uuid_t u) {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-uuidv6-function-in-c" class="selfRef">UUIDv6 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="creating_a_uuidv7_value">
 <section id="appendix-A.2">
-        <h3 id="name-creating-a-uuidv7e-value">
-<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7e-value" class="section-name selfRef">Creating a UUIDv7E Value</a>
+        <h3 id="name-creating-a-uuidv7-value">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7-value" class="section-name selfRef">Creating a UUIDv7 Value</a>
         </h3>
-<span id="name-uuidv7e-function-in-c"></span><figure id="figure-12">
+<span id="name-uuidv7-function-in-c"></span><figure id="figure-7">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
-#include &lt;stdio.h&gt;
-#include &lt;stdlib.h&gt;
-#include &lt;stdint.h&gt;
-#include &lt;string.h&gt;
-#include &lt;time.h&gt;
-
-// ...
-
-// csprng data source
-FILE *rndf;
-rndf = fopen("/dev/urandom", "r");
-if (rndf == 0) {
-        printf("fopen /dev/urandom error\n");
-        return 1;
-}
-
-// ...
-
-// generate one UUIDv7E
-uint8_t u[16];
-struct timespec ts;
-int ret;
-
-ret = clock_gettime(CLOCK_REALTIME, &amp;ts);
-if (ret != 0) {
-        printf("clock_gettime error: %d\n", ret);
-        return 1;
-}
-
-uint64_t tms;
-
-tms = ((uint64_t)ts.tv_sec) * 1000;
-tms += ((uint64_t)ts.tv_nsec) / 1000000;
-
-printf("tms: %lld\n", tms);
-
-memset(u, 0, 16);
-
-fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
-
-*((uint64_t*)(u)) |= htonll(tms &lt;&lt; 16); // shift time into first 48 bits and OR into place
-
-u[8] = 0xE7; // set var-ver field
+TODO UUIDv7
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
-<a href="#name-uuidv7e-function-in-c" class="selfRef">UUIDv7E Function in C</a>
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<a href="#name-uuidv7-function-in-c" class="selfRef">UUIDv7 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="creating_a_uuidv8_value">
 <section id="appendix-A.3">
-        <h3 id="name-creating-a-uuidv8e-value">
-<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8e-value" class="section-name selfRef">Creating a UUIDv8E Value</a>
+        <h3 id="name-creating-a-uuidv8-value">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8-value" class="section-name selfRef">Creating a UUIDv8 Value</a>
         </h3>
-<p id="appendix-A.3-1">UUIDv8E will vary greatly from implementation to implementation. A good candidate use case for UUIDv8E is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuid8-function-in-c"></span><figure id="figure-13">
+<p id="appendix-A.3-1">UUIDv8 will vary greatly from implementation to implementation. A good candidate use case for UUIDv8 is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
+<span id="name-uuidv8-function-in-c"></span><figure id="figure-8">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 #include &lt;stdint.h&gt;
@@ -2923,8 +2531,8 @@ int main() {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
-<a href="#name-uuid8-function-in-c" class="selfRef">UUID8 Function in C</a>
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<a href="#name-uuidv8-function-in-c" class="selfRef">UUIDv8 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
@@ -2937,7 +2545,7 @@ int main() {
       </h2>
 <p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
-<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-14">
+<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-9">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
 <pre>
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
@@ -2964,7 +2572,7 @@ gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
 <a href="#name-test-vector-timestamp-pseud" class="selfRef">Test Vector Timestamp Pseudo-code</a>
         </figcaption></figure>
 <div id="uuidv6_example">
@@ -2972,7 +2580,7 @@ gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
         <h3 id="name-example-of-a-uuidv6-value">
 <a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-example-of-a-uuidv6-value" class="section-name selfRef">Example of a UUIDv6 Value</a>
         </h3>
-<span id="name-uuidv1-example-test-vector"></span><figure id="figure-15">
+<span id="name-uuidv1-example-test-vector"></span><figure id="figure-10">
           <div class="alignLeft art-text artwork" id="appendix-B.1-1.1">
 <pre>
 ----------------------------------------------
@@ -2990,10 +2598,10 @@ total                128
 final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
 <a href="#name-uuidv1-example-test-vector" class="selfRef">UUIDv1 Example Test Vector</a>
           </figcaption></figure>
-<span id="name-uuidv6-example-test-vector"></span><figure id="figure-16">
+<span id="name-uuidv6-example-test-vector"></span><figure id="figure-11">
           <div class="alignLeft art-text artwork" id="appendix-B.1-2.1">
 <pre>
 -----------------------------------------------
@@ -3011,7 +2619,7 @@ total                 128
 final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-uuidv6-example-test-vector" class="selfRef">UUIDv6 Example Test Vector</a>
           </figcaption></figure>
 </section>
@@ -3024,7 +2632,7 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 <p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7-example-test-vector"></span><figure id="figure-17">
+<span id="name-uuidv7-example-test-vector"></span><figure id="figure-12">
           <div class="alignLeft art-text artwork" id="appendix-B.2-4.1">
 <pre>
 -------------------------------
@@ -3041,51 +2649,22 @@ total       128
 final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
 </pre>
 </div>
-<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-uuidv7-example-test-vector" class="selfRef">UUIDv7 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
-<div id="uuidv7E_example">
-<section id="appendix-B.3">
-        <h3 id="name-example-of-a-uuidv7e-value">
-<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
-        </h3>
-<p id="appendix-B.3-1">This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-18">
-          <div class="alignLeft art-text artwork" id="appendix-B.3-4.1">
-<pre>
--------------------------------
-field      bits    value
--------------------------------
-unix_ts_ms   48    0x017F21CFD130
-rand_a       16    0xF8B8
-var_ver       8    0xE7
-rand_b       56    0xD6A139DC9535C5
--------------------------------
-total       128
--------------------------------
-final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
-</pre>
-</div>
-<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
-<a href="#name-uuidv7e-example-test-vector" class="selfRef">UUIDv7E Example Test Vector</a>
-          </figcaption></figure>
-</section>
-</div>
 <div id="uuidv8_example">
-<section id="appendix-B.4">
+<section id="appendix-B.3">
         <h3 id="name-example-of-a-uuidv8-value">
-<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.4-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.4-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.4-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.4-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.4-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-19">
-          <div class="alignLeft art-text artwork" id="appendix-B.4-5.1">
+<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8-example-test-vector"></span><figure id="figure-13">
+          <div class="alignLeft art-text artwork" id="appendix-B.3-5.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -3101,37 +2680,8 @@ total       128
 final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
 </pre>
 </div>
-<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
-<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
-          </figcaption></figure>
-</section>
-</div>
-<div id="uuidv8E_example">
-<section id="appendix-B.5">
-        <h3 id="name-example-of-a-uuidv8e-value">
-<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
-        </h3>
-<p id="appendix-B.5-1">This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.5-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-2">The final 56 bits are filled with random data.<a href="#appendix-B.5-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.5-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.5-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector-2"></span><figure id="figure-20">
-          <div class="alignLeft art-text artwork" id="appendix-B.5-5.1">
-<pre>
--------------------------------
-field      bits    value
--------------------------------
-custom_a     64    0x16D6320C3D4DCC00
-var_ver       8    0xE8
-custom_b     56    0x3C2D06302FC417
--------------------------------
-total       128
--------------------------------
-final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
-</pre>
-</div>
-<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
-<a href="#name-uuidv8e-example-test-vector-2" class="selfRef">UUIDv8E Example Test Vector</a>
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<a href="#name-uuidv8-example-test-vector" class="selfRef">UUIDv8 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
@@ -3147,10 +2697,10 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
         <h3 id="name-variant-10xx-versions">
 <a href="#appendix-C.1" class="section-number selfRef">C.1. </a><a href="#name-variant-10xx-versions" class="section-name selfRef">Variant 10xx Versions</a>
         </h3>
-<span id="name-all-uuid-variant-10xx-versi"></span><table class="center" id="table-5">
+<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-3">
           <caption>
-<a href="#table-5" class="selfRef">Table 5</a>:
-<a href="#name-all-uuid-variant-10xx-versi" class="selfRef">All UUID variant 10xx version definitions.</a>
+<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#name-all-uuid-variant-10xx-8-9-a" class="selfRef">All UUID variant 10xx (8/9/A/B) version definitions.</a>
           </caption>
 <thead>
             <tr>
@@ -3291,159 +2841,6 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">15</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-          </tbody>
-        </table>
-</section>
-</div>
-<div id="new_var_table">
-<section id="appendix-C.2">
-        <h3 id="name-variant-1110-versions">
-<a href="#appendix-C.2" class="section-number selfRef">C.2. </a><a href="#name-variant-1110-versions" class="section-name selfRef">Variant 1110 Versions</a>
-        </h3>
-<span id="name-all-uuid-variant-1110-versi"></span><table class="center" id="table-6">
-          <caption>
-<a href="#table-6" class="selfRef">Table 6</a>:
-<a href="#name-all-uuid-variant-1110-versi" class="selfRef">All UUID variant 1110 version definitions.</a>
-          </caption>
-<thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">2E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">3E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">4E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">5E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">6E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">9E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">10E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">11E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">12E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">13E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">14E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">15E</td>
               <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
             </tr>
           </tbody>

--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/Zff8bBwAJZ.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/K22ubvQGu0.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 10 September 2022</td>
+<td class="center">Expires 15 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-09" class="published">9 March 2022</time>
+<time datetime="2022-03-14" class="published">14 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-10">10 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-15">15 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 15 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1624,7 +1624,7 @@ li > p:last-of-type {
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate format for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate variant for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
@@ -1632,7 +1632,7 @@ li > p:last-of-type {
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate format for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
+        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate variant for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.11">Max UUID</dt>
@@ -2474,16 +2474,19 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <span class="break"></span><dl class="dlNewline" id="section-8.2-7">
           <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
           <dd style="margin-left: 1.5em" id="section-8.2-7.2">
- Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+ Implementations utilizing fixed-length counter method SHOULD randomly initialize the counter with each new timestamp tick. 
+ However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. 
+ When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. 
+ Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
           <dd style="margin-left: 1.5em" id="section-8.2-7.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -9,14 +9,7 @@
 <meta content="Kyzer R. Davis" name="author">
 <meta content="
        
- This document presents three new Universally Unique Identifier (UUID) formats.
-       
-       
- A common case for modern applications is to create a unique identifier for use as a database key.
- This identifier usually implements an embedded timestamp that is sortable using the monotonic creation time in the most significant bits. 
- In addition the identifier is highly collision resistant, difficult to guess, and provides minimal security attack surfaces.
- None of the existing UUID versions, including UUIDv1, fulfill each of these requirements in the most efficient possible way.
- This document is a proposal to update   with three new UUID versions that address these concerns, each with different trade-offs.
+ This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
        
     " name="description">
 <meta content="xml2rfc 3.12.2" name="generator">
@@ -40,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/h0xIfLwVNj.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/Zff8bBwAJZ.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1199,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 5 September 2022</td>
+<td class="center">Expires 10 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1215,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-04" class="published">4 March 2022</time>
+<time datetime="2022-03-09" class="published">9 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-05">5 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-10">10 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1236,13 +1229,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
- This document presents three new Universally Unique Identifier (UUID) formats.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">
- A common case for modern applications is to create a unique identifier for use as a database key.
- This identifier usually implements an embedded timestamp that is sortable using the monotonic creation time in the most significant bits. 
- In addition the identifier is highly collision resistant, difficult to guess, and provides minimal security attack surfaces.
- None of the existing UUID versions, including UUIDv1, fulfill each of these requirements in the most efficient possible way.
- This document is a proposal to update <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> with three new UUID versions that address these concerns, each with different trade-offs.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+ This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1263,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 5 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 10 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1315,110 +1302,141 @@ li > p:last-of-type {
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-variant-and-version-fields" class="xref">Variant and Version Fields</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-uuid-version-6" class="xref">UUID Version 6</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3">
-                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4">
-                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5">
-                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-variant-and-version-fields" class="xref">Variant and Version Fields</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-new-formats" class="xref">New Formats</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
-                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-uuid-version-6" class="xref">UUID Version 6</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
-                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-uuid-version-7" class="xref">UUID Version 7</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
-                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
-                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5">
-                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="xref">5.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6">
-                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="xref">5.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.7">
-                <p id="section-toc.1-1.5.2.7.1"><a href="#section-5.7" class="xref">5.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.8">
-                <p id="section-toc.1-1.5.2.8.1"><a href="#section-5.8" class="xref">5.8</a>.  <a href="#name-storing-uuids-opacity" class="xref">Storing UUIDs, Opacity</a></p>
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-uuid-version-8" class="xref">UUID Version 8</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-alternate-variants" class="xref">Alternate Variants</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-alternate-formats" class="xref">Alternate Formats</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.3">
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.4">
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.5">
+                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.6">
+                <p id="section-toc.1-1.8.2.6.1"><a href="#section-8.6" class="xref">8.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.7">
+                <p id="section-toc.1-1.8.2.7.1"><a href="#section-8.7" class="xref">8.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.8">
+                <p id="section-toc.1-1.8.2.8.1"><a href="#section-8.8" class="xref">8.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.9">
+                <p id="section-toc.1-1.8.2.9.1"><a href="#section-8.9" class="xref">8.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-normative-references" class="xref">Normative References</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
-                <p id="section-toc.1-1.11.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
-                <p id="section-toc.1-1.11.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.3">
-                <p id="section-toc.1-1.11.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
-                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#section-13" class="xref">13</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
-                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
+                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
+                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
+            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.1">
+                <p id="section-toc.1-1.15.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.2">
+                <p id="section-toc.1-1.15.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.3">
+                <p id="section-toc.1-1.15.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.4">
+                <p id="section-toc.1-1.15.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.5">
+                <p id="section-toc.1-1.15.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
+            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.1">
+                <p id="section-toc.1-1.16.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.2">
+                <p id="section-toc.1-1.16.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
+            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1434,7 +1452,7 @@ li > p:last-of-type {
  Modern applications have a need to create and utilize UUIDs as the primary
  identifier for a variety of different items in complex computational systems,
  including but not limited to database keys, file names, machine
- or system names, identifiers for transactions or other objects or processes.<a href="#section-1-1" class="pilcrow">¶</a></p>
+ or system names, identifiers for event-driven transactions, and other objects or processes.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">
  A specific use case for UUIDs which has gained popularity is as database keys.
  The motivation for this stems primarily from the fact that applications
@@ -1463,17 +1481,25 @@ li > p:last-of-type {
 </li>
         <li id="section-1-4.4">
           <p id="section-1-4.4.1">
- Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
- Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
- information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
+ The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.5">
           <p id="section-1-4.5.1">
- Many implementation details are specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but some of the decisions made involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
+ The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.6">
           <p id="section-1-4.6.1">
- The previous specification also does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are different.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
+ Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
+ Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
+ information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-1-4.7">
+          <p id="section-1-4.7.1">
+ Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.7.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-1-4.8">
+          <p id="section-1-4.8.1">
+ <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.8.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-1-5">
@@ -1572,6 +1598,10 @@ li > p:last-of-type {
 <dt id="section-2.2-2.7">MSB</dt>
           <dd style="margin-left: 7.0em" id="section-2.2-2.8">Most Significant Bit<a href="#section-2.2-2.8" class="pilcrow">¶</a>
 </dd>
+          <dd class="break"></dd>
+<dt id="section-2.2-2.9">DBMS</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.10">Database Management System<a href="#section-2.2-2.10" class="pilcrow">¶</a>
+</dd>
         <dd class="break"></dd>
 </dl>
 </section>
@@ -1584,20 +1614,36 @@ li > p:last-of-type {
       </h2>
 <p id="section-3-1">
  The following UUIDs are hereby introduced:<a href="#section-3-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-3-2">
- <li id="section-3-2.1">
-          <p id="section-3-2.1.1">UUID version 6: A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <a href="#uuidv6" class="xref">Section 4.2</a><a href="#section-3-2.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.2">
-          <p id="section-3-2.2.1">UUID version 7E: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#uuidv7" class="xref">Section 4.3</a><a href="#section-3-2.2.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.3">
-          <p id="section-3-2.3.1">UUID version 8E: A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#uuidv8" class="xref">Section 4.4</a><a href="#section-3-2.3.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.4">
-          <p id="section-3-2.4.1">Max UUID: A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 4.5</a><a href="#section-3-2.4.1" class="pilcrow">¶</a></p>
-</li>
-      </ol>
+<span class="break"></span><dl class="dlNewline" id="section-3-2">
+        <dt id="section-3-2.1">UUID version 6 (UUIDv6)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.2">A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <a href="#uuidv6" class="xref">Section 5.1</a><a href="#section-3-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.3">UUID version 7 (UUIDv7)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.4">An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#v7" class="xref">Section 5.2</a><a href="#section-3-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate format for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.8">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate format for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.11">Max UUID</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.12">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 7.1</a><a href="#section-3-2.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.13">UUID Long</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.14">An extension of the base UUID with variable length beyond 128 bits. See <a href="#uuid_long" class="xref">Section 7.2</a><a href="#section-3-2.14" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
 <div id="changelog">
 <section id="section-3.1">
         <h3 id="name-changelog">
@@ -1613,49 +1659,58 @@ li > p:last-of-type {
             <p id="section-3.1-3.2.1">- UUIDv6 section reworked to just the reorder of the timestamp<a href="#section-3.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.3">
-            <p id="section-3.1-3.3.1">- UUIDv7E changed to simplify timestamp mechanism to just millisecond unix timestamp<a href="#section-3.1-3.3.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.3.1">- UUIDv7 changed to simplify timestamp mechanism to just millisecond Unix timestamp<a href="#section-3.1-3.3.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.4">
-            <p id="section-3.1-3.4.1">- UUIDv8E relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.4.1">- UUIDv8 relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.5">
             <p id="section-3.1-3.5.1">- Changed UUIDv7E and UUIDv8E to use Variant 111.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.6">
-            <p id="section-3.1-3.6.1">- Added C code samples in Appendix.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.6.1">- Introduced Max UUID.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.7">
-            <p id="section-3.1-3.7.1">- Added test vectors in Appendix.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.7.1">- Re-introduced variable length UUIDs as UUID Long.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.8">
-            <p id="section-3.1-3.8.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.8.1">- Re-introduced alternate encoding techniques for all UUIDs.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.9">
-            <p id="section-3.1-3.9.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.9.1">- Added C code samples in Appendix.<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.10">
-            <p id="section-3.1-3.10.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.10.1">- Added test vectors in Appendix.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.11">
-            <p id="section-3.1-3.11.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.11.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.12">
-            <p id="section-3.1-3.12.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.12.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.13">
-            <p id="section-3.1-3.13.1">- Node verbiage only used in UUIDv6 and v7E and v8E reference random instead<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.13.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.14">
-            <p id="section-3.1-3.14.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.14.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.15">
-            <p id="section-3.1-3.15.1">- Added Abbreviations section<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.15.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.16">
-            <p id="section-3.1-3.16.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.16.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.17">
-            <p id="section-3.1-3.17.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.17.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.18">
+            <p id="section-3.1-3.18.1">- Added Abbreviations section<a href="#section-3.1-3.18.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.19">
+            <p id="section-3.1-3.19.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.19.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.20">
+            <p id="section-3.1-3.20.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.20.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="section-3.1-4">draft-02<a href="#section-3.1-4" class="pilcrow">¶</a></p>
@@ -1682,10 +1737,10 @@ li > p:last-of-type {
             <p id="section-3.1-5.7.1">- Changed "proceeding" verbiage to "after" in section 7<a href="#section-3.1-5.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.8">
-            <p id="section-3.1-5.8.1">- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-5.8.1">- Added details on how to pad 32 bit Unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.9">
-            <p id="section-3.1-5.9.1">- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-5.9.1">- Added details on how to truncate 64 bit Unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.10">
             <p id="section-3.1-5.10.1">- Added forward reference and bullet to UUIDv8 if truncating 64 bit Unix Epoch is not an option.<a href="#section-3.1-5.10.1" class="pilcrow">¶</a></p>
@@ -1716,114 +1771,123 @@ li > p:last-of-type {
 </div>
 </section>
 </div>
-<div id="format">
+<div id="variant_and_version_fields">
 <section id="section-4">
-      <h2 id="name-format">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-format" class="section-name selfRef">Format</a>
+      <h2 id="name-variant-and-version-fields">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-variant-and-version-fields" class="section-name selfRef">Variant and Version Fields</a>
       </h2>
 <p id="section-4-1">
- The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<div id="variant_and_version_fields">
-<section id="section-4.1">
-        <h3 id="name-variant-and-version-fields">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-variant-and-version-fields" class="section-name selfRef">Variant and Version Fields</a>
-        </h3>
-<p id="section-4.1-1">
  The variant bits utilized by UUIDs in this specification 
- remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.1-2">
+ remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">
  This specification makes use of the unused variant bits of 111 defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.
  This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
  All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
- The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+ The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4-2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-4.1-3.1">
-            <p id="section-4.1-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4.1-3.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-4-3.1">
+          <p id="section-4-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4-3.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-4.1-3.2">
-            <p id="section-4.1-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4.1-3.2.1" class="pilcrow">¶</a></p>
+        <li class="compact" id="section-4-3.2">
+          <p id="section-4-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4-3.2.1" class="pilcrow">¶</a></p>
 </li>
-        </ul>
-<p id="section-4.1-4">
- The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
+      </ul>
+<p id="section-4-4">
+ The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4-4" class="pilcrow">¶</a></p>
 <span id="name-uuid-variant-defined-by-thi"></span><table class="center" id="table-1">
-          <caption>
+        <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
 <a href="#name-uuid-variant-defined-by-thi" class="selfRef">UUID Variant defined by this specification</a>
-          </caption>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Hex</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">x</td>
-              <td class="text-left" rowspan="1" colspan="1">x</td>
-              <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
-              <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">E</td>
-              <td class="text-left" rowspan="1" colspan="1">The variant specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">F</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-6">
- UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4.1-6" class="pilcrow">¶</a></p>
-<p id="section-4.1-7">
- The next table details Variant 10xx and the new versions defined by this specification. 
- A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4.1-7" class="pilcrow">¶</a></p>
-<span id="name-new-uuid-variant-10xx-versi"></span><table class="center" id="table-2">
-          <caption>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Hex</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">x</td>
+            <td class="text-left" rowspan="1" colspan="1">x</td>
+            <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
+            <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">E</td>
+            <td class="text-left" rowspan="1" colspan="1">The new variant specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">F</td>
+            <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-6">
+ UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4-6" class="pilcrow">¶</a></p>
+<p id="section-4-7">
+ The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
+ A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-7" class="pilcrow">¶</a></p>
+<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
+        <caption>
 <a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-new-uuid-variant-10xx-versi" class="selfRef">New UUID variant 10xx versions defined by this specification</a>
-          </caption>
+<a href="#name-new-uuid-variant-10xx-8-9-a" class="selfRef">New UUID variant 10xx (8/9/A/B) versions defined by this specification</a>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">6</td>
-              <td class="text-left" rowspan="1" colspan="1">Reordered Gregorian time-based UUID specified in this document.</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-9">
- For UUIDv6 the version and variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged and a new version (0110b [6]) has been added.
- An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4.1-9" class="pilcrow">¶</a></p>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Version</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">6</td>
+            <td class="text-left" rowspan="1" colspan="1">Reordered Gregorian time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">7</td>
+            <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">8</td>
+            <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-9">
+ For UUID version 6, 7 and 8 the variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged.
+ An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-9" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-variant-examples"></span><figure id="figure-1">
-          <div class="alignLeft art-text artwork" id="section-4.1-10.1">
+        <div class="alignLeft art-text artwork" id="section-4-10.1">
 <pre>
 00000000-0000-6000-8000-000000000000
 00000000-0000-6000-9000-000000000000
@@ -1834,50 +1898,50 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 </div>
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
 <a href="#name-uuidv6-variant-examples" class="selfRef">UUIDv6 Variant Examples</a>
-          </figcaption></figure>
-<p id="section-4.1-11">
- The next table details Variant 110 and the new versions defined by this specification.
- A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4.1-11" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-1110-versions-"></span><table class="center" id="table-3">
-          <caption>
+        </figcaption></figure>
+<p id="section-4-11">
+ The next table details Variant 1110 (E) and the new versions defined by this specification.
+ A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4-11" class="pilcrow">¶</a></p>
+<span id="name-uuid-variant-1110-e-version"></span><table class="center" id="table-3">
+        <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:
-<a href="#name-uuid-variant-1110-versions-" class="selfRef">UUID variant 1110 versions defined by this specification</a>
-          </caption>
+<a href="#name-uuid-variant-1110-e-version" class="selfRef">UUID variant 1110 (E) versions defined by this specification</a>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-13">
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Version</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">7E</td>
+            <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">8E</td>
+            <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-13">
                     For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
  Since the bits of the variant remain in the same place as described in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
- An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4.1-13" class="pilcrow">¶</a></p>
+ An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4-13" class="pilcrow">¶</a></p>
 <span id="name-uuid-version-7e-and-8e-vari"></span><figure id="figure-2">
-          <div class="alignLeft art-text artwork" id="section-4.1-14.1">
+        <div class="alignLeft art-text artwork" id="section-4-14.1">
 <pre>
 00000000-0000-0000-E700-000000000000
 xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
@@ -1888,31 +1952,38 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </div>
 <figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
 <a href="#name-uuid-version-7e-and-8e-vari" class="selfRef">UUID version 7E and 8E Variant Examples</a>
-          </figcaption></figure>
+        </figcaption></figure>
 </section>
 </div>
+<div id="format">
+<section id="section-5">
+      <h2 id="name-new-formats">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-new-formats" class="section-name selfRef">New Formats</a>
+      </h2>
+<p id="section-5-1">
+ The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <div id="uuidv6">
-<section id="section-4.2">
+<section id="section-5.1">
         <h3 id="name-uuid-version-6">
-<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-uuid-version-6" class="section-name selfRef">UUID Version 6</a>
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-uuid-version-6" class="section-name selfRef">UUID Version 6</a>
         </h3>
-<p id="section-4.2-1">
+<p id="section-5.1-1">
  UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
  It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
- Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7E instead.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.2-2">
+ Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">
  Instead of splitting the timestamp into the low, mid and high sections from UUIDv1, UUIDv6 changes this sequence so timestamp bytes are stored from most to least significant.  
  That is, given a 60 bit timestamp value as specified for UUIDv1 in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>,
  for UUIDv6, the first 48 most significant bits are stored
- first, followed by the 4 bit version (same position), followed by the remaining 12 bits of the original 60 bit timestamp.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
-<p id="section-4.2-3">
- The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
-<p id="section-4.2-4">
- The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 7</a><a href="#section-4.2-4" class="pilcrow">¶</a></p>
-<p id="section-4.2-5">
- The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-4.2-5" class="pilcrow">¶</a></p>
+ first, followed by the 4 bit version (same position), followed by the remaining 12 bits of the original 60 bit timestamp.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3">
+ The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.1-4">
+ The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 10</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
+<p id="section-5.1-5">
+ The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-5.1-5" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-3">
-          <div class="alignLeft art-text artwork" id="section-4.2-6.1">
+          <div class="alignLeft art-text artwork" id="section-5.1-6.1">
 <pre>
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1930,47 +2001,47 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
 <a href="#name-uuidv6-field-and-bit-layout" class="selfRef">UUIDv6 Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.2-7">
-          <dt id="section-4.2-7.1">time_high:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.2">The most significant 32 bits of the 60 bit starting timestamp.
-            Occupies bits 0 through 31 (octets 0-3)<a href="#section-4.2-7.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-5.1-7">
+          <dt id="section-5.1-7.1">time_high:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.2">The most significant 32 bits of the 60 bit starting timestamp.
+            Occupies bits 0 through 31 (octets 0-3)<a href="#section-5.1-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.3">time_mid:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.4">The middle 16 bits of the 60 bit starting timestamp.
-            Occupies bits 32 through 47 (octets 4-5)<a href="#section-4.2-7.4" class="pilcrow">¶</a>
+<dt id="section-5.1-7.3">time_mid:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.4">The middle 16 bits of the 60 bit starting timestamp.
+            Occupies bits 32 through 47 (octets 4-5)<a href="#section-5.1-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.5">time_low_and_version:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.6">The first four most significant bits MUST contain
+<dt id="section-5.1-7.5">time_low_and_version:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.6">The first four most significant bits MUST contain
             the UUIDv6 version (0110) while the remaining 12 bits will contain
             the least significant 12 bits from the 60 bit starting timestamp.
-            Occupies bits 48 through 63 (octets 6-7)<a href="#section-4.2-7.6" class="pilcrow">¶</a>
+            Occupies bits 48 through 63 (octets 6-7)<a href="#section-5.1-7.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.7">clk_seq_hi_res:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.8">The first two bits MUST be set to the UUID variant (10)
+<dt id="section-5.1-7.7">clk_seq_hi_res:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.8">The first two bits MUST be set to the UUID variant (10)
             The remaining 6 bits contain the high portion of the clock sequence.
-            Occupies bits 64 through 71 (octet 8)<a href="#section-4.2-7.8" class="pilcrow">¶</a>
+            Occupies bits 64 through 71 (octet 8)<a href="#section-5.1-7.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.9">clock_seq_low:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.10">The 8 bit low portion of the clock sequence.
-            Occupies bits 72 through 79 (octet 9)<a href="#section-4.2-7.10" class="pilcrow">¶</a>
+<dt id="section-5.1-7.9">clock_seq_low:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.10">The 8 bit low portion of the clock sequence.
+            Occupies bits 72 through 79 (octet 9)<a href="#section-5.1-7.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.11">node:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.12">48 bit spatially unique identifier
-            Occupies bits 80 through 127 (octets 10-15)<a href="#section-4.2-7.12" class="pilcrow">¶</a>
+<dt id="section-5.1-7.11">node:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.12">48 bit spatially unique identifier
+            Occupies bits 80 through 127 (octets 10-15)<a href="#section-5.1-7.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-4.2-8">
+<p id="section-5.1-8">
  With UUIDv6 the steps for splitting the timestamp into time_high and time_mid are OPTIONAL
  since the 48 bits of time_high and time_mid will remain in the same order.
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
  32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
- In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.2-8" class="pilcrow">¶</a></p>
+ In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
 <span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-4">
           <caption>
 <a href="#table-4" class="selfRef">Table 4</a>:
@@ -2003,16 +2074,147 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
         </table>
 </section>
 </div>
-<div id="uuidv7">
-<section id="section-4.3">
-        <h3 id="name-uuid-version-7e">
-<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
+<div id="v7">
+<section id="section-5.2">
+        <h3 id="name-uuid-version-7">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-uuid-version-7" class="section-name selfRef">UUID Version 7</a>
         </h3>
-<p id="section-4.3-1">
- UUID version 7E features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.
- Implementations SHOULD utilize UUID version 7E over UUID version 1 and 6 if possible.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-4">
-          <div class="alignLeft art-text artwork" id="section-4.3-2.1">
+<p id="section-5.2-1">
+ UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">
+ Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-4">
+          <div class="alignLeft art-text artwork" id="section-5.2-3.1">
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           unix_ts_ms                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          unix_ts_ms           |  ver  |       rand_a          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                        rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-uuidv7-field-and-bit-layout" class="selfRef">UUIDv7 Field and Bit Layout</a>
+          </figcaption></figure>
+<span class="break"></span><dl class="dlNewline" id="section-5.2-4">
+          <dt id="section-5.2-4.1">unix_ts_ms:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.3">ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.4">4 bit UUIDv7 version set as per <a href="#variant_and_version_fields" class="xref">Section 4</a><a href="#section-5.2-4.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.5">rand_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.7">var:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.8">The 2 bit variant defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-5.2-4.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.9">rand_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+<div id="v8">
+<section id="section-5.3">
+        <h3 id="name-uuid-version-8">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-uuid-version-8" class="section-name selfRef">UUID Version 8</a>
+        </h3>
+<p id="section-5.3-1">
+ UUID version 8 provides an RFC-compatible format for experimental or vendor-specific use cases.
+ The only requirement is that the variant and version bits MUST be set as defined in <a href="#variant_and_version_fields" class="xref">Section 4</a>. 
+ UUIDv8's uniqueness will be implementation-specific and SHOULD NOT be assumed.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3-2">
+ The only explicitly defined bits are the Version and Variant leaving 120 bits
+ for implementation specific time-based UUIDs. To be clear:
+ UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
+ filled with random data.<a href="#section-5.3-2" class="pilcrow">¶</a></p>
+<p id="section-5.3-3">
+ Some example situations in which UUIDv8 usage could occur:<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5.3-4.1">
+            <p id="section-5.3-4.1.1">An implementation would like to embed extra information
+   within the UUID other than what is defined in this document.<a href="#section-5.3-4.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-5.3-4.2">
+            <p id="section-5.3-4.2.1">An implementation has other application/language restrictions which
+   inhibit the use of one of the current UUIDs.<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-5">
+          <div class="alignLeft art-text artwork" id="section-5.3-5.1">
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_a                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          custom_a             |  ver  |       custom_b        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                       custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<a href="#name-uuidv8-field-and-bit-layout" class="selfRef">UUIDv8 Field and Bit Layout</a>
+          </figcaption></figure>
+<span class="break"></span><dl class="dlNewline" id="section-5.3-6">
+          <dt id="section-5.3-6.1">custom_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.2">The first 48 bits of the layout that can be filled as an implementation sees fit.<a href="#section-5.3-6.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.3">ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.4">The 4 bit version field as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a><a href="#section-5.3-6.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.5">custom_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.6">12 more bits of the layout that can be filled as an implementation sees fit.<a href="#section-5.3-6.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.7">var:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.8">The 2 bit variant field as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-5.3-6.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.9">custom_c:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+</div>
+<div id="alternate_uuid_variants">
+<section id="section-6">
+      <h2 id="name-alternate-variants">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-alternate-variants" class="section-name selfRef">Alternate Variants</a>
+      </h2>
+<p id="section-6-1">
+ This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<div id="uuidv7">
+<section id="section-6.1">
+        <h3 id="name-uuid-version-7e">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
+        </h3>
+<p id="section-6.1-1">
+ UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">
+ With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-6">
+          <div class="alignLeft art-text artwork" id="section-6.1-3.1">
 <pre>
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -2027,59 +2229,40 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-uuidv7e-field-and-bit-layou" class="selfRef">UUIDv7E Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.3-3">
-          <dt id="section-4.3-3.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.2">48 bit big-endian unsigned number of unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 5.1</a>.<a href="#section-4.3-3.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-6.1-4">
+          <dt id="section-6.1-4.1">unix_ts_ms:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-6.1-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.3">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 5.2</a> and <a href="#unguessability" class="xref">Section 5.6</a>.<a href="#section-4.3-3.4" class="pilcrow">¶</a>
+<dt id="section-6.1-4.3">rand_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.5">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4.1</a>.<a href="#section-4.3-3.6" class="pilcrow">¶</a>
+<dt id="section-6.1-4.5">var_ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.1-4.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.7">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 5.2</a> and <a href="#unguessability" class="xref">Section 5.6</a>.<a href="#section-4.3-3.8" class="pilcrow">¶</a>
+<dt id="section-6.1-4.7">rand_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="uuidv8">
-<section id="section-4.4">
+<section id="section-6.2">
         <h3 id="name-uuid-version-8e">
-<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
         </h3>
-<p id="section-4.4-1">
- UUID version 8E provides an RFC-compatible format for experimental or vendor-specific use cases.
- The only requirement is that the variant and version bits MUST be set as defined in <a href="#variant_and_version_fields" class="xref">Section 4.1</a>. 
- UUIDv8E's uniqueness will be implementation-specific and SHOULD NOT be assumed.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
-<p id="section-4.4-2">
- UUIDv8E SHOULD only be utilized if an implementation cannot utilize another UUID in this document or <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-4.4-2" class="pilcrow">¶</a></p>
-<p id="section-4.4-3">
- The only explicitly defined bits are the Version and Variant leaving 120 bits
- for implementation specific time-based UUIDs. To be clear:
- UUIDv8E is not a replacement for UUIDv4 where all 122 extra bits are
- filled with random data.<a href="#section-4.4-3" class="pilcrow">¶</a></p>
-<p id="section-4.4-4">
- Some example situations in which UUIDv8E usage could occur:<a href="#section-4.4-4" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-4.4-5.1">
-            <p id="section-4.4-5.1.1">An implementation would like to embed extra information
-   within the UUID other than what is defined in this document.<a href="#section-4.4-5.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-4.4-5.2">
-            <p id="section-4.4-5.2.1">An implementation has other application/language restrictions which
-   inhibit the use of one of the current UUIDs.<a href="#section-4.4-5.2.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
-<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-5">
-          <div class="alignLeft art-text artwork" id="section-4.4-6.1">
+<p id="section-6.2-1">
+ UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">
+ With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-7">
+          <div class="alignLeft art-text artwork" id="section-6.2-3.1">
 <pre>
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -2094,311 +2277,397 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
 <a href="#name-uuidv8e-field-and-bit-layou" class="selfRef">UUIDv8E Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.4-7">
-          <dt id="section-4.4-7.1">custom_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-4.4-7.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-4">
+          <dt id="section-6.2-4.1">custom_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-6.2-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.4-7.3">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4.1</a>.<a href="#section-4.4-7.4" class="pilcrow">¶</a>
+<dt id="section-6.2-4.3">var_ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.2-4.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.4-7.5">custom_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-4.4-7.6" class="pilcrow">¶</a>
+<dt id="section-6.2-4.5">custom_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-6.2-4.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
+</section>
+</div>
+<div id="alternate_uuid_formats">
+<section id="section-7">
+      <h2 id="name-alternate-formats">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-alternate-formats" class="section-name selfRef">Alternate Formats</a>
+      </h2>
+<p id="section-7-1">
+ This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-7-1" class="pilcrow">¶</a></p>
 <div id="maxuuid">
-<section id="section-4.5">
+<section id="section-7.1">
         <h3 id="name-max-uuid">
-<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
         </h3>
-<p id="section-4.5-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1.<a href="#section-4.5-1" class="pilcrow">¶</a></p>
-<span id="name-max-uuid-format"></span><figure id="figure-6">
-          <div class="alignLeft art-text artwork" id="section-4.5-2.1">
+<p id="section-7.1-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<span id="name-max-uuid-format"></span><figure id="figure-8">
+          <div class="alignLeft art-text artwork" id="section-7.1-2.1">
 <pre>
 FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </pre>
 </div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
 <a href="#name-max-uuid-format" class="selfRef">Max UUID Format</a>
           </figcaption></figure>
+</section>
+</div>
+<div id="uuid_long">
+<section id="section-7.2">
+        <h3 id="name-uuid-long">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
+        </h3>
+<p id="section-7.2-1">
+ UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-7.2-2">
+          <dt id="section-7.2-2.1">Increased Entropy:</dt>
+          <dd style="margin-left: 1.5em" id="section-7.2-2.2">While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<a href="#collision_resistance" class="xref">Section 8.4</a>) or guessability (<a href="#unguessability" class="xref">Section 8.6</a>).<a href="#section-7.2-2.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-7.2-2.3">Requirements for additional embedded items:</dt>
+          <dd style="margin-left: 1.5em" id="section-7.2-2.4">Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-7.2-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-7.2-3">
+ UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
+<span id="name-uuid-long-examples"></span><figure id="figure-9">
+          <div class="alignLeft art-text artwork" id="section-7.2-4.1">
+<pre>
+UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
+   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
+  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
+</pre>
+</div>
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
+          </figcaption></figure>
+<p id="section-7.2-5">
+ Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-7.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.2-6">
+ When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="uuid_encoding">
+<section id="section-7.3">
+        <h3 id="name-alternate-encodings">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
+        </h3>
+<p id="section-7.3-1">
+ The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.3-2">
+ Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.<a href="#section-7.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.3-3">
+ When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.<a href="#section-7.3-3" class="pilcrow">¶</a></p>
+<p id="section-7.3-4">
+ The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
+<span id="name-alternate-encoding-examples"></span><figure id="figure-10">
+          <div class="alignLeft art-text artwork" id="section-7.3-5.1">
+<pre>
+UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+UUIDv4 Int: 154072644812979270675542139334331768221
+UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
+UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
+UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
+</pre>
+</div>
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
+          </figcaption></figure>
+<p id="section-7.3-6">
+ For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="uuid_best_practices">
-<section id="section-5">
+<section id="section-8">
       <h2 id="name-uuid-best-practices">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
       </h2>
-<p id="section-5-1">
+<p id="section-8-1">
  The minimum requirements for generating UUIDs are 
  described in this document for each version.
  Everything else is an implementation detail and 
  up to the implementer to decide what is appropriate for a given 
  implementation. That being said, various relevant factors are covered
- below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-5-1" class="pilcrow">¶</a></p>
+ below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <div id="timestamp_granularity">
-<section id="section-5.1">
+<section id="section-8.1">
         <h3 id="name-timestamp-granularity">
-<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
         </h3>
-<p id="section-5.1-1">
- UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.1-2">
-          <dt id="section-5.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-5.1-2.2" class="pilcrow">¶</a>
+<p id="section-8.1-1">
+ UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.1-2">
+          <dt id="section-8.1-2.1">Reliability:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-8.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.3">Source:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8E SHOULD be leveraged.<a href="#section-5.1-2.4" class="pilcrow">¶</a>
+<dt id="section-8.1-2.3">Source:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.<a href="#section-8.1-2.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8E SHOULD be utilized.<a href="#section-5.1-2.6" class="pilcrow">¶</a>
+<dt id="section-8.1-2.5">Sub-second Precision and Accuracy:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.<a href="#section-8.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.7">Length:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7E features a 48 bit timestamp.<a href="#section-5.1-2.8" class="pilcrow">¶</a>
+<dt id="section-8.1-2.7">Length:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.<a href="#section-8.1-2.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.9">Fuzzing:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-5.1-2.10" class="pilcrow">¶</a>
+<dt id="section-8.1-2.9">Fuzzing:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-8.1-2.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.11">Padding:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7E.<a href="#section-5.1-2.12" class="pilcrow">¶</a>
+<dt id="section-8.1-2.11">Padding:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.<a href="#section-8.1-2.12" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.13">Truncating:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-5.1-2.14" class="pilcrow">¶</a>
+<dt id="section-8.1-2.13">Truncating:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-8.1-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="monotonicity_counters">
-<section id="section-5.2">
+<section id="section-8.2">
         <h3 id="name-monotonicity-and-counters">
-<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
         </h3>
-<p id="section-5.2-1">
- Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.2-2">
+<p id="section-8.2-1">
+ Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation of order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
-<p id="section-5.2-3">
- For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a><a href="#section-5.2-3" class="pilcrow">¶</a></p>
-<p id="section-5.2-4">
- Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-5.2-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.2-5">
-          <dt id="section-5.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.2">
+ For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+<p id="section-8.2-3">
+ For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a><a href="#section-8.2-3" class="pilcrow">¶</a></p>
+<p id="section-8.2-4">
+ Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-8.2-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.2-5">
+          <dt id="section-8.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-5.2">
  This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
- Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits..<a href="#section-5.2-5.2" class="pilcrow">¶</a>
+ Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.<a href="#section-8.2-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.2-5.3">Fixed-Length Dedicated Counter Bits (Method 2):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.4">
- An alternative approach to the previous method is to dedicate a number of bits in the least significant position of the UUID. With this alternative method, the random data MUST be frozen for a given timestamp tick else sorting will be impacted. UUIDs utilizing this method SHOULD be created using UUIDv8E.<a href="#section-5.2-5.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.5">Fixed-Length Dedicated Counter Seeding:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.6">
- Implementations utilizing either fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. A randomly seeded counter alongside Method 2 is more-or-less the same as Monotonic Random (Method 3). Implementations utilizing either fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-5.2-5.6" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.7">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.8">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-5.2-5.8" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.9">Fixed-Length Dedicated Counter Rollover Handling</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.10">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-5.2-5.10" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.11">Monotonic Random (Method 3):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.12">
- With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits (Position B) method described in the previous bullets but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by both fixed-length counter bit positions. As such, UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-5.2-5.12" class="pilcrow">¶</a>
+<dt id="section-8.2-5.3">Monotonic Random (Method 2):</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-5.4">
+ With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-8.2-5.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-5.2-6">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-5.2-6" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-5.2-7">
- <li id="section-5.2-7.1">
-            <p id="section-5.2-7.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-5.2-7.1.1" class="pilcrow">¶</a></p>
+<p id="section-8.2-6">
+ The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-8.2-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.2-7">
+          <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.2">
+ Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.6">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-8.2-8">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-8.2-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-8.2-9">
+ <li id="section-8.2-9.1">
+            <p id="section-8.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-8.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-5.2-7.2">
-            <p id="section-5.2-7.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-5.2-7.2.1" class="pilcrow">¶</a></p>
+          <li id="section-8.2-9.2">
+            <p id="section-8.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-8.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-5.2-7.3">
-            <p id="section-5.2-7.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-5.2-7.3.1" class="pilcrow">¶</a></p>
+          <li id="section-8.2-9.3">
+            <p id="section-8.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-8.2-9.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-5.2-8">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-5.2-8" class="pilcrow">¶</a></p>
-<p id="section-5.2-9">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.2-9" class="pilcrow">¶</a></p>
+<p id="section-8.2-10">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-8.2-10" class="pilcrow">¶</a></p>
+<p id="section-8.2-11">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-8.2-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
-<section id="section-5.3">
+<section id="section-8.3">
         <h3 id="name-distributed-uuid-generation">
-<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
         </h3>
-<p id="section-5.3-1">
+<p id="section-8.3-1">
  Some implementations MAY desire to utilize multi-node, clustered, applications which involve two or more 
  applications independently generating UUIDs that will be stored in a common location. 
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
- This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.3-2">
-          <dt id="section-5.3-2.1">Shared Knowledge System:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-5.3-2.2" class="pilcrow">¶</a>
+ This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.3-2">
+          <dt id="section-8.3-2.1">Shared Knowledge System:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-8.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.3-2.3">Node IDs:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 7</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-5.3-2.4" class="pilcrow">¶</a>
+<dt id="section-8.3-2.3">Node IDs:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 10</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-8.3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-5.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<p id="section-8.3-3">
+ Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-8.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
-<section id="section-5.4">
+<section id="section-8.4">
         <h3 id="name-collision-resistance">
-<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
-<p id="section-5.4-1">
- Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 5.1</a> and <a href="#monotonicity_counters" class="xref">Section 5.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a>.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
-<p id="section-5.4-2">
- There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-5.4-2" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.4-3">
-          <dt id="section-5.4-3.1">Low Impact</dt>
-          <dd style="margin-left: 1.5em" id="section-5.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-5.4-3.2" class="pilcrow">¶</a>
+<p id="section-8.4-1">
+ Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 8.1</a> and <a href="#monotonicity_counters" class="xref">Section 8.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
+<p id="section-8.4-2">
+ There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.4-3">
+          <dt id="section-8.4-3.1">Low Impact</dt>
+          <dd style="margin-left: 1.5em" id="section-8.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-8.4-3.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.4-3.3">High Impact:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-5.4-3.4" class="pilcrow">¶</a>
+<dt id="section-8.4-3.3">High Impact:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-8.4-3.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="global_local_uniqueness">
-<section id="section-5.5">
+<section id="section-8.5">
         <h3 id="name-global-and-local-uniqueness">
-<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
+<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
         </h3>
-<p id="section-5.5-1">
+<p id="section-8.5-1">
  UUIDs created by this specification MAY be used to provide local uniqueness guarantees. 
- For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
-<p id="section-5.5-2">
+ For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
+<p id="section-8.5-2">
  Although true global uniqueness is impossible to guarantee without shared knowledge scheme; a shared knowledge scheme is not required by UUID to provide uniqueness guarantees.
- Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-5.5-2" class="pilcrow">¶</a></p>
+ Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="unguessability">
-<section id="section-5.6">
+<section id="section-8.6">
         <h3 id="name-unguessability">
-<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
+<a href="#section-8.6" class="section-number selfRef">8.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
         </h3>
-<p id="section-5.6-1">
+<p id="section-8.6-1">
  Implementations SHOULD utilize a cryptographically secure pseudo-random number generator (CSPRNG) to provide values that are both difficult to predict ("unguessable") and have a low likelihood of collision ("unique").
- CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 5.4</a> and <a href="#Security" class="xref">Section 7</a> are present in modern UUIDs.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
-<p id="section-5.6-2">
- Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-5.6-2" class="pilcrow">¶</a></p>
+ CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 8.4</a> and <a href="#Security" class="xref">Section 10</a> are present in modern UUIDs.<a href="#section-8.6-1" class="pilcrow">¶</a></p>
+<p id="section-8.6-2">
+ Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-8.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sorting">
-<section id="section-5.7">
+<section id="section-8.7">
         <h3 id="name-sorting">
-<a href="#section-5.7" class="section-number selfRef">5.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
+<a href="#section-8.7" class="section-number selfRef">8.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
         </h3>
-<p id="section-5.7-1">
- UUIDv6 and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-5.7-1" class="pilcrow">¶</a></p>
-<p id="section-5.7-2">
+<p id="section-8.7-1">
+ UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-8.7-1" class="pilcrow">¶</a></p>
+<p id="section-8.7-2">
  Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
  As a result objects can much more easily be clustered together for better performance.  
- The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-5.7-2" class="pilcrow">¶</a></p>
-<p id="section-5.7-3">
- UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-5.7-3" class="pilcrow">¶</a></p>
-<p id="section-5.7-4">
- UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-5.7-4" class="pilcrow">¶</a></p>
+ The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-8.7-2" class="pilcrow">¶</a></p>
+<p id="section-8.7-3">
+ UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-8.7-3" class="pilcrow">¶</a></p>
+<p id="section-8.7-4">
+ UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-8.7-4" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="storing_uuids_opacity">
-<section id="section-5.8">
-        <h3 id="name-storing-uuids-opacity">
-<a href="#section-5.8" class="section-number selfRef">5.8. </a><a href="#name-storing-uuids-opacity" class="section-name selfRef">Storing UUIDs, Opacity</a>
+<div id="opacity">
+<section id="section-8.8">
+        <h3 id="name-opacity">
+<a href="#section-8.8" class="section-number selfRef">8.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
         </h3>
-<p id="section-5.8-1">
+<p id="section-8.8-1">
+ UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-8.8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="database_considerations">
+<section id="section-8.9">
+        <h3 id="name-dbms-and-database-considera">
+<a href="#section-8.9" class="section-number selfRef">8.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
+        </h3>
+<p id="section-8.9-1">
  For many applications, such as databases, storing UUIDs as the text is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID value.
- Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-5.8-1" class="pilcrow">¶</a></p>
+ Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-8.9-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.8-2.1">
-            <p id="section-5.8-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-5.8-2.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-8.9-2.1">
+            <p id="section-8.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-8.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-5.8-2.2">
-            <p id="section-5.8-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-5.8-2.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-8.9-2.2">
+            <p id="section-8.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-8.9-2.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-5.8-3">
+<p id="section-8.9-3">
  
  For other systems, UUIDs MAY be stored in binary form or as text, as appropriate. 
- The trade offs to both approaches are as such:<a href="#section-5.8-3" class="pilcrow">¶</a></p>
+ The trade offs to both approaches are as such:<a href="#section-8.9-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.8-4.1">
-            <p id="section-5.8-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-5.8-4.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-8.9-4.1">
+            <p id="section-8.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-8.9-4.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-5.8-4.2">
-            <p id="section-5.8-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-5.8-4.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-8.9-4.2">
+            <p id="section-8.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-8.9-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-5.8-5">
- UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4.1</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-5.8-5" class="pilcrow">¶</a></p>
+<p id="section-8.9-5">
+ DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+ If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
+ In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-8.9-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="IANA">
-<section id="section-6">
+<section id="section-9">
       <h2 id="name-iana-considerations">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-6-1">This document has no IANA actions.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-9-1">This document has no IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Security">
-<section id="section-7">
+<section id="section-10">
       <h2 id="name-security-considerations">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-7-1"> 
+<p id="section-10-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
  Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
- uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 5.6</a> for more information.<a href="#section-7-1" class="pilcrow">¶</a></p>
-<p id="section-7-2">
+ uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 8.6</a> for more information.<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-10-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 
  an embedded counter does signal the order of creation for a given UUID and it's corresponding data but 
  does not define anything about the data itself or the application as a whole. If UUIDs are required for
- use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-7-2" class="pilcrow">¶</a></p>
+ use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-10-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Acknowledgements">
-<section id="section-8">
+<section id="section-11">
       <h2 id="name-acknowledgements">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-8-1">The authors gratefully acknowledge the contributions of 
+<p id="section-11-1">The authors gratefully acknowledge the contributions of 
  Ben Campbell,
  Ben Ramsey,
  Fabio Lima,
@@ -2412,12 +2681,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Robert Kieffer,
  sergeyprokhorenko,
  LiosK
- As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-8-1" class="pilcrow">¶</a></p>
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-9">
+<section id="section-12">
       <h2 id="name-normative-references">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
       </h2>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -2433,14 +2702,18 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC4086">[RFC4086]</dt>
-    <dd>
+      <dd>
 <span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4648">[RFC4648]</dt>
+    <dd>
+<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-10">
+<section id="section-13">
       <h2 id="name-informative-references">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
       </h2>
 <dl class="references">
 <dt id="LexicalUUID">[LexicalUUID]</dt>
@@ -2524,7 +2797,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-creating-a-uuidv6-value" class="section-name selfRef">Creating a UUIDv6 Value</a>
         </h3>
 <p id="appendix-A.1-1">This section details a function in C which converts from a UUID version 1 to version 6:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-function-in-c"></span><figure id="figure-7">
+<span id="name-uuidv6-function-in-c"></span><figure id="figure-11">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2558,7 +2831,7 @@ void uuidv1tov6(uuid_t u) {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-uuidv6-function-in-c" class="selfRef">UUIDv6 Function in C</a>
           </figcaption></figure>
 </section>
@@ -2568,7 +2841,7 @@ void uuidv1tov6(uuid_t u) {
         <h3 id="name-creating-a-uuidv7e-value">
 <a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7e-value" class="section-name selfRef">Creating a UUIDv7E Value</a>
         </h3>
-<span id="name-uuidv7e-function-in-c"></span><figure id="figure-8">
+<span id="name-uuidv7e-function-in-c"></span><figure id="figure-12">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2616,7 +2889,7 @@ fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with rando
 u[8] = 0xE7; // set var-ver field
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-uuidv7e-function-in-c" class="selfRef">UUIDv7E Function in C</a>
           </figcaption></figure>
 </section>
@@ -2627,7 +2900,7 @@ u[8] = 0xE7; // set var-ver field
 <a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8e-value" class="section-name selfRef">Creating a UUIDv8E Value</a>
         </h3>
 <p id="appendix-A.3-1">UUIDv8E will vary greatly from implementation to implementation. A good candidate use case for UUIDv8E is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuid8-function-in-c"></span><figure id="figure-9">
+<span id="name-uuid8-function-in-c"></span><figure id="figure-13">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 #include &lt;stdint.h&gt;
@@ -2647,7 +2920,7 @@ int main() {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
 <a href="#name-uuid8-function-in-c" class="selfRef">UUID8 Function in C</a>
           </figcaption></figure>
 </section>
@@ -2661,24 +2934,24 @@ int main() {
       </h2>
 <p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
-<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-10">
+<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-14">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
 <pre>
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
-gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
+gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 
 # Gregorian to Unix Offset:
 # The number of 100-ns intervals between the
 # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-# gregorian_unix_offset = 0x01b21dd213814000 or 122192928000000000
+# gregorian_Unix_offset = 0x01b21dd213814000 or 122192928000000000
 
 # Unix 64 bit Nanosecond Timestamp:
 # Unix NS: Tuesday, February 22, 2022 2:22:22 PM GMT-05:00
-# unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
+# Unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
 
 # Work:
 # gregorian_100_ns = (1645557742000000000 / 100) + 122192928000000000
-# (138648505420000000 - 122192928000000000) * 100 = unix_64_bit_nanoseconds
+# (138648505420000000 - 122192928000000000) * 100 = Unix_64_bit_nanoseconds
 
 # Final:
 # gregorian_100_ns = 0x1EC9414C232AB00 or 138648505420000000
@@ -2688,7 +2961,7 @@ gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 </pre>
 </div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
 <a href="#name-test-vector-timestamp-pseud" class="selfRef">Test Vector Timestamp Pseudo-code</a>
         </figcaption></figure>
 <div id="uuidv6_example">
@@ -2696,7 +2969,7 @@ gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
         <h3 id="name-example-of-a-uuidv6-value">
 <a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-example-of-a-uuidv6-value" class="section-name selfRef">Example of a UUIDv6 Value</a>
         </h3>
-<span id="name-uuidv1-example-test-vector"></span><figure id="figure-11">
+<span id="name-uuidv1-example-test-vector"></span><figure id="figure-15">
           <div class="alignLeft art-text artwork" id="appendix-B.1-1.1">
 <pre>
 ----------------------------------------------
@@ -2714,10 +2987,10 @@ total                128
 final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
 <a href="#name-uuidv1-example-test-vector" class="selfRef">UUIDv1 Example Test Vector</a>
           </figcaption></figure>
-<span id="name-uuidv6-example-test-vector"></span><figure id="figure-12">
+<span id="name-uuidv6-example-test-vector"></span><figure id="figure-16">
           <div class="alignLeft art-text artwork" id="appendix-B.1-2.1">
 <pre>
 -----------------------------------------------
@@ -2735,21 +3008,51 @@ total                 128
 final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
+<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
 <a href="#name-uuidv6-example-test-vector" class="selfRef">UUIDv6 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="uuidv7_example">
 <section id="appendix-B.2">
-        <h3 id="name-example-of-a-uuidv7e-value">
-<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
+        <h3 id="name-example-of-a-uuidv7-value">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7-value" class="section-name selfRef">Example of a UUIDv7 Value</a>
         </h3>
-<p id="appendix-B.2-1">This example UUIDv7E test vector utilizes a well-known 32-bit unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-13">
+<span id="name-uuidv7-example-test-vector"></span><figure id="figure-17">
           <div class="alignLeft art-text artwork" id="appendix-B.2-4.1">
+<pre>
+-------------------------------
+field      bits    value
+-------------------------------
+unix_ts_ms   48    0x017F21CFD130
+var           4    0x7
+rand_a       12    0xCC3
+var           2    b10
+rand_b       62    0x18C4DC0C0C07398F
+-------------------------------
+total       128
+-------------------------------
+final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
+</pre>
+</div>
+<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<a href="#name-uuidv7-example-test-vector" class="selfRef">UUIDv7 Example Test Vector</a>
+          </figcaption></figure>
+</section>
+</div>
+<div id="uuidv7E_example">
+<section id="appendix-B.3">
+        <h3 id="name-example-of-a-uuidv7e-value">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
+        </h3>
+<p id="appendix-B.3-1">This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
+<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-18">
+          <div class="alignLeft art-text artwork" id="appendix-B.3-4.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -2759,27 +3062,58 @@ rand_a       16    0xF8B8
 var_ver       8    0xE7
 rand_b       56    0xD6A139DC9535C5
 -------------------------------
-total        128
+total       128
 -------------------------------
 final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
 <a href="#name-uuidv7e-example-test-vector" class="selfRef">UUIDv7E Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="uuidv8_example">
-<section id="appendix-B.3">
-        <h3 id="name-example-of-a-uuidv8e-value">
-<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
+<section id="appendix-B.4">
+        <h3 id="name-example-of-a-uuidv8-value">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.3-1">This example UUIDv8E test vector utilizes a well-known 64-bit unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-2">The final 56 bits are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-14">
-          <div class="alignLeft art-text artwork" id="appendix-B.3-5.1">
+<p id="appendix-B.4-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.4-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.4-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.4-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.4-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-19">
+          <div class="alignLeft art-text artwork" id="appendix-B.4-5.1">
+<pre>
+-------------------------------
+field      bits    value
+-------------------------------
+custom_a     48    0x320C3D4DCC00
+ver           4    0x8
+custom_b     12    0x75B
+var           2    b10
+custom_c     62    0xEC932D5F69181C0
+-------------------------------
+total       128
+-------------------------------
+final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
+</pre>
+</div>
+<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
+<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
+          </figcaption></figure>
+</section>
+</div>
+<div id="uuidv8E_example">
+<section id="appendix-B.5">
+        <h3 id="name-example-of-a-uuidv8e-value">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
+        </h3>
+<p id="appendix-B.5-1">This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.5-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-2">The final 56 bits are filled with random data.<a href="#appendix-B.5-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.5-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.5-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-example-test-vector-2"></span><figure id="figure-20">
+          <div class="alignLeft art-text artwork" id="appendix-B.5-5.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -2788,13 +3122,13 @@ custom_a     64    0x16D6320C3D4DCC00
 var_ver       8    0xE8
 custom_b     56    0x3C2D06302FC417
 -------------------------------
-total        128
+total       128
 -------------------------------
 final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
-<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
+<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<a href="#name-uuidv8e-example-test-vector-2" class="selfRef">UUIDv8E Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
@@ -2890,7 +3224,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">7</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -2898,7 +3232,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">8</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -3043,7 +3377,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
+              <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -3051,7 +3385,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
+              <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                            9 March 2022
-Expires: 10 September 2022
+Intended status: Standards Track                           14 March 2022
+Expires: 15 September 2022
 
 
                             New UUID Formats
@@ -33,7 +33,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 10 September 2022.
+   This Internet-Draft will expire on 15 September 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 1]
+Peabody & Davis         Expires 15 September 2022               [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -84,7 +84,7 @@ Table of Contents
      8.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  22
      8.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  23
      8.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  23
-     8.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  23
+     8.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  24
      8.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  24
      8.8.  Opacity . . . . . . . . . . . . . . . . . . . . . . . . .  24
      8.9.  DBMS and Database Considerations  . . . . . . . . . . . .  24
@@ -93,8 +93,8 @@ Table of Contents
    11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
    12. Normative References  . . . . . . . . . . . . . . . . . . . .  25
    13. Informative References  . . . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  27
-     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  27
+   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  28
+     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  28
      A.2.  Creating a UUIDv7E Value  . . . . . . . . . . . . . . . .  28
      A.3.  Creating a UUIDv8E Value  . . . . . . . . . . . . . . . .  30
    Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  30
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 2]
+Peabody & Davis         Expires 15 September 2022               [Page 2]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -165,7 +165,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 3]
+Peabody & Davis         Expires 15 September 2022               [Page 3]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -221,7 +221,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 4]
+Peabody & Davis         Expires 15 September 2022               [Page 4]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -269,7 +269,7 @@ Internet-Draft               new-uuid-format                  March 2022
       Section 5.2
 
    UUID version 7E (UUIDv7E)
-      An alternate format for UUIDv7.  See Section 6.1
+      An alternate variant for UUIDv7.  See Section 6.1
 
    UUID version 8 (UUIDv8)
       A free-form UUID format which has no explicit requirements except
@@ -277,13 +277,13 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 5]
+Peabody & Davis         Expires 15 September 2022               [Page 5]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
    UUID version 8E (UUIDv8E)
-      An alternate format for UUIDv8.  See Section 6.2
+      An alternate variant for UUIDv8.  See Section 6.2
 
    Max UUID
       A specialized UUID which is the inverse of [RFC4122],
@@ -333,7 +333,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 6]
+Peabody & Davis         Expires 15 September 2022               [Page 6]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -389,7 +389,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 7]
+Peabody & Davis         Expires 15 September 2022               [Page 7]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -445,7 +445,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 8]
+Peabody & Davis         Expires 15 September 2022               [Page 8]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -501,7 +501,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022               [Page 9]
+Peabody & Davis         Expires 15 September 2022               [Page 9]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -557,7 +557,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 10]
+Peabody & Davis         Expires 15 September 2022              [Page 10]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -613,7 +613,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 11]
+Peabody & Davis         Expires 15 September 2022              [Page 11]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -669,7 +669,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 12]
+Peabody & Davis         Expires 15 September 2022              [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -725,7 +725,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 13]
+Peabody & Davis         Expires 15 September 2022              [Page 13]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -781,7 +781,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 14]
+Peabody & Davis         Expires 15 September 2022              [Page 14]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -837,7 +837,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 15]
+Peabody & Davis         Expires 15 September 2022              [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -893,7 +893,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 16]
+Peabody & Davis         Expires 15 September 2022              [Page 16]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -949,7 +949,7 @@ UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 17]
+Peabody & Davis         Expires 15 September 2022              [Page 17]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1005,7 +1005,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 18]
+Peabody & Davis         Expires 15 September 2022              [Page 18]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1061,7 +1061,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 19]
+Peabody & Davis         Expires 15 September 2022              [Page 19]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1117,40 +1117,49 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 20]
+Peabody & Davis         Expires 15 September 2022              [Page 20]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
    Fixed-Length Dedicated Counter Seeding:
-      Implementations utilizing fixed-length counter method MAY randomly
-      initialize the counter with each new timestamp tick.  However,
-      when the timestamp has not incremented; the counter SHOULD be
-      frozen and incremented by one.  When utilizing a randomly seeded
-      counter alongside Method 1; the random MAY be regenerated with
-      each counter increment without impacting sortability.  The
-      downside is that Method 1 is prone to overflows if a counter of
-      adequate length is not selected or the random data generated
-      leaves little room for the required number of increments.
-      Implementations utilizing fixed-length counter method MAY also
-      choose to initialize the counter at zero to ensure the full bit-
-      space is utilized and help avoid counter rollovers.  This approach
-      has less entropy and more guessibility but ensures the most of the
-      counter bit space.
+      Implementations utilizing fixed-length counter method SHOULD
+      randomly initialize the counter with each new timestamp tick.
+      However, when the timestamp has not incremented; the counter
+      SHOULD be frozen and incremented by one.  When utilizing a
+      randomly seeded counter alongside Method 1; the random MAY be
+      regenerated with each counter increment without impacting
+      sortability.  The downside is that Method 1 is prone to overflows
+      if a counter of adequate length is not selected or the random data
+      generated leaves little room for the required number of
+      increments.  Implementations utilizing fixed-length counter method
+      MAY also choose to randomly initialize a portion counter rather
+      than the entire counter.  For example, a 24 bit counter could have
+      the 23 bits in least-significant, right-most, position randomly
+      initialized.  The remaining most significant, left-most counter
+      bits are initialized as zero for the sole purpose of guarding
+      against counter rollovers.
 
    Fixed-Length Dedicated Counter Length
       Care MUST be taken to select a counter bit-length that can
       properly handle the level of timestamp precision in use.  For
       example, millisecond precision SHOULD require a larger counter
       than a timestamp with nanosecond precision.  General Guidance is
-      that the counter SHOULD be at least 12 bits and no more than a
-      maximum of 24 bits.
+      that the counter SHOULD be at least 12 bits but can be longer.
+      Care SHOULD also be given to ensure that the counter length
+      selected leaves room for sufficient entropy in the random portion
+      of the UUID after the counter.  This entropy helps improve the
+      unguessability characteristics of UUIDs created within the batch.
 
    Fixed-Length Dedicated Counter Rollover Handling
       Counter rollovers SHOULD be handled by the application to avoid
       sorting issues.  The general guidance is that applications SHOULD
       freeze the counter and wait for the timestamp to advance which
-      ensures monotonicity is not broken.
+      ensures monotonicity is not broken.  The technique from Fixed-
+      Length Dedicated Counter Seeding which describes allocating a
+      segment of the fixed-length counter as a rollover guard is also
+      recommended and SHOULD be employed to help mitigate counter
+      rollover issues.
 
    Implementations MAY use the following logic to ensure UUIDs featuring
    embedded counters are monotonic in nature:
@@ -1159,24 +1168,20 @@ Internet-Draft               new-uuid-format                  March 2022
        timestamp.
    2.  If the current timestamp is equal to the previous timestamp;
        increment desired counter logic.
+
+
+
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 21]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    3.  If the current timestamp is greater than the previous timestamp;
        re-initialize the counter to the new timestamp and generate new
        random bytes (if the bytes were frozen or being used as the seed
        for a monotonic counter).
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 21]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Implementations SHOULD check if the the currently generated UUID is
    greater than the previously generated UUID.  If this is not the case
@@ -1222,17 +1227,17 @@ Internet-Draft               new-uuid-format                  March 2022
       node id among distributed nodes is also out of scope for this
       specification.
 
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 22]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    Utilization of either a shared knowledge scheme or Node ID are not
    required for implementing UUIDs in this specification.  However
    implementations SHOULD utilize one of the two aforementioned methods
    if distributed UUID generation is a requirements.
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 22]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
 8.4.  Collision Resistance
 
@@ -1275,6 +1280,16 @@ Internet-Draft               new-uuid-format                  March 2022
    a shared knowledge scheme introduced in Section 8.3 as they see fit
    to extend the uniqueness guaranteed this specification and [RFC4122].
 
+
+
+
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 23]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
 8.6.  Unguessability
 
    Implementations SHOULD utilize a cryptographically secure pseudo-
@@ -1282,13 +1297,6 @@ Internet-Draft               new-uuid-format                  March 2022
    difficult to predict ("unguessable") and have a low likelihood of
    collision ("unique").  CSPRNG ensures the best of Section 8.4 and
    Section 10 are present in modern UUIDs.
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 23]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Advice on generating cryptographic-quality random numbers can be
    found in [RFC4086]
@@ -1330,6 +1338,14 @@ Internet-Draft               new-uuid-format                  March 2022
    *  8 bits for each of the 32 hex characters = 256 bits
    *  8 bits for each of the 4 hyphens = 32 bits
 
+
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 24]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    For other systems, UUIDs MAY be stored in binary form or as text, as
    appropriate.  The trade offs to both approaches are as such:
 
@@ -1338,13 +1354,6 @@ Internet-Draft               new-uuid-format                  March 2022
    *  Storing as text requires more space but may require less
       translation if the resulting text form is to be used after
       retrieval and thus maybe simpler to implement.
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 24]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    DBMS vendors are encouraged to provide functionality to generate and
    store UUID formats defined by this specification for use as
@@ -1386,6 +1395,13 @@ Internet-Draft               new-uuid-format                  March 2022
 
 12.  Normative References
 
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 25]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
@@ -1394,13 +1410,6 @@ Internet-Draft               new-uuid-format                  March 2022
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 25]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    [RFC4122]  Leach, P., Mealling, M., and R. Salz, "A Universally
               Unique IDentifier (UUID) URN Namespace", RFC 4122,
@@ -1442,6 +1451,13 @@ Internet-Draft               new-uuid-format                  March 2022
    [KSUID]    Segment, "K-Sortable Globally Unique IDs", Commit bf376a7,
               July 2020, <https://github.com/segmentio/ksuid>.
 
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 26]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    [Elasticflake]
               Pearcy, P., "Sequential UUID / Flake ID generator pulled
               out of elasticsearch common", Commit dd71c21, January
@@ -1449,14 +1465,6 @@ Internet-Draft               new-uuid-format                  March 2022
 
    [FlakeID]  Pawlak, T., "Flake ID Generator", Commit fcd6a2f, April
               2020, <https://github.com/T-PWK/flake-idgen>.
-
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 26]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    [Sonyflake]
               Sony, "A distributed unique ID generator inspired by
@@ -1499,20 +1507,19 @@ Internet-Draft               new-uuid-format                  March 2022
               scaling and performance.", Series 754-2019, July 2019,
               <https://standards.ieee.org/ieee/754/6210/>.
 
+
+
+Peabody & Davis         Expires 15 September 2022              [Page 27]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
 Appendix A.  Example Code
 
 A.1.  Creating a UUIDv6 Value
 
    This section details a function in C which converts from a UUID
    version 1 to version 6:
-
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 27]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    #include <stdio.h>
    #include <stdint.h>
@@ -1558,14 +1565,7 @@ A.2.  Creating a UUIDv7E Value
 
 
 
-
-
-
-
-
-
-
-Peabody & Davis         Expires 10 September 2022              [Page 28]
+Peabody & Davis         Expires 15 September 2022              [Page 28]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1621,7 +1621,7 @@ u[8] = 0xE7; // set var-ver field
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 29]
+Peabody & Davis         Expires 15 September 2022              [Page 29]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1677,7 +1677,7 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 30]
+Peabody & Davis         Expires 15 September 2022              [Page 30]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1733,7 +1733,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 31]
+Peabody & Davis         Expires 15 September 2022              [Page 31]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1789,7 +1789,7 @@ B.3.  Example of a UUIDv7E Value
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 32]
+Peabody & Davis         Expires 15 September 2022              [Page 32]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1845,7 +1845,7 @@ B.4.  Example of a UUIDv8 Value
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 33]
+Peabody & Davis         Expires 15 September 2022              [Page 33]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1901,7 +1901,7 @@ C.1.  Variant 10xx Versions
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 34]
+Peabody & Davis         Expires 15 September 2022              [Page 34]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1957,7 +1957,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 35]
+Peabody & Davis         Expires 15 September 2022              [Page 35]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -2013,7 +2013,7 @@ C.2.  Variant 1110 Versions
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 36]
+Peabody & Davis         Expires 15 September 2022              [Page 36]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -2069,4 +2069,4 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 10 September 2022              [Page 37]
+Peabody & Davis         Expires 15 September 2022              [Page 37]

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                           14 March 2022
-Expires: 15 September 2022
+Intended status: Standards Track                           16 March 2022
+Expires: 17 September 2022
 
 
                             New UUID Formats
@@ -15,8 +15,7 @@ Expires: 15 September 2022
 Abstract
 
    This document presents new Universally Unique Identifier (UUID)
-   formats, variants, and encoding techniques for use in modern
-   applications and databases.
+   formats for use in modern applications and databases.
 
 Status of This Memo
 
@@ -33,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 15 September 2022.
+   This Internet-Draft will expire on 17 September 2022.
 
 Copyright Notice
 
@@ -53,7 +52,8 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 15 September 2022               [Page 1]
+
+Peabody & Davis         Expires 17 September 2022               [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -61,60 +61,58 @@ Internet-Draft               new-uuid-format                  March 2022
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   5
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   4
      2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   5
      2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   5
    3.  Summary of Changes  . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  changelog . . . . . . . . . . . . . . . . . . . . . . . .   6
+     3.1.  changelog . . . . . . . . . . . . . . . . . . . . . . . .   5
    4.  Variant and Version Fields  . . . . . . . . . . . . . . . . .   7
-   5.  New Formats . . . . . . . . . . . . . . . . . . . . . . . . .  10
-     5.1.  UUID Version 6  . . . . . . . . . . . . . . . . . . . . .  10
-     5.2.  UUID Version 7  . . . . . . . . . . . . . . . . . . . . .  12
-     5.3.  UUID Version 8  . . . . . . . . . . . . . . . . . . . . .  13
-   6.  Alternate Variants  . . . . . . . . . . . . . . . . . . . . .  14
-     6.1.  UUID Version 7E . . . . . . . . . . . . . . . . . . . . .  14
-     6.2.  UUID Version 8E . . . . . . . . . . . . . . . . . . . . .  15
-   7.  Alternate Formats . . . . . . . . . . . . . . . . . . . . . .  16
-     7.1.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  16
-     7.2.  UUID Long . . . . . . . . . . . . . . . . . . . . . . . .  16
-     7.3.  Alternate Encodings . . . . . . . . . . . . . . . . . . .  17
-   8.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  18
-     8.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  18
-     8.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  20
-     8.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  22
-     8.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  23
-     8.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  23
-     8.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  24
-     8.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  24
-     8.8.  Opacity . . . . . . . . . . . . . . . . . . . . . . . . .  24
-     8.9.  DBMS and Database Considerations  . . . . . . . . . . . .  24
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
-   10. Security Considerations . . . . . . . . . . . . . . . . . . .  25
-   11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
-   12. Normative References  . . . . . . . . . . . . . . . . . . . .  25
-   13. Informative References  . . . . . . . . . . . . . . . . . . .  26
-   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  28
-     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  28
-     A.2.  Creating a UUIDv7E Value  . . . . . . . . . . . . . . . .  28
-     A.3.  Creating a UUIDv8E Value  . . . . . . . . . . . . . . . .  30
-   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  30
-     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  31
-     B.2.  Example of a UUIDv7 Value . . . . . . . . . . . . . . . .  32
-     B.3.  Example of a UUIDv7E Value  . . . . . . . . . . . . . . .  32
-     B.4.  Example of a UUIDv8 Value . . . . . . . . . . . . . . . .  33
-     B.5.  Example of a UUIDv8E Value  . . . . . . . . . . . . . . .  34
-   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  34
-     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  34
-     C.2.  Variant 1110 Versions . . . . . . . . . . . . . . . . . .  36
+   5.  New Formats . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     5.1.  UUID Version 6  . . . . . . . . . . . . . . . . . . . . .   8
+     5.2.  UUID Version 7  . . . . . . . . . . . . . . . . . . . . .  10
+     5.3.  UUID Version 8  . . . . . . . . . . . . . . . . . . . . .  11
+     5.4.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  12
+   6.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  12
+     6.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  12
+     6.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  13
+     6.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  16
+     6.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  17
+     6.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  17
+     6.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  18
+     6.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     6.8.  Opacity . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     6.9.  DBMS and Database Considerations  . . . . . . . . . . . .  18
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  19
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  19
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  19
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .  19
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  20
+   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  22
+     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  22
+     A.2.  Creating a UUIDv7 Value . . . . . . . . . . . . . . . . .  22
+     A.3.  Creating a UUIDv8 Value . . . . . . . . . . . . . . . . .  23
+   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  23
+     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  24
+     B.2.  Example of a UUIDv7 Value . . . . . . . . . . . . . . . .  25
+     B.3.  Example of a UUIDv8 Value . . . . . . . . . . . . . . . .  25
+   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  26
+     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  26
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
 
 
 
-Peabody & Davis         Expires 15 September 2022               [Page 2]
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 2]
 
 Internet-Draft               new-uuid-format                  March 2022
 
-
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  37
 
 1.  Introduction
 
@@ -153,24 +151,7 @@ Internet-Draft               new-uuid-format                  March 2022
        opposed to being able to perform a simple byte-by-byte
        comparison.
 
-   4.  The textual representation of existing UUIDs utilized for storage
-       or transport is oftentimes unnecessarily verbose.
-
-   5.  The 128 bit length of current UUIDs oftentimes leads to
-       alternative unique identifier solutions featuring longer bit
-       lengths.
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 3]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   6.  Privacy and network security issues arise from using a MAC
+   4.  Privacy and network security issues arise from using a MAC
        address in the node field of Version 1 UUIDs.  Exposed MAC
        addresses can be used as an attack surface to locate machines and
        reveal various other information about such machines (minimally
@@ -178,12 +159,23 @@ Internet-Draft               new-uuid-format                  March 2022
        advent of virtual machines and containers, MAC address uniqueness
        is no longer guaranteed.
 
-   7.  Many of the implementation details specified in [RFC4122] involve
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 3]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   5.  Many of the implementation details specified in [RFC4122] involve
        trade offs that are neither possible to specify for all
        applications nor necessary to produce interoperable
        implementations.
 
-   8.  [RFC4122] does not distinguish between the requirements for
+   6.  [RFC4122] does not distinguish between the requirements for
        generation of a UUID versus an application which simply stores
        one, which are often different.
 
@@ -217,20 +209,22 @@ Internet-Draft               new-uuid-format                  March 2022
    15.  [ObjectID] by MongoDB
    16.  [CUID] by E.  Elliott
 
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 4]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    An inspection of these implementations and the issues described above
    has led to this document which attempts to adapt UUIDs to address
    these issues.
 
 2.  Terminology
+
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 4]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
 2.1.  Requirements Language
 
@@ -268,34 +262,25 @@ Internet-Draft               new-uuid-format                  March 2022
       implemented and well known Unix Epoch timestamp source.  See
       Section 5.2
 
-   UUID version 7E (UUIDv7E)
-      An alternate variant for UUIDv7.  See Section 6.1
-
    UUID version 8 (UUIDv8)
       A free-form UUID format which has no explicit requirements except
       maintaining backward compatibility.  See Section 5.3
 
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 5]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   UUID version 8E (UUIDv8E)
-      An alternate variant for UUIDv8.  See Section 6.2
-
    Max UUID
       A specialized UUID which is the inverse of [RFC4122],
-      Section 4.1.7 See Section 7.1
-
-   UUID Long
-      An extension of the base UUID with variable length beyond 128
-      bits.  See Section 7.2
+      Section 4.1.7 See Section 5.4
 
 3.1.  changelog
 
    RFC EDITOR PLEASE DELETE THIS SECTION.
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 5]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    draft-03
 
@@ -305,21 +290,19 @@ Internet-Draft               new-uuid-format                  March 2022
       millisecond Unix timestamp
       - UUIDv8 relaxed to be custom in all elements except version and
       variant
-      - Changed UUIDv7E and UUIDv8E to use Variant 111.
       - Introduced Max UUID.
-      - Re-introduced variable length UUIDs as UUID Long.
-      - Re-introduced alternate encoding techniques for all UUIDs.
       - Added C code samples in Appendix.
       - Added test vectors in Appendix.
       - Version and Variant section combined into one section.
       - Changed from pseudo-random number generators to
       cryptographically secure pseudo-random number generator (CSPRNG).
-      - Split Encoding and Storage renamed Storing UUIDs, Opacity
-      - Reworked Global Uniqueness under new section Global and Local
-      Uniqueness
       - Combined redundant topics from all UUIDs into sections such as
       Timestamp granularity, Monotonicity and Counters, Collision
       Resistance, Sorting, and Unguessability, etc.
+      - Split Encoding and Storage into Opacity and DBMS and Database
+      Considerations
+      - Reworked Global Uniqueness under new section Global and Local
+      Uniqueness
       - Node verbiage only used in UUIDv6 all others reference random/
       rand instead
       - Clock sequence verbiage changed simply to counter in any section
@@ -329,14 +312,6 @@ Internet-Draft               new-uuid-format                  March 2022
       - Added information about little-endian UUIDs
 
    draft-02
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 6]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
       - Added Changelog
       - Fixed misc. grammatical errors
@@ -355,6 +330,13 @@ Internet-Draft               new-uuid-format                  March 2022
       4.5.4
 
    draft-01
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 6]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
       - Complete rewrite of entire document.
       - The format, flow and verbiage used in the specification has been
@@ -376,79 +358,9 @@ Internet-Draft               new-uuid-format                  March 2022
    The variant bits utilized by UUIDs in this specification remain in
    the same octet as originally defined by [RFC4122], Section 4.1.1.
 
-   This specification makes use of the unused variant bits of 111
-   defined in [RFC4122], Section 4.1.1.  This variant will move the
-   4-bit version to the same octet as the variant to overcoming many bit
-   shuffling techniques found in UUID implementations.  All UUIDs
-   utilizing this variant SHOULD be referenced by their version number
-   plus the uppercase E character to represent the hex character 0xE
-   which will frequent the text representation of UUIDs.  The placement
-   of the version within the same octet as the variant leaves room for a
-   future variant as described below:
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 7]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   *  UUID Version 7E and 8E specified by this document MUST set the
-      first 3 bits of octet 8 to 111 and the fourth bit to 0.  The 4 bit
-      version MUST follow the variant to fill out the final bits of
-      octet 8.
-   *  Future specifications that wish to utilize variant 111 for a
-      different version position (or any other bit layout position) MUST
-      set the first 3 bits of octet 8 to 111 and then the fourth bit to
-      1.
-
-   The table below detail the three variants described in this document
-   where the letter "x" indicates a "don't-care" value.
-
-    +------+------+------+------+---------+---------------------------+
-    | Msb0 | Msb1 | Msb2 | Msb3 | Hex     | Description               |
-    +------+------+------+------+---------+---------------------------+
-    | 1    | 0    | x    | x    | 8/9/A/B | The variant specified by  |
-    |      |      |      |      |         | [RFC4122], Section 4.1.1. |
-    +------+------+------+------+---------+---------------------------+
-    | 1    | 1    | 1    | 0    | E       | The new variant specified |
-    |      |      |      |      |         | in this document.         |
-    +------+------+------+------+---------+---------------------------+
-    | 1    | 1    | 1    | 1    | F       | Reserved for future       |
-    |      |      |      |      |         | definition.               |
-    +------+------+------+------+---------+---------------------------+
-
-            Table 1: UUID Variant defined by this specification
-
-   UUID Versions defined within the RFC 4122 Variant are distinct from
-   UUID versions defined by the new variant.
-
    The next table details Variant 10xx (8/9/A/B) and the new versions
    defined by this specification.  A complete guide to all versions
    within this variant has been includes in Appendix C.1.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 8]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
     +------+------+------+------+---------+---------------------------+
     | Msb0 | Msb1 | Msb2 | Msb3 | Version | Description               |
@@ -466,12 +378,21 @@ Internet-Draft               new-uuid-format                  March 2022
     |      |      |      |      |         | document                  |
     +------+------+------+------+---------+---------------------------+
 
-     Table 2: New UUID variant 10xx (8/9/A/B) versions defined by this
+     Table 1: New UUID variant 10xx (8/9/A/B) versions defined by this
                                specification
 
    For UUID version 6, 7 and 8 the variant field placement from
    [RFC4122] are unchanged.  An example version/variant layout for
    UUIDv6 follows the table where M is the version and N is the variant.
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 7]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    00000000-0000-6000-8000-000000000000
    00000000-0000-6000-9000-000000000000
@@ -481,66 +402,9 @@ Internet-Draft               new-uuid-format                  March 2022
 
                      Figure 1: UUIDv6 Variant Examples
 
-   The next table details Variant 1110 (E) and the new versions defined
-   by this specification.  A complete guide to all versions within this
-   variant has been includes in Appendix C.2.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022               [Page 9]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   +------+------+------+------+---------+-----------------------------+
-   | Msb0 | Msb1 | Msb2 | Msb3 | Version | Description                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 1    | 1    | 7E      | Alternate Unix Epoch        |
-   |      |      |      |      |         | time-based UUID specified   |
-   |      |      |      |      |         | in this document.           |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 0    | 0    | 8E      | Alternate reservation for   |
-   |      |      |      |      |         | custom UUID formats         |
-   |      |      |      |      |         | specified in this           |
-   |      |      |      |      |         | document.                   |
-   +------+------+------+------+---------+-----------------------------+
-
-   Table 3: UUID variant 1110 (E) versions defined by this specification
-
-   For UUID versions 7E and 8E, the variant field has been incremented
-   and the version field has been moved to the same octet as the
-   variant.  Since the bits of the variant remain in the same place as
-   described in [RFC4122] but utilized the previously reserved value
-   111, this allows a UUID to simply define octet 8 as var_ver, and the
-   values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.  An
-   example version/variant layout for versions 7E and 8E follows the
-   table where M is the version and N is the variant.
-
-   00000000-0000-0000-E700-000000000000
-   xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-
-   00000000-0000-0000-E800-000000000000
-   xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-
-             Figure 2: UUID version 7E and 8E Variant Examples
-
 5.  New Formats
 
-   The UUID format is 16 octets; The variant bits in conjunction with
+   The UUID format is 16 octets; the variant bits in conjunction with
    the version bits described in the next section in determine finer
    structure.
 
@@ -549,18 +413,7 @@ Internet-Draft               new-uuid-format                  March 2022
    UUID version 6 is a field-compatible version of UUIDv1, reordered for
    improved DB locality.  It is expected that UUIDv6 will primarily be
    used in contexts where there are existing v1 UUIDs.  Systems that do
-   not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E
-   instead.
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 10]
-
-Internet-Draft               new-uuid-format                  March 2022
-
+   not involve legacy UUIDv1 SHOULD consider using UUIDv7 instead.
 
    Instead of splitting the timestamp into the low, mid and high
    sections from UUIDv1, UUIDv6 changes this sequence so timestamp bytes
@@ -576,9 +429,26 @@ Internet-Draft               new-uuid-format                  March 2022
    The 48 bit node SHOULD be set to a pseudo-random value however
    implementations MAY choose retain the old MAC address behavior from
    [RFC4122], Section 4.1.6 and [RFC4122], Section 4.5.  For more
-   information on MAC address usage within UUIDs see the Section 10
+   information on MAC address usage within UUIDs see the Section 8
 
    The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 8]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
         0                   1                   2                   3
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -592,7 +462,7 @@ Internet-Draft               new-uuid-format                  March 2022
        |                         node (2-5)                            |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 3: UUIDv6 Field and Bit Layout
+                   Figure 2: UUIDv6 Field and Bit Layout
 
    time_high:
       The most significant 32 bits of the 60 bit starting timestamp.
@@ -607,16 +477,6 @@ Internet-Draft               new-uuid-format                  March 2022
       version (0110) while the remaining 12 bits will contain the least
       significant 12 bits from the 60 bit starting timestamp.  Occupies
       bits 48 through 63 (octets 6-7)
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 11]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    clk_seq_hi_res:
       The first two bits MUST be set to the UUID variant (10) The
@@ -639,6 +499,13 @@ Internet-Draft               new-uuid-format                  March 2022
    implementation.  In which the following logic can be applied to
    reshuffle the bits with minimal modifications.
 
+
+
+Peabody & Davis         Expires 17 September 2022               [Page 9]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
                   +--------------+------+--------------+
                   | UUIDv1 Field | Bits | UUIDv6 Field |
                   +--------------+------+--------------+
@@ -649,7 +516,7 @@ Internet-Draft               new-uuid-format                  March 2022
                   | time_high    | 12   | time_low     |
                   +--------------+------+--------------+
 
-                     Table 4: UUIDv1 to UUIDv6 Field
+                     Table 2: UUIDv1 to UUIDv6 Field
                                  Mappings
 
 5.2.  UUID Version 7
@@ -660,19 +527,6 @@ Internet-Draft               new-uuid-format                  March 2022
 
    Implementations SHOULD utilize UUID version 7 over UUID version 1 and
    6 if possible.
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 12]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -686,25 +540,34 @@ Internet-Draft               new-uuid-format                  March 2022
    |                            rand_b                             |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 4: UUIDv7 Field and Bit Layout
+                   Figure 3: UUIDv7 Field and Bit Layout
 
    unix_ts_ms:
       48 bit big-endian unsigned number of Unix epoch timestamp as per
-      Section 8.1.
+      Section 6.1.
 
    ver:
       4 bit UUIDv7 version set as per Section 4
 
    rand_a:
       12 bits pseudo-random data to provide uniqueness as per
-      Section 8.2 and Section 8.6.
+      Section 6.2 and Section 6.6.
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 10]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    var:
       The 2 bit variant defined by Section 4.
 
    rand_b:
       The final 62 bits of pseudo-random data to provide uniqueness as
-      per Section 8.2 and Section 8.6.
+      per Section 6.2 and Section 6.6.
 
 5.3.  UUID Version 8
 
@@ -723,13 +586,6 @@ Internet-Draft               new-uuid-format                  March 2022
    *  An implementation would like to embed extra information within the
       UUID other than what is defined in this document.
 
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 13]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    *  An implementation has other application/language restrictions
       which inhibit the use of one of the current UUIDs.
 
@@ -745,7 +601,7 @@ Internet-Draft               new-uuid-format                  March 2022
    |                           custom_c                            |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 5: UUIDv8 Field and Bit Layout
+                   Figure 4: UUIDv8 Field and Bit Layout
 
    custom_a:
       The first 48 bits of the layout that can be filled as an
@@ -753,6 +609,14 @@ Internet-Draft               new-uuid-format                  March 2022
 
    ver:
       The 4 bit version field as defined by Section 4
+
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 11]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    custom_b:
       12 more bits of the layout that can be filled as an implementation
@@ -762,120 +626,10 @@ Internet-Draft               new-uuid-format                  March 2022
       The 2 bit variant field as defined by Section 4.
 
    custom_c:
-      The final 62 bits of the layout immediatly following the var_var
-      field to be filled as an implementation sees fit.
+      The final 62 bits of the layout immediatly following the var field
+      to be filled as an implementation sees fit.
 
-6.  Alternate Variants
-
-   This section details alternate formats utilizing the newly defined
-   "E" variant layout for use with UUID version 7 and version 8 of this
-   document.
-
-6.1.  UUID Version 7E
-
-   UUID version 7E is an alternative bit layout for UUIDv7 which
-   leverages the new simplified "E" variant introduced in this
-   specification.
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 14]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   With UUIDv7E the first 64 bits of the UUID layout are unbroken and
-   the version has been moved to the same octet as the variant to
-   produce var_ver field populated with 0xE7.
-
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                           unix_ts_ms                          |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |          unix_ts_ms           |            rand_a             |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |    var_ver    |            rand_b                             |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                            rand_b                             |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-                   Figure 6: UUIDv7E Field and Bit Layout
-
-   unix_ts_ms:
-      48 bit big-endian unsigned number of Unix epoch timestamp as per
-      Section 8.1.
-
-   rand_a:
-      16 bits pseudo-random data to provide uniqueness as per
-      Section 8.2 and Section 8.6.
-
-   var_ver:
-      The 8 bit combined variant and version field with the value 0xE7
-      as defined by Section 4.
-
-   rand_b:
-      The final 56 bits of pseudo-random data to provide uniqueness as
-      per Section 8.2 and Section 8.6.
-
-6.2.  UUID Version 8E
-
-   UUID version 8E is an alternative bit layout for UUIDv8 which
-   leverages the new simplified "E" variant introduced in this
-   specification.
-
-   With UUIDv8E the first 64 bits of the UUID layout are unbroken and
-   the version has been moved to the same octet as the variant to
-   produce the var_ver field populated with 0xE8.
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 15]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                           custom_a                            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                           custom_a                            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |    var_ver    |           custom_b                            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                           custom_b                            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-                   Figure 7: UUIDv8E Field and Bit Layout
-
-   custom_a:
-      The first 64 bits of the layout that can be filled as an
-      implementation sees fit.
-
-   var_ver:
-      The 8 bit combined variant and version field with the value 0xE8
-      as defined by Section 4.
-
-   custom_b:
-      The final 56 bits of the layout immediatly following the var_var
-      field to be filled as an implementation sees fit.
-
-7.  Alternate Formats
-
-   This section details alternate UUID formats such as the Max UUID, a
-   longer form of UUID aptly named "UUID Long" and some alternate
-   encoding techniques applicable to all UUIDs in this document and
-   [RFC4122].
-
-7.1.  Max UUID
+5.4.  Max UUID
 
    The Max UUID is special form of UUID that is specified to have all
    128 bits set to 1.  This UUID can be thought of as the inverse of Nil
@@ -883,105 +637,9 @@ Internet-Draft               new-uuid-format                  March 2022
 
    FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 
-                         Figure 8: Max UUID Format
+                         Figure 5: Max UUID Format
 
-7.2.  UUID Long
-
-   UUID Long generally references any variable length UUID longer than
-   128 bits.  There are two main driving factors behind extending UUID
-   beyond 128 bits:
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 16]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   Increased Entropy:
-      While existing UUID formats provide sufficient entropy for most
-      use cases; there exists scenarios where even more entropy is
-      required to further reduce collision probabilities (Section 8.4)
-      or guessability (Section 8.6).
-
-   Requirements for additional embedded items:
-      Some implementations require more than 128 bits to properly embed
-      all of the application specific data they require.  Some examples
-      include database metadata like entity types, checksum values,
-      shard/partition identifiers, and even node identifiers defined by
-      Section 8.3.
-
-   UUID Long is compatible with any UUID specified in this document and
-   [RFC4122].  UUID long is variable in length and there is no minimum
-   or maximum value for UUID Long; however, UUID Long SHOULD leverage
-   natural byte boundaries.  UUID long is defined by appending an
-   additional dash to the existing 8-4-4-4-12 hex format to create
-   8-4-4-4-12-variable_length text format.  The next example shows a
-   UUID Long +32, +64 and +128 example for UUIDv4 with random data
-   filling the values beyond 128 bits.
-
-UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
-   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
-  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
-
-                     Figure 9: UUID Long Examples
-
-   Where required, for compatibility with legacy UUID implementations,
-   the most significant, left-most, 128 bits MUST be leveraged to
-   truncate from UUID Long back to a regular UUID.
-
-   When UUID Long is utilized with Nil UUID or Max UUID all bits should
-   be set as specified.  That is for Nil UUID Long all bits MUST be set
-   to 0 while Max UUID Long all bits MUST be set to 1.
-
-7.3.  Alternate Encodings
-
-   The existing UUID hex and dash format of 8-4-4-4-12 is retained for
-   both backwards compatibility and human readability.  This format MUST
-   be implemented for all UUIDs.
-
-   Where required, UUIDs defined by this specification and [RFC4122] MAY
-   be encoded utilizing new techniques such as, but not limited to,
-   Base32, Base36, or Base64.  Applications MAY also utilize other
-   encoding techniques such as modulo division or alternate alphabets
-   such as Crockford's base32.  When selecting an alternate encoding
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 17]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   implementations SHOULD take into consideration items such as:
-   uppercase/lowercase/mixed character encoding for application
-   sortability, special character inclusions or omissions, and the
-   exclusion of key letters like "I", "L", "O", and "U" which may impact
-   sortability of UUIDv7 and UUIDv7E and collision resistance provided
-   by all UUIDs.
-
-   When utilizing alternate encoding techniques with other applications;
-   the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that
-   the value therein is that of a UUID.
-
-   The conversion from UUID to a new encoding technique SHOULD be done
-   utilizing the underlying integer or binary value for a given UUID
-   versus converting the hex representation.  Two examples for UUIDv4
-   encoded as base-32 and base-36 are included below.
-
-UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-UUIDv4 Int: 154072644812979270675542139334331768221
-UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
-UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
-UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
-
-                Figure 10: Alternate Encoding Examples
-
-   For information on converting a UUID into Base 16, Base 32 or Base 64
-   refer to [RFC4648].
-
-8.  UUID Best Practices
+6.  UUID Best Practices
 
    The minimum requirements for generating UUIDs are described in this
    document for each version.  Everything else is an implementation
@@ -990,7 +648,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
    covered below to help guide an implementer through the different
    trade-offs among differing UUID implementations.
 
-8.1.  Timestamp Granularity
+6.1.  Timestamp Granularity
 
    UUID timestamp source, precision and length was the topic of great
    debate while creating this specification.  As such choosing the right
@@ -1003,18 +661,18 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
       increasing.  Care SHOULD be taken to ensure the timestamp does not
       move backwards which will impact UUID sorting.
 
+   Source:
+      UUID version 1 and 6 both utilize a Gregorian epoch timestamp
+      while UUIDv7 utilizes a Unix Epoch timestamp.  If other timestamp
+      sources or a custom timestamp epoch are required UUIDv8 SHOULD be
+      leveraged.
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 18]
+
+Peabody & Davis         Expires 17 September 2022              [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
-
-   Source:
-      UUID version 1 and 6 both utilize a Gregorian epoch timestamp
-      while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp.  If
-      other timestamp sources or a custom timestamp epoch are required
-      UUIDv8 or UUIDv8E SHOULD be leveraged.
 
    Sub-second Precision and Accuracy:
       Many levels of precision exist for timestamps: milliseconds,
@@ -1022,16 +680,16 @@ Internet-Draft               new-uuid-format                  March 2022
       representations of sub-second precision may be desired to mix
       various levels of precision in a time-ordered manner.  With UUID
       version 1 and 6, 100-nanoseconds of precision are present while
-      UUIDv7 and UUIDv7E features fixed millisecond level of precision
-      within the Unix epoch.  If additional levels of precision are
-      required UUIDv8 or UUIDv8E SHOULD be utilized.
+      UUIDv7 features fixed millisecond level of precision within the
+      Unix epoch.  If additional levels of precision are required UUIDv8
+      SHOULD be utilized.
 
    Length:
       The length of a given timestamp directly impacts how long a given
       UUID will be valid.  Care should be given to ensure that the
       proper length is selected for a given timestamp.  UUID version 1
-      and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a
-      48 bit timestamp.
+      and 6 utilize a 60 bit timestamp and UUIDv7 features a 48 bit
+      timestamp.
 
    Fuzzing:
       Implementations MAY fuzz a timestamp.  Some examples included
@@ -1044,34 +702,33 @@ Internet-Draft               new-uuid-format                  March 2022
       When timestamp padding is required, implementations MUST pad the
       most significant bits (left-most) bits with zeros.  An example is
       padding the most significant, left-most bits of a 32 bit Unix
-      timestamp with zero's to fill out the 48 bit timestamp in UUIDv7
-      and UUIDv7E.
+      timestamp with zero's to fill out the 48 bit timestamp in UUIDv7.
 
    Truncating:
       Similarly, when timestamps need to be truncated: the lower, least
       significant bits MUST be used.  An example would be truncating a
       64 bit Unix timestamp to the least significant, right-most 48 bits
-      for UUIDv7E.
+      for UUIDv7.
 
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 19]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-8.2.  Monotonicity and Counters
+6.2.  Monotonicity and Counters
 
    Monotonicity is the backbone of time-based sortable UUIDs.  Naturally
    time-based UUIDs from this document will be monotonic due to an
    embedded timestamp however implementations can guarantee additional
    monotonicity via the concepts covered in this section.
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 13]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    Additionally, care MUST be taken to ensure UUIDs generated in batches
    are also monotonic.  That is, if one-thousand UUIDs are generated for
@@ -1081,10 +738,10 @@ Internet-Draft               new-uuid-format                  March 2022
    increment for each UUID created during a given timestamp.
 
    For single-node UUID implementations that do not need to create
-   batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7,
-   and 7E can provide sufficient monotonicity guarantees by simply
+   batches of UUIDs, the embedded timestamp within UUID version 1, 6,
+   and 7 can provide sufficient monotonicity guarantees by simply
    ensuring that timestamp increments before creating a new UUID.  For
-   the topic of Distributed Nodes please refer to Section 8.3
+   the topic of Distributed Nodes please refer to Section 6.3
 
    Implementations SHOULD choose one method for single-node UUID
    implementations that require batch UUID creation.
@@ -1096,8 +753,8 @@ Internet-Draft               new-uuid-format                  March 2022
       Positioning of a fixed bit-length counter SHOULD be immediatly
       after the embedded timestamp.  This promotes sortability and
       allows random data generation for each counter increment.  With
-      this method the rand_a section of UUIDv7 and UUIDv7E MAY be
-      utilized as fixed-length dedicated counter bits.
+      this method the rand_a section of UUIDv7 MAY be utilized as fixed-
+      length dedicated counter bits.
 
    Monotonic Random (Method 2):
       With this method the random data is extended to also double as a
@@ -1107,9 +764,14 @@ Internet-Draft               new-uuid-format                  March 2022
       similar to the Fixed-Length Dedicated Counter Bits method
       described in the previous bullet but does not suffer from rollover
       issues, length problems, or wasted entropy bits plagued by fixed-
-      length counter bit positions.  As such, UUIDv7 and UUIDv7E SHOULD
-      utilize this method to handle batch UUID generation during a
-      single timestamp tick.
+      length counter bit positions.  As such, UUIDv7 SHOULD utilize this
+      method to handle batch UUID generation during a single timestamp
+      tick.  Furthermore, with this method the actual increment of the
+      counter MAY be a random integer of any desired length instead of
+      using simplistic "plus one" logic found with Fixed Length
+      Dedicated Counters.  This random increment of the counter ensures
+      the UUIDs retain the required level of unguessability characters
+      provided by the underlying entropy.
 
    The following sub-topics cover topics related solely with creating
    reliable fixed-length dedicated counters:
@@ -1117,7 +779,9 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 20]
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 14]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1153,13 +817,13 @@ Internet-Draft               new-uuid-format                  March 2022
 
    Fixed-Length Dedicated Counter Rollover Handling
       Counter rollovers SHOULD be handled by the application to avoid
-      sorting issues.  The general guidance is that applications SHOULD
-      freeze the counter and wait for the timestamp to advance which
-      ensures monotonicity is not broken.  The technique from Fixed-
-      Length Dedicated Counter Seeding which describes allocating a
-      segment of the fixed-length counter as a rollover guard is also
-      recommended and SHOULD be employed to help mitigate counter
-      rollover issues.
+      sorting issues.  The general guidance is that applications that
+      care about absolute monotonicity and sortability SHOULD freeze the
+      counter and wait for the timestamp to advance which ensures
+      monotonicity is not broken.  The technique from Fixed-Length
+      Dedicated Counter Seeding which describes allocating a segment of
+      the fixed-length counter as a rollover guard is also recommended
+      and SHOULD be employed to help mitigate counter rollover issues.
 
    Implementations MAY use the following logic to ensure UUIDs featuring
    embedded counters are monotonic in nature:
@@ -1173,7 +837,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 21]
+Peabody & Davis         Expires 17 September 2022              [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1195,7 +859,7 @@ Internet-Draft               new-uuid-format                  March 2022
    in the form of "clock sequence" bits.  The usage of the clock
    sequence will remain as defined in [RFC4122], Section 4.1.5.
 
-8.3.  Distributed UUID Generation
+6.3.  Distributed UUID Generation
 
    Some implementations MAY desire to utilize multi-node, clustered,
    applications which involve two or more applications independently
@@ -1220,16 +884,16 @@ Internet-Draft               new-uuid-format                  March 2022
       space for a given node is unique resulting in UUIDs that do not
       conflict with any other UUID created by another node with a
       different node id.  Implementations that choose to leverage an
-      embedded node id SHOULD utilize UUIDv8E.  The node id SHOULD NOT
-      be an IEEE 802 MAC address as per Section 10.  The location and
-      bit length are up to implements and outside the scope of this
+      embedded node id SHOULD utilize UUIDv8.  The node id SHOULD NOT be
+      an IEEE 802 MAC address as per Section 8.  The location and bit
+      length are up to implements and outside the scope of this
       specification.  Furthermore, the creation and negotiation of a
       node id among distributed nodes is also out of scope for this
       specification.
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 22]
+Peabody & Davis         Expires 17 September 2022              [Page 16]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1239,14 +903,14 @@ Internet-Draft               new-uuid-format                  March 2022
    implementations SHOULD utilize one of the two aforementioned methods
    if distributed UUID generation is a requirements.
 
-8.4.  Collision Resistance
+6.4.  Collision Resistance
 
    Implementations SHOULD weigh the importance of a collision within
    their application and take this into account when making a selections
    around the total entropy (random) to dedicated to a UUID layout
-   versus the other components such as Section 8.1 and Section 8.2.
+   versus the other components such as Section 6.1 and Section 6.2.
    This is especially true for distributed node collision resistance as
-   defined by Section 8.3.
+   defined by Section 6.3.
 
    There are two example scenarios below which help illustrate the
    varying seriousness of a collision within an application.
@@ -1265,7 +929,7 @@ Internet-Draft               new-uuid-format                  March 2022
       scenario MUST employ as much collision resistance as possible
       within the given application context.
 
-8.5.  Global and Local Uniqueness
+6.5.  Global and Local Uniqueness
 
    UUIDs created by this specification MAY be used to provide local
    uniqueness guarantees.  For example, ensuring UUIDs created within a
@@ -1277,7 +941,7 @@ Internet-Draft               new-uuid-format                  March 2022
    Although true global uniqueness is impossible to guarantee without
    shared knowledge scheme; a shared knowledge scheme is not required by
    UUID to provide uniqueness guarantees.  Implementations MAY implement
-   a shared knowledge scheme introduced in Section 8.3 as they see fit
+   a shared knowledge scheme introduced in Section 6.3 as they see fit
    to extend the uniqueness guaranteed this specification and [RFC4122].
 
 
@@ -1285,27 +949,27 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 23]
+Peabody & Davis         Expires 17 September 2022              [Page 17]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-8.6.  Unguessability
+6.6.  Unguessability
 
    Implementations SHOULD utilize a cryptographically secure pseudo-
    random number generator (CSPRNG) to provide values that are both
    difficult to predict ("unguessable") and have a low likelihood of
-   collision ("unique").  CSPRNG ensures the best of Section 8.4 and
-   Section 10 are present in modern UUIDs.
+   collision ("unique").  CSPRNG ensures the best of Section 6.4 and
+   Section 8 are present in modern UUIDs.
 
    Advice on generating cryptographic-quality random numbers can be
    found in [RFC4086]
 
-8.7.  Sorting
+6.7.  Sorting
 
-   UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that
-   require sorting (e.g. database indexes) SHOULD sort as opaque raw
-   bytes, without examining the contents at all.
+   UUIDv6 and UUIDv7 are designed so that implementations that require
+   sorting (e.g. database indexes) SHOULD sort as opaque raw bytes,
+   without examining the contents at all.
 
    Time ordered monotonic UUIDs benefit from greater index locality
    because the new values are near each other in the index.  As a result
@@ -1318,9 +982,9 @@ Internet-Draft               new-uuid-format                  March 2022
 
    UUIDs created by this specification are crafted with big-ending byte
    order (network byte order) in mind.  If Little-endian style is
-   required a custom UUID format SHOULD be created using UUIDv8E.
+   required a custom UUID format SHOULD be created using UUIDv8.
 
-8.8.  Opacity
+6.8.  Opacity
 
    UUIDs SHOULD be treated as opaque values and implementations SHOULD
    NOT examine the bits in a UUID to whatever extent is possible.
@@ -1328,7 +992,7 @@ Internet-Draft               new-uuid-format                  March 2022
    information on determining a UUID version based on the inspected
    variant bits.
 
-8.9.  DBMS and Database Considerations
+6.9.  DBMS and Database Considerations
 
    For many applications, such as databases, storing UUIDs as the text
    is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID
@@ -1341,7 +1005,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 24]
+Peabody & Davis         Expires 17 September 2022              [Page 18]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1365,16 +1029,16 @@ Internet-Draft               new-uuid-format                  March 2022
    in indexes.  In addition to UUIDs, additional identifiers MAY be used
    to ensure integrity and feedback.
 
-9.  IANA Considerations
+7.  IANA Considerations
 
    This document has no IANA actions.
 
-10.  Security Considerations
+8.  Security Considerations
 
    MAC addresses pose inherent security risks and SHOULD not be used
    within a UUID.  Instead CSPRNG data SHOULD selected from a source
    with sufficient entropy to ensure guaranteed uniqueness among UUID
-   generation.  See Section 8.6 for more information.
+   generation.  See Section 6.6 for more information.
 
    Timestamps embedded in the UUID do pose a very small attack surface.
    The timestamp in conjunction with an embedded counter does signal the
@@ -1384,7 +1048,7 @@ Internet-Draft               new-uuid-format                  March 2022
    within an application context in any shape or form then [RFC4122]
    UUIDv4 SHOULD be utilized.
 
-11.  Acknowledgements
+9.  Acknowledgements
 
    The authors gratefully acknowledge the contributions of Ben Campbell,
    Ben Ramsey, Fabio Lima, Gonzalo Salgueiro, Martin Thomson, Murray S.
@@ -1393,11 +1057,11 @@ Internet-Draft               new-uuid-format                  March 2022
    those in the IETF community and on GitHub to who contributed to the
    discussions which resulted in this document.
 
-12.  Normative References
+10.  Normative References
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 25]
+Peabody & Davis         Expires 17 September 2022              [Page 19]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1425,7 +1089,7 @@ Internet-Draft               new-uuid-format                  March 2022
               Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
               <https://www.rfc-editor.org/info/rfc4122>.
 
-13.  Informative References
+11.  Informative References
 
    [LexicalUUID]
               Twitter, "A Scala client for Cassandra", commit f6da4e0,
@@ -1453,7 +1117,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 26]
+Peabody & Davis         Expires 17 September 2022              [Page 20]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1509,7 +1173,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 27]
+Peabody & Davis         Expires 17 September 2022              [Page 21]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1551,86 +1215,30 @@ A.1.  Creating a UUIDv6 Value
 
    }
 
-                      Figure 11: UUIDv6 Function in C
+                       Figure 6: UUIDv6 Function in C
 
-A.2.  Creating a UUIDv7E Value
+A.2.  Creating a UUIDv7 Value
 
+   TODO UUIDv7
 
-
-
-
-
+                       Figure 7: UUIDv7 Function in C
 
 
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 28]
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 22]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
+A.3.  Creating a UUIDv8 Value
 
-// ...
-
-// csprng data source
-FILE *rndf;
-rndf = fopen("/dev/urandom", "r");
-if (rndf == 0) {
-        printf("fopen /dev/urandom error\n");
-        return 1;
-}
-
-// ...
-
-// generate one UUIDv7E
-uint8_t u[16];
-struct timespec ts;
-int ret;
-
-ret = clock_gettime(CLOCK_REALTIME, &ts);
-if (ret != 0) {
-        printf("clock_gettime error: %d\n", ret);
-        return 1;
-}
-
-uint64_t tms;
-
-tms = ((uint64_t)ts.tv_sec) * 1000;
-tms += ((uint64_t)ts.tv_nsec) / 1000000;
-
-printf("tms: %lld\n", tms);
-
-memset(u, 0, 16);
-
-fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
-
-*((uint64_t*)(u)) |= htonll(tms << 16); // shift time into first 48 bits and OR into place
-
-u[8] = 0xE7; // set var-ver field
-
-                   Figure 12: UUIDv7E Function in C
-
-
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 29]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-A.3.  Creating a UUIDv8E Value
-
-   UUIDv8E will vary greatly from implementation to implementation.  A
-   good candidate use case for UUIDv8E is to embed exotic timestamps
-   like the one found in this example which employs approximately 0.25
+   UUIDv8 will vary greatly from implementation to implementation.  A
+   good candidate use case for UUIDv8 is to embed exotic timestamps like
+   the one found in this example which employs approximately 0.25
    milliseconds and approximately 5 microseconds per timestamp tick as a
    48 bit value.
 
@@ -1650,7 +1258,7 @@ A.3.  Creating a UUIDv8E Value
      return 0;
    }
 
-                       Figure 13: UUID8 Function in C
+                       Figure 8: UUIDv8 Function in C
 
 Appendix B.  Test Vectors
 
@@ -1677,7 +1285,7 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 30]
+Peabody & Davis         Expires 17 September 2022              [Page 23]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1705,7 +1313,7 @@ gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 # UUIDv1:   11000010001100101010101100000000|1001010000010100|0001|000111101100
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 
-             Figure 14: Test Vector Timestamp Pseudo-code
+             Figure 9: Test Vector Timestamp Pseudo-code
 
 B.1.  Example of a UUIDv6 Value
 
@@ -1723,7 +1331,7 @@ B.1.  Example of a UUIDv6 Value
    ----------------------------------------------
    final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 
-                   Figure 15: UUIDv1 Example Test Vector
+                   Figure 10: UUIDv1 Example Test Vector
 
 
 
@@ -1733,7 +1341,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 31]
+Peabody & Davis         Expires 17 September 2022              [Page 24]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1752,7 +1360,7 @@ Internet-Draft               new-uuid-format                  March 2022
    -----------------------------------------------
    final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 
-                   Figure 16: UUIDv6 Example Test Vector
+                   Figure 11: UUIDv6 Example Test Vector
 
 B.2.  Example of a UUIDv7 Value
 
@@ -1777,45 +1385,22 @@ B.2.  Example of a UUIDv7 Value
    -------------------------------
    final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
 
-                   Figure 17: UUIDv7 Example Test Vector
+                   Figure 12: UUIDv7 Example Test Vector
 
-B.3.  Example of a UUIDv7E Value
-
-   This example UUIDv7E test vector utilizes a well-known 32-bit Unix
-   epoch with additional millisecond precision to fill the first 48 bits
-
-   rand_a and rand_b are filled with random data.
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 32]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00
-   represented as 0x17F21CFD130 or 1645539742000
-
-   -------------------------------
-   field      bits    value
-   -------------------------------
-   unix_ts_ms   48    0x017F21CFD130
-   rand_a       16    0xF8B8
-   var_ver       8    0xE7
-   rand_b       56    0xD6A139DC9535C5
-   -------------------------------
-   total       128
-   -------------------------------
-   final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
-
-                   Figure 18: UUIDv7E Example Test Vector
-
-B.4.  Example of a UUIDv8 Value
+B.3.  Example of a UUIDv8 Value
 
    This example UUIDv8 test vector utilizes a well-known 64-bit Unix
    epoch with nanosecond precision, truncated to the least-significant
    (right-most) bits to fill the first 48 bits through version.
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 25]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    The next two segments of custom_b and custmo_c are are filled with
    random data.
@@ -1824,7 +1409,7 @@ B.4.  Example of a UUIDv8 Value
    represented as 0x16D6320C3D4DCC00 or 1645557742000000000
 
    It should be noted that this example is just to illustrate one
-   scenario for UUIDv8E.  Test vectors will likely be implementation
+   scenario for UUIDv8.  Test vectors will likely be implementation
    specific and vary greatly from this simple example.
 
    -------------------------------
@@ -1840,43 +1425,7 @@ B.4.  Example of a UUIDv8 Value
    -------------------------------
    final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
 
-                   Figure 19: UUIDv8E Example Test Vector
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 33]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-B.5.  Example of a UUIDv8E Value
-
-   This example UUIDv8E test vector utilizes a well-known 64-bit Unix
-   epoch with nanosecond precision to fill the first 64 bits through
-   ver_var.
-
-   The final 56 bits are filled with random data.
-
-   Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00
-   represented as 0x16D6320C3D4DCC00 or 1645557742000000000
-
-   It should be noted that this example is just to illustrate one
-   scenario for UUIDv8E.  Test vectors will likely be implementation
-   specific and vary greatly from this simple example.
-
-   -------------------------------
-   field      bits    value
-   -------------------------------
-   custom_a     64    0x16D6320C3D4DCC00
-   var_ver       8    0xE8
-   custom_b     56    0x3C2D06302FC417
-   -------------------------------
-   total       128
-   -------------------------------
-   final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
-
-                   Figure 20: UUIDv8E Example Test Vector
+                   Figure 13: UUIDv8 Example Test Vector
 
 Appendix C.  Version and Variant Tables
 
@@ -1898,17 +1447,17 @@ C.1.  Variant 10xx Versions
    | 0    | 0    | 1    | 1    | 3       | The name-based version     |
    |      |      |      |      |         | specified in [RFC4122],    |
    |      |      |      |      |         | Section 4.1.3 that uses    |
+   |      |      |      |      |         | MD5 hashing.               |
+   +------+------+------+------+---------+----------------------------+
+   | 0    | 1    | 0    | 0    | 4       | The randomly or pseudo-    |
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 34]
+Peabody & Davis         Expires 17 September 2022              [Page 26]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-   |      |      |      |      |         | MD5 hashing.               |
-   +------+------+------+------+---------+----------------------------+
-   | 0    | 1    | 0    | 0    | 4       | The randomly or pseudo-    |
    |      |      |      |      |         | randomly generated version |
    |      |      |      |      |         | specified in [RFC4122],    |
    |      |      |      |      |         | Section 4.1.3.             |
@@ -1952,86 +1501,19 @@ Internet-Draft               new-uuid-format                  March 2022
    |      |      |      |      |         | definition.                |
    +------+------+------+------+---------+----------------------------+
 
-           Table 5: All UUID variant 10xx version definitions.
-
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 35]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-C.2.  Variant 1110 Versions
-
-   +------+------+------+------+---------+-----------------------------+
-   | Msb0 | Msb1 | Msb2 | Msb3 | Version | Description                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 0    | 0    | 0    | 0E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 0    | 0    | 1    | 1E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 0    | 1    | 0    | 2E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 0    | 1    | 1    | 3E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 0    | 0    | 4E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 0    | 1    | 5E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 1    | 0    | 6E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 1    | 1    | 7E      | Alternate Unix Epoch        |
-   |      |      |      |      |         | time-based UUID specified   |
-   |      |      |      |      |         | in this document.           |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 0    | 0    | 8E      | Alternate reservation for   |
-   |      |      |      |      |         | custom UUID formats         |
-   |      |      |      |      |         | specified in this           |
-   |      |      |      |      |         | document.                   |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 0    | 1    | 9E      | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 1    | 0    | 10E     | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 1    | 1    | 11E     | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 1    | 0    | 0    | 12E     | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 1    | 0    | 1    | 13E     | Reserved for future         |
-
-
-
-Peabody & Davis         Expires 15 September 2022              [Page 36]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 1    | 1    | 0    | 14E     | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-   | 1    | 1    | 1    | 1    | 15E     | Reserved for future         |
-   |      |      |      |      |         | definition.                 |
-   +------+------+------+------+---------+-----------------------------+
-
-            Table 6: All UUID variant 1110 version definitions.
+      Table 3: All UUID variant 10xx (8/9/A/B) version definitions.
 
 Authors' Addresses
 
    Brad G. Peabody
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 27]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    Email: brad@peabody.io
 
 
@@ -2069,4 +1551,18 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 15 September 2022              [Page 37]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 17 September 2022              [Page 28]

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                            4 March 2022
-Expires: 5 September 2022
+Intended status: Standards Track                            9 March 2022
+Expires: 10 September 2022
 
 
                             New UUID Formats
@@ -14,19 +14,9 @@ Expires: 5 September 2022
 
 Abstract
 
-   This document presents three new Universally Unique Identifier (UUID)
-   formats.
-
-   A common case for modern applications is to create a unique
-   identifier for use as a database key.  This identifier usually
-   implements an embedded timestamp that is sortable using the monotonic
-   creation time in the most significant bits.  In addition the
-   identifier is highly collision resistant, difficult to guess, and
-   provides minimal security attack surfaces.  None of the existing UUID
-   versions, including UUIDv1, fulfill each of these requirements in the
-   most efficient possible way.  This document is a proposal to update
-   [RFC4122] with three new UUID versions that address these concerns,
-   each with different trade-offs.
+   This document presents new Universally Unique Identifier (UUID)
+   formats, variants, and encoding techniques for use in modern
+   applications and databases.
 
 Status of This Memo
 
@@ -43,20 +33,12 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 September 2022.
+   This Internet-Draft will expire on 10 September 2022.
 
 Copyright Notice
 
    Copyright (c) 2022 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
-
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 1]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents (https://trustee.ietf.org/
@@ -67,54 +49,72 @@ Internet-Draft               new-uuid-format                  March 2022
    described in Section 4.e of the Trust Legal Provisions and are
    provided without warranty as described in the Revised BSD License.
 
-Table of Contents
-
-   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   4
-     2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   5
-     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Summary of Changes  . . . . . . . . . . . . . . . . . . . . .   5
-     3.1.  changelog . . . . . . . . . . . . . . . . . . . . . . . .   5
-   4.  Format  . . . . . . . . . . . . . . . . . . . . . . . . . . .   7
-     4.1.  Variant and Version Fields  . . . . . . . . . . . . . . .   7
-     4.2.  UUID Version 6  . . . . . . . . . . . . . . . . . . . . .   9
-     4.3.  UUID Version 7E . . . . . . . . . . . . . . . . . . . . .  11
-     4.4.  UUID Version 8E . . . . . . . . . . . . . . . . . . . . .  12
-     4.5.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  13
-   5.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  14
-     5.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  14
-     5.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  15
-     5.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  17
-     5.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  18
-     5.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  19
-     5.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  19
-     5.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     5.8.  Storing UUIDs, Opacity  . . . . . . . . . . . . . . . . .  20
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
-   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  21
-   9.  Normative References  . . . . . . . . . . . . . . . . . . . .  21
-   10. Informative References  . . . . . . . . . . . . . . . . . . .  21
-   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  23
-     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  23
-     A.2.  Creating a UUIDv7E Value  . . . . . . . . . . . . . . . .  24
-     A.3.  Creating a UUIDv8E Value  . . . . . . . . . . . . . . . .  25
-   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  25
-     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  26
-     B.2.  Example of a UUIDv7E Value  . . . . . . . . . . . . . . .  27
-     B.3.  Example of a UUIDv8E Value  . . . . . . . . . . . . . . .  27
-   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  28
-     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  28
-     C.2.  Variant 1110 Versions . . . . . . . . . . . . . . . . . .  29
 
 
 
-Peabody & Davis         Expires 5 September 2022                [Page 2]
+
+Peabody & Davis         Expires 10 September 2022               [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  31
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   5
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   5
+   3.  Summary of Changes  . . . . . . . . . . . . . . . . . . . . .   5
+     3.1.  changelog . . . . . . . . . . . . . . . . . . . . . . . .   6
+   4.  Variant and Version Fields  . . . . . . . . . . . . . . . . .   7
+   5.  New Formats . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     5.1.  UUID Version 6  . . . . . . . . . . . . . . . . . . . . .  10
+     5.2.  UUID Version 7  . . . . . . . . . . . . . . . . . . . . .  12
+     5.3.  UUID Version 8  . . . . . . . . . . . . . . . . . . . . .  13
+   6.  Alternate Variants  . . . . . . . . . . . . . . . . . . . . .  14
+     6.1.  UUID Version 7E . . . . . . . . . . . . . . . . . . . . .  14
+     6.2.  UUID Version 8E . . . . . . . . . . . . . . . . . . . . .  15
+   7.  Alternate Formats . . . . . . . . . . . . . . . . . . . . . .  16
+     7.1.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  16
+     7.2.  UUID Long . . . . . . . . . . . . . . . . . . . . . . . .  16
+     7.3.  Alternate Encodings . . . . . . . . . . . . . . . . . . .  17
+   8.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  18
+     8.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  18
+     8.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  20
+     8.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  22
+     8.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  23
+     8.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  23
+     8.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  23
+     8.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  24
+     8.8.  Opacity . . . . . . . . . . . . . . . . . . . . . . . . .  24
+     8.9.  DBMS and Database Considerations  . . . . . . . . . . . .  24
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  25
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  25
+   11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  25
+   12. Normative References  . . . . . . . . . . . . . . . . . . . .  25
+   13. Informative References  . . . . . . . . . . . . . . . . . . .  26
+   Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  27
+     A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  27
+     A.2.  Creating a UUIDv7E Value  . . . . . . . . . . . . . . . .  28
+     A.3.  Creating a UUIDv8E Value  . . . . . . . . . . . . . . . .  30
+   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  30
+     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  31
+     B.2.  Example of a UUIDv7 Value . . . . . . . . . . . . . . . .  32
+     B.3.  Example of a UUIDv7E Value  . . . . . . . . . . . . . . .  32
+     B.4.  Example of a UUIDv8 Value . . . . . . . . . . . . . . . .  33
+     B.5.  Example of a UUIDv8E Value  . . . . . . . . . . . . . . .  34
+   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  34
+     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  34
+     C.2.  Variant 1110 Versions . . . . . . . . . . . . . . . . . .  36
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 2]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  37
 
 1.  Introduction
 
@@ -122,8 +122,8 @@ Internet-Draft               new-uuid-format                  March 2022
    created.  Modern applications have a need to create and utilize UUIDs
    as the primary identifier for a variety of different items in complex
    computational systems, including but not limited to database keys,
-   file names, machine or system names, identifiers for transactions or
-   other objects or processes.
+   file names, machine or system names, identifiers for event-driven
+   transactions, and other objects or processes.
 
    A specific use case for UUIDs which has gained popularity is as
    database keys.  The motivation for this stems primarily from the fact
@@ -153,7 +153,24 @@ Internet-Draft               new-uuid-format                  March 2022
        opposed to being able to perform a simple byte-by-byte
        comparison.
 
-   4.  Privacy and network security issues arise from using a MAC
+   4.  The textual representation of existing UUIDs utilized for storage
+       or transport is oftentimes unnecessarily verbose.
+
+   5.  The 128 bit length of current UUIDs oftentimes leads to
+       alternative unique identifier solutions featuring longer bit
+       lengths.
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 3]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   6.  Privacy and network security issues arise from using a MAC
        address in the node field of Version 1 UUIDs.  Exposed MAC
        addresses can be used as an attack surface to locate machines and
        reveal various other information about such machines (minimally
@@ -161,23 +178,14 @@ Internet-Draft               new-uuid-format                  March 2022
        advent of virtual machines and containers, MAC address uniqueness
        is no longer guaranteed.
 
+   7.  Many of the implementation details specified in [RFC4122] involve
+       trade offs that are neither possible to specify for all
+       applications nor necessary to produce interoperable
+       implementations.
 
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 3]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   5.  Many implementation details are specified in [RFC4122] but some
-       of the decisions made involve trade offs that are neither
-       possible to specify for all applications nor necessary to produce
-       interoperable implementations.
-
-   6.  The previous specification also does not distinguish between the
-       requirements for generation of a UUID versus an application which
-       simply stores one, which are different.
+   8.  [RFC4122] does not distinguish between the requirements for
+       generation of a UUID versus an application which simply stores
+       one, which are often different.
 
    Due to the aforementioned issue, many widely distributed database
    applications and large application vendors have sought to solve the
@@ -209,22 +217,20 @@ Internet-Draft               new-uuid-format                  March 2022
    15.  [ObjectID] by MongoDB
    16.  [CUID] by E.  Elliott
 
+
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 4]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    An inspection of these implementations and the issues described above
    has led to this document which attempts to adapt UUIDs to address
    these issues.
 
 2.  Terminology
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 4]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
 2.1.  Requirements Language
 
@@ -246,21 +252,46 @@ Internet-Draft               new-uuid-format                  March 2022
 
    MSB           Most Significant Bit
 
+   DBMS          Database Management System
+
 3.  Summary of Changes
 
    The following UUIDs are hereby introduced:
 
-   1.  UUID version 6: A re-ordering of UUID version 1 so it is sortable
-       as an opaque sequence of bytes.  Easy to implement given an
-       existing UUIDv1 implementation.  See Section 4.2
-   2.  UUID version 7E: An entirely new time-based UUID bit layout
-       sourced from the widely implemented and well known Unix Epoch
-       timestamp source.  See Section 4.3
-   3.  UUID version 8E: A free-form UUID format which has no explicit
-       requirements except maintaining backward compatibility.  See
-       Section 4.4
-   4.  Max UUID: A specialized UUID which is the inverse of [RFC4122],
-       Section 4.1.7 See Section 4.5
+   UUID version 6 (UUIDv6)
+      A re-ordering of UUID version 1 so it is sortable as an opaque
+      sequence of bytes.  Easy to implement given an existing UUIDv1
+      implementation.  See Section 5.1
+
+   UUID version 7 (UUIDv7)
+      An entirely new time-based UUID bit layout sourced from the widely
+      implemented and well known Unix Epoch timestamp source.  See
+      Section 5.2
+
+   UUID version 7E (UUIDv7E)
+      An alternate format for UUIDv7.  See Section 6.1
+
+   UUID version 8 (UUIDv8)
+      A free-form UUID format which has no explicit requirements except
+      maintaining backward compatibility.  See Section 5.3
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 5]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   UUID version 8E (UUIDv8E)
+      An alternate format for UUIDv8.  See Section 6.2
+
+   Max UUID
+      A specialized UUID which is the inverse of [RFC4122],
+      Section 4.1.7 See Section 7.1
+
+   UUID Long
+      An extension of the base UUID with variable length beyond 128
+      bits.  See Section 7.2
 
 3.1.  changelog
 
@@ -270,19 +301,14 @@ Internet-Draft               new-uuid-format                  March 2022
 
       - Reworked the draft body to make the content more concise
       - UUIDv6 section reworked to just the reorder of the timestamp
-      - UUIDv7E changed to simplify timestamp mechanism to just
-      millisecond unix timestamp
-      - UUIDv8E relaxed to be custom in all elements except version and
+      - UUIDv7 changed to simplify timestamp mechanism to just
+      millisecond Unix timestamp
+      - UUIDv8 relaxed to be custom in all elements except version and
       variant
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 5]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
       - Changed UUIDv7E and UUIDv8E to use Variant 111.
+      - Introduced Max UUID.
+      - Re-introduced variable length UUIDs as UUID Long.
+      - Re-introduced alternate encoding techniques for all UUIDs.
       - Added C code samples in Appendix.
       - Added test vectors in Appendix.
       - Version and Variant section combined into one section.
@@ -294,8 +320,8 @@ Internet-Draft               new-uuid-format                  March 2022
       - Combined redundant topics from all UUIDs into sections such as
       Timestamp granularity, Monotonicity and Counters, Collision
       Resistance, Sorting, and Unguessability, etc.
-      - Node verbiage only used in UUIDv6 and v7E and v8E reference
-      random instead
+      - Node verbiage only used in UUIDv6 all others reference random/
+      rand instead
       - Clock sequence verbiage changed simply to counter in any section
       other than UUIDv6
       - Added Abbreviations section
@@ -304,6 +330,14 @@ Internet-Draft               new-uuid-format                  March 2022
 
    draft-02
 
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 6]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
       - Added Changelog
       - Fixed misc. grammatical errors
       - Fixed section numbering issue
@@ -311,9 +345,9 @@ Internet-Draft               new-uuid-format                  March 2022
       - Changed all instances of "motonic" to "monotonic"
       - Changed all instances of "#-bit" to "# bit"
       - Changed "proceeding" verbiage to "after" in section 7
-      - Added details on how to pad 32 bit unix timestamp to 36 bits in
+      - Added details on how to pad 32 bit Unix timestamp to 36 bits in
       UUIDv7
-      - Added details on how to truncate 64 bit unix timestamp to 36
+      - Added details on how to truncate 64 bit Unix timestamp to 36
       bits in UUIDv7
       - Added forward reference and bullet to UUIDv8 if truncating 64
       bit Unix Epoch is not an option.
@@ -328,16 +362,6 @@ Internet-Draft               new-uuid-format                  March 2022
       standards.
       - Removed the topics of UUID length modification, alternate UUID
       text formats, and alternate UUID encoding techniques.
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 6]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
       - Research into 16 different historical and current
       implementations of time-based universal identifiers was completed
       at the end of 2020 in attempt to identify trends which have
@@ -347,13 +371,7 @@ Internet-Draft               new-uuid-format                  March 2022
       and UUIDv8 in various languages by many GitHub community members.
       (https://github.com/uuid6/prototypes)
 
-4.  Format
-
-   The UUID format is 16 octets; The variant bits in conjunction with
-   the version bits described in the next section in determine finer
-   structure.
-
-4.1.  Variant and Version Fields
+4.  Variant and Version Fields
 
    The variant bits utilized by UUIDs in this specification remain in
    the same octet as originally defined by [RFC4122], Section 4.1.1.
@@ -368,6 +386,14 @@ Internet-Draft               new-uuid-format                  March 2022
    of the version within the same octet as the variant leaves room for a
    future variant as described below:
 
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 7]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    *  UUID Version 7E and 8E specified by this document MUST set the
       first 3 bits of octet 8 to 111 and the fourth bit to 0.  The 4 bit
       version MUST follow the variant to fill out the final bits of
@@ -380,28 +406,14 @@ Internet-Draft               new-uuid-format                  March 2022
    The table below detail the three variants described in this document
    where the letter "x" indicates a "don't-care" value.
 
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 7]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
     +------+------+------+------+---------+---------------------------+
     | Msb0 | Msb1 | Msb2 | Msb3 | Hex     | Description               |
     +------+------+------+------+---------+---------------------------+
     | 1    | 0    | x    | x    | 8/9/A/B | The variant specified by  |
     |      |      |      |      |         | [RFC4122], Section 4.1.1. |
     +------+------+------+------+---------+---------------------------+
-    | 1    | 1    | 1    | 0    | E       | The variant specified in  |
-    |      |      |      |      |         | this document.            |
+    | 1    | 1    | 1    | 0    | E       | The new variant specified |
+    |      |      |      |      |         | in this document.         |
     +------+------+------+------+---------+---------------------------+
     | 1    | 1    | 1    | 1    | F       | Reserved for future       |
     |      |      |      |      |         | definition.               |
@@ -412,9 +424,31 @@ Internet-Draft               new-uuid-format                  March 2022
    UUID Versions defined within the RFC 4122 Variant are distinct from
    UUID versions defined by the new variant.
 
-   The next table details Variant 10xx and the new versions defined by
-   this specification.  A complete guide to all versions within this
-   variant has been includes in Appendix C.1.
+   The next table details Variant 10xx (8/9/A/B) and the new versions
+   defined by this specification.  A complete guide to all versions
+   within this variant has been includes in Appendix C.1.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 8]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
     +------+------+------+------+---------+---------------------------+
     | Msb0 | Msb1 | Msb2 | Msb3 | Version | Description               |
@@ -423,14 +457,21 @@ Internet-Draft               new-uuid-format                  March 2022
     |      |      |      |      |         | based UUID specified in   |
     |      |      |      |      |         | this document.            |
     +------+------+------+------+---------+---------------------------+
+    | 0    | 1    | 1    | 1    | 7       | Unix Epoch time-based     |
+    |      |      |      |      |         | UUID specified in this    |
+    |      |      |      |      |         | document.                 |
+    +------+------+------+------+---------+---------------------------+
+    | 1    | 0    | 0    | 0    | 8       | Reserved for custom UUID  |
+    |      |      |      |      |         | formats specified in this |
+    |      |      |      |      |         | document                  |
+    +------+------+------+------+---------+---------------------------+
 
-          Table 2: New UUID variant 10xx versions defined by this
+     Table 2: New UUID variant 10xx (8/9/A/B) versions defined by this
                                specification
 
-   For UUIDv6 the version and variant field placement from [RFC4122] are
-   unchanged and a new version (0110b [6]) has been added.  An example
-   version/variant layout for UUIDv6 follows the table where M is the
-   version and N is the variant.
+   For UUID version 6, 7 and 8 the variant field placement from
+   [RFC4122] are unchanged.  An example version/variant layout for
+   UUIDv6 follows the table where M is the version and N is the variant.
 
    00000000-0000-6000-8000-000000000000
    00000000-0000-6000-9000-000000000000
@@ -440,33 +481,45 @@ Internet-Draft               new-uuid-format                  March 2022
 
                      Figure 1: UUIDv6 Variant Examples
 
+   The next table details Variant 1110 (E) and the new versions defined
+   by this specification.  A complete guide to all versions within this
+   variant has been includes in Appendix C.2.
 
 
 
 
 
-Peabody & Davis         Expires 5 September 2022                [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022               [Page 9]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-   The next table details Variant 110 and the new versions defined by
-   this specification.  A complete guide to all versions within this
-   variant has been includes in Appendix C.2.
-
    +------+------+------+------+---------+-----------------------------+
    | Msb0 | Msb1 | Msb2 | Msb3 | Version | Description                 |
    +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 1    | 1    | 7E      | Unix Epoch time-based       |
-   |      |      |      |      |         | UUID specified in this      |
+   | 0    | 1    | 1    | 1    | 7E      | Alternate Unix Epoch        |
+   |      |      |      |      |         | time-based UUID specified   |
+   |      |      |      |      |         | in this document.           |
+   +------+------+------+------+---------+-----------------------------+
+   | 1    | 0    | 0    | 0    | 8E      | Alternate reservation for   |
+   |      |      |      |      |         | custom UUID formats         |
+   |      |      |      |      |         | specified in this           |
    |      |      |      |      |         | document.                   |
    +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 0    | 0    | 8E      | Reserved for custom         |
-   |      |      |      |      |         | UUID formats specified      |
-   |      |      |      |      |         | in this document            |
-   +------+------+------+------+---------+-----------------------------+
 
-     Table 3: UUID variant 1110 versions defined by this specification
+   Table 3: UUID variant 1110 (E) versions defined by this specification
 
    For UUID versions 7E and 8E, the variant field has been incremented
    and the version field has been moved to the same octet as the
@@ -485,23 +538,26 @@ Internet-Draft               new-uuid-format                  March 2022
 
              Figure 2: UUID version 7E and 8E Variant Examples
 
-4.2.  UUID Version 6
+5.  New Formats
+
+   The UUID format is 16 octets; The variant bits in conjunction with
+   the version bits described in the next section in determine finer
+   structure.
+
+5.1.  UUID Version 6
 
    UUID version 6 is a field-compatible version of UUIDv1, reordered for
    improved DB locality.  It is expected that UUIDv6 will primarily be
    used in contexts where there are existing v1 UUIDs.  Systems that do
-   not involve legacy UUIDv1 SHOULD consider using UUIDv7E instead.
+   not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E
+   instead.
 
 
 
 
 
 
-
-
-
-
-Peabody & Davis         Expires 5 September 2022                [Page 9]
+Peabody & Davis         Expires 10 September 2022              [Page 10]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -520,7 +576,7 @@ Internet-Draft               new-uuid-format                  March 2022
    The 48 bit node SHOULD be set to a pseudo-random value however
    implementations MAY choose retain the old MAC address behavior from
    [RFC4122], Section 4.1.6 and [RFC4122], Section 4.5.  For more
-   information on MAC address usage within UUIDs see the Section 7
+   information on MAC address usage within UUIDs see the Section 10
 
    The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1
 
@@ -557,7 +613,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 10]
+Peabody & Davis         Expires 10 September 2022              [Page 11]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -596,13 +652,14 @@ Internet-Draft               new-uuid-format                  March 2022
                      Table 4: UUIDv1 to UUIDv6 Field
                                  Mappings
 
-4.3.  UUID Version 7E
+5.2.  UUID Version 7
 
-   UUID version 7E features a time-ordered value field derived from the
+   UUID version 7 features a time-ordered value field derived from the
    widely implemented and well known Unix Epoch timestamp source, as
    well as improved entropy characteristics over versions 1 or 6.
-   Implementations SHOULD utilize UUID version 7E over UUID version 1
-   and 6 if possible.
+
+   Implementations SHOULD utilize UUID version 7 over UUID version 1 and
+   6 if possible.
 
 
 
@@ -612,11 +669,126 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-
-Peabody & Davis         Expires 5 September 2022               [Page 11]
+Peabody & Davis         Expires 10 September 2022              [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           unix_ts_ms                          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |          unix_ts_ms           |  ver  |       rand_a          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |var|                        rand_b                             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                            rand_b                             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                   Figure 4: UUIDv7 Field and Bit Layout
+
+   unix_ts_ms:
+      48 bit big-endian unsigned number of Unix epoch timestamp as per
+      Section 8.1.
+
+   ver:
+      4 bit UUIDv7 version set as per Section 4
+
+   rand_a:
+      12 bits pseudo-random data to provide uniqueness as per
+      Section 8.2 and Section 8.6.
+
+   var:
+      The 2 bit variant defined by Section 4.
+
+   rand_b:
+      The final 62 bits of pseudo-random data to provide uniqueness as
+      per Section 8.2 and Section 8.6.
+
+5.3.  UUID Version 8
+
+   UUID version 8 provides an RFC-compatible format for experimental or
+   vendor-specific use cases.  The only requirement is that the variant
+   and version bits MUST be set as defined in Section 4.  UUIDv8's
+   uniqueness will be implementation-specific and SHOULD NOT be assumed.
+
+   The only explicitly defined bits are the Version and Variant leaving
+   120 bits for implementation specific time-based UUIDs.  To be clear:
+   UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
+   filled with random data.
+
+   Some example situations in which UUIDv8 usage could occur:
+
+   *  An implementation would like to embed extra information within the
+      UUID other than what is defined in this document.
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 13]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   *  An implementation has other application/language restrictions
+      which inhibit the use of one of the current UUIDs.
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           custom_a                            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |          custom_a             |  ver  |       custom_b        |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |var|                       custom_c                            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                           custom_c                            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                   Figure 5: UUIDv8 Field and Bit Layout
+
+   custom_a:
+      The first 48 bits of the layout that can be filled as an
+      implementation sees fit.
+
+   ver:
+      The 4 bit version field as defined by Section 4
+
+   custom_b:
+      12 more bits of the layout that can be filled as an implementation
+      sees fit.
+
+   var:
+      The 2 bit variant field as defined by Section 4.
+
+   custom_c:
+      The final 62 bits of the layout immediatly following the var_var
+      field to be filled as an implementation sees fit.
+
+6.  Alternate Variants
+
+   This section details alternate formats utilizing the newly defined
+   "E" variant layout for use with UUID version 7 and version 8 of this
+   document.
+
+6.1.  UUID Version 7E
+
+   UUID version 7E is an alternative bit layout for UUIDv7 which
+   leverages the new simplified "E" variant introduced in this
+   specification.
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 14]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   With UUIDv7E the first 64 bits of the UUID layout are unbroken and
+   the version has been moved to the same octet as the variant to
+   produce var_ver field populated with 0xE7.
 
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -630,55 +802,45 @@ Internet-Draft               new-uuid-format                  March 2022
    |                            rand_b                             |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 4: UUIDv7E Field and Bit Layout
+                   Figure 6: UUIDv7E Field and Bit Layout
 
    unix_ts_ms:
-      48 bit big-endian unsigned number of unix epoch timestamp as per
-      Section 5.1.
+      48 bit big-endian unsigned number of Unix epoch timestamp as per
+      Section 8.1.
 
    rand_a:
       16 bits pseudo-random data to provide uniqueness as per
-      Section 5.2 and Section 5.6.
+      Section 8.2 and Section 8.6.
 
    var_ver:
       The 8 bit combined variant and version field with the value 0xE7
-      as defined by Section 4.1.
+      as defined by Section 4.
 
    rand_b:
       The final 56 bits of pseudo-random data to provide uniqueness as
-      per Section 5.2 and Section 5.6.
+      per Section 8.2 and Section 8.6.
 
-4.4.  UUID Version 8E
+6.2.  UUID Version 8E
 
-   UUID version 8E provides an RFC-compatible format for experimental or
-   vendor-specific use cases.  The only requirement is that the variant
-   and version bits MUST be set as defined in Section 4.1.  UUIDv8E's
-   uniqueness will be implementation-specific and SHOULD NOT be assumed.
+   UUID version 8E is an alternative bit layout for UUIDv8 which
+   leverages the new simplified "E" variant introduced in this
+   specification.
 
-   UUIDv8E SHOULD only be utilized if an implementation cannot utilize
-   another UUID in this document or [RFC4122].
-
-   The only explicitly defined bits are the Version and Variant leaving
-   120 bits for implementation specific time-based UUIDs.  To be clear:
-   UUIDv8E is not a replacement for UUIDv4 where all 122 extra bits are
-   filled with random data.
-
-   Some example situations in which UUIDv8E usage could occur:
+   With UUIDv8E the first 64 bits of the UUID layout are unbroken and
+   the version has been moved to the same octet as the variant to
+   produce the var_ver field populated with 0xE8.
 
 
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 12]
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
-
-   *  An implementation would like to embed extra information within the
-      UUID other than what is defined in this document.
-
-   *  An implementation has other application/language restrictions
-      which inhibit the use of one of the current UUIDs.
 
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -692,7 +854,7 @@ Internet-Draft               new-uuid-format                  March 2022
    |                           custom_b                            |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-                   Figure 5: UUIDv8E Field and Bit Layout
+                   Figure 7: UUIDv8E Field and Bit Layout
 
    custom_a:
       The first 64 bits of the layout that can be filled as an
@@ -700,37 +862,126 @@ Internet-Draft               new-uuid-format                  March 2022
 
    var_ver:
       The 8 bit combined variant and version field with the value 0xE8
-      as defined by Section 4.1.
+      as defined by Section 4.
 
    custom_b:
       The final 56 bits of the layout immediatly following the var_var
       field to be filled as an implementation sees fit.
 
-4.5.  Max UUID
+7.  Alternate Formats
+
+   This section details alternate UUID formats such as the Max UUID, a
+   longer form of UUID aptly named "UUID Long" and some alternate
+   encoding techniques applicable to all UUIDs in this document and
+   [RFC4122].
+
+7.1.  Max UUID
 
    The Max UUID is special form of UUID that is specified to have all
-   128 bits set to 1.
+   128 bits set to 1.  This UUID can be thought of as the inverse of Nil
+   UUID defined in [RFC4122], Section 4.1.7
 
    FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 
-                         Figure 6: Max UUID Format
+                         Figure 8: Max UUID Format
+
+7.2.  UUID Long
+
+   UUID Long generally references any variable length UUID longer than
+   128 bits.  There are two main driving factors behind extending UUID
+   beyond 128 bits:
 
 
 
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 13]
+Peabody & Davis         Expires 10 September 2022              [Page 16]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-5.  UUID Best Practices
+   Increased Entropy:
+      While existing UUID formats provide sufficient entropy for most
+      use cases; there exists scenarios where even more entropy is
+      required to further reduce collision probabilities (Section 8.4)
+      or guessability (Section 8.6).
+
+   Requirements for additional embedded items:
+      Some implementations require more than 128 bits to properly embed
+      all of the application specific data they require.  Some examples
+      include database metadata like entity types, checksum values,
+      shard/partition identifiers, and even node identifiers defined by
+      Section 8.3.
+
+   UUID Long is compatible with any UUID specified in this document and
+   [RFC4122].  UUID long is variable in length and there is no minimum
+   or maximum value for UUID Long; however, UUID Long SHOULD leverage
+   natural byte boundaries.  UUID long is defined by appending an
+   additional dash to the existing 8-4-4-4-12 hex format to create
+   8-4-4-4-12-variable_length text format.  The next example shows a
+   UUID Long +32, +64 and +128 example for UUIDv4 with random data
+   filling the values beyond 128 bits.
+
+UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
+   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
+  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
+
+                     Figure 9: UUID Long Examples
+
+   Where required, for compatibility with legacy UUID implementations,
+   the most significant, left-most, 128 bits MUST be leveraged to
+   truncate from UUID Long back to a regular UUID.
+
+   When UUID Long is utilized with Nil UUID or Max UUID all bits should
+   be set as specified.  That is for Nil UUID Long all bits MUST be set
+   to 0 while Max UUID Long all bits MUST be set to 1.
+
+7.3.  Alternate Encodings
+
+   The existing UUID hex and dash format of 8-4-4-4-12 is retained for
+   both backwards compatibility and human readability.  This format MUST
+   be implemented for all UUIDs.
+
+   Where required, UUIDs defined by this specification and [RFC4122] MAY
+   be encoded utilizing new techniques such as, but not limited to,
+   Base32, Base36, or Base64.  Applications MAY also utilize other
+   encoding techniques such as modulo division or alternate alphabets
+   such as Crockford's base32.  When selecting an alternate encoding
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 17]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   implementations SHOULD take into consideration items such as:
+   uppercase/lowercase/mixed character encoding for application
+   sortability, special character inclusions or omissions, and the
+   exclusion of key letters like "I", "L", "O", and "U" which may impact
+   sortability of UUIDv7 and UUIDv7E and collision resistance provided
+   by all UUIDs.
+
+   When utilizing alternate encoding techniques with other applications;
+   the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that
+   the value therein is that of a UUID.
+
+   The conversion from UUID to a new encoding technique SHOULD be done
+   utilizing the underlying integer or binary value for a given UUID
+   versus converting the hex representation.  Two examples for UUIDv4
+   encoded as base-32 and base-36 are included below.
+
+UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+UUIDv4 Int: 154072644812979270675542139334331768221
+UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
+UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
+UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
+
+                Figure 10: Alternate Encoding Examples
+
+   For information on converting a UUID into Base 16, Base 32 or Base 64
+   refer to [RFC4648].
+
+8.  UUID Best Practices
 
    The minimum requirements for generating UUIDs are described in this
    document for each version.  Everything else is an implementation
@@ -739,7 +990,7 @@ Internet-Draft               new-uuid-format                  March 2022
    covered below to help guide an implementer through the different
    trade-offs among differing UUID implementations.
 
-5.1.  Timestamp Granularity
+8.1.  Timestamp Granularity
 
    UUID timestamp source, precision and length was the topic of great
    debate while creating this specification.  As such choosing the right
@@ -752,11 +1003,18 @@ Internet-Draft               new-uuid-format                  March 2022
       increasing.  Care SHOULD be taken to ensure the timestamp does not
       move backwards which will impact UUID sorting.
 
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 18]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    Source:
       UUID version 1 and 6 both utilize a Gregorian epoch timestamp
-      while UUIDv7E utilizes a Unix Epoch timestamp.  If other timestamp
-      sources or a custom timestamp epoch are required UUIDv8E SHOULD be
-      leveraged.
+      while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp.  If
+      other timestamp sources or a custom timestamp epoch are required
+      UUIDv8 or UUIDv8E SHOULD be leveraged.
 
    Sub-second Precision and Accuracy:
       Many levels of precision exist for timestamps: milliseconds,
@@ -764,28 +1022,20 @@ Internet-Draft               new-uuid-format                  March 2022
       representations of sub-second precision may be desired to mix
       various levels of precision in a time-ordered manner.  With UUID
       version 1 and 6, 100-nanoseconds of precision are present while
-      UUIDv7E features fixed millisecond level of precision within the
-      Unix epoch.  If additional levels of precision are required
-      UUIDv8E SHOULD be utilized.
+      UUIDv7 and UUIDv7E features fixed millisecond level of precision
+      within the Unix epoch.  If additional levels of precision are
+      required UUIDv8 or UUIDv8E SHOULD be utilized.
 
    Length:
       The length of a given timestamp directly impacts how long a given
       UUID will be valid.  Care should be given to ensure that the
       proper length is selected for a given timestamp.  UUID version 1
-      and 6 utilize a 60 bit timestamp and UUIDv7E features a 48 bit
-      timestamp.
+      and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a
+      48 bit timestamp.
 
    Fuzzing:
       Implementations MAY fuzz a timestamp.  Some examples included
       security considerations around providing a real clock value within
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 14]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
       a UUID or to correct inaccurate clocks.  This specification makes
       no requirement or guarantee about how close the clock value needs
       to be to actual time.
@@ -793,16 +1043,30 @@ Internet-Draft               new-uuid-format                  March 2022
    Padding:
       When timestamp padding is required, implementations MUST pad the
       most significant bits (left-most) bits with zeros.  An example is
-      padding the most significant, left-most bits of a 32 bit unix
-      timestamp with zero's to fill out the 48 bit timestamp in UUIDv7E.
+      padding the most significant, left-most bits of a 32 bit Unix
+      timestamp with zero's to fill out the 48 bit timestamp in UUIDv7
+      and UUIDv7E.
 
    Truncating:
       Similarly, when timestamps need to be truncated: the lower, least
       significant bits MUST be used.  An example would be truncating a
-      64 bit unix timestamp to the least significant, right-most 48 bits
+      64 bit Unix timestamp to the least significant, right-most 48 bits
       for UUIDv7E.
 
-5.2.  Monotonicity and Counters
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 19]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+8.2.  Monotonicity and Counters
 
    Monotonicity is the backbone of time-based sortable UUIDs.  Naturally
    time-based UUIDs from this document will be monotonic due to an
@@ -817,10 +1081,10 @@ Internet-Draft               new-uuid-format                  March 2022
    increment for each UUID created during a given timestamp.
 
    For single-node UUID implementations that do not need to create
-   batches of UUIDs, the embedded timestamp within UUID version 1, 6,
-   and 7 can provide sufficient monotonicity guarantees by simply
+   batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7,
+   and 7E can provide sufficient monotonicity guarantees by simply
    ensuring that timestamp increments before creating a new UUID.  For
-   the topic of Distributed Nodes please refer to Section 5.3
+   the topic of Distributed Nodes please refer to Section 8.3
 
    Implementations SHOULD choose one method for single-node UUID
    implementations that require batch UUID creation.
@@ -832,40 +1096,47 @@ Internet-Draft               new-uuid-format                  March 2022
       Positioning of a fixed bit-length counter SHOULD be immediatly
       after the embedded timestamp.  This promotes sortability and
       allows random data generation for each counter increment.  With
-      this method the rand_a section of UUIDv7 MAY be utilized as fixed-
-      length dedicated counter bits..
+      this method the rand_a section of UUIDv7 and UUIDv7E MAY be
+      utilized as fixed-length dedicated counter bits.
+
+   Monotonic Random (Method 2):
+      With this method the random data is extended to also double as a
+      counter.  This monotonic random can be thought of as a "randomly
+      seeded counter" which MUST be incremented in the least significant
+      position for each UUID created on a given timestamp tick.  This is
+      similar to the Fixed-Length Dedicated Counter Bits method
+      described in the previous bullet but does not suffer from rollover
+      issues, length problems, or wasted entropy bits plagued by fixed-
+      length counter bit positions.  As such, UUIDv7 and UUIDv7E SHOULD
+      utilize this method to handle batch UUID generation during a
+      single timestamp tick.
+
+   The following sub-topics cover topics related solely with creating
+   reliable fixed-length dedicated counters:
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 15]
+
+Peabody & Davis         Expires 10 September 2022              [Page 20]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-   Fixed-Length Dedicated Counter Bits (Method 2):
-      An alternative approach to the previous method is to dedicate a
-      number of bits in the least significant position of the UUID.
-      With this alternative method, the random data MUST be frozen for a
-      given timestamp tick else sorting will be impacted.  UUIDs
-      utilizing this method SHOULD be created using UUIDv8E.
-
    Fixed-Length Dedicated Counter Seeding:
-      Implementations utilizing either fixed-length counter method MAY
-      randomly initialize the counter with each new timestamp tick.
-      However, when the timestamp has not incremented; the counter
-      SHOULD be frozen and incremented by one.  When utilizing a
-      randomly seeded counter alongside Method 1; the random MAY be
-      regenerated with each counter increment without impacting
-      sortability.  The downside is that Method 1 is prone to overflows
-      if a counter of adequate length is not selected or the random data
-      generated leaves little room for the required number of
-      increments.  A randomly seeded counter alongside Method 2 is more-
-      or-less the same as Monotonic Random (Method 3).  Implementations
-      utilizing either fixed-length counter method MAY also choose to
-      initialize the counter at zero to ensure the full bit-space is
-      utilized and help avoid counter rollovers.  This approach has less
-      entropy and more guessibility but ensures the most of the counter
-      bit space.
+      Implementations utilizing fixed-length counter method MAY randomly
+      initialize the counter with each new timestamp tick.  However,
+      when the timestamp has not incremented; the counter SHOULD be
+      frozen and incremented by one.  When utilizing a randomly seeded
+      counter alongside Method 1; the random MAY be regenerated with
+      each counter increment without impacting sortability.  The
+      downside is that Method 1 is prone to overflows if a counter of
+      adequate length is not selected or the random data generated
+      leaves little room for the required number of increments.
+      Implementations utilizing fixed-length counter method MAY also
+      choose to initialize the counter at zero to ensure the full bit-
+      space is utilized and help avoid counter rollovers.  This approach
+      has less entropy and more guessibility but ensures the most of the
+      counter bit space.
 
    Fixed-Length Dedicated Counter Length
       Care MUST be taken to select a counter bit-length that can
@@ -881,35 +1152,6 @@ Internet-Draft               new-uuid-format                  March 2022
       freeze the counter and wait for the timestamp to advance which
       ensures monotonicity is not broken.
 
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 16]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-   Monotonic Random (Method 3):
-      With this method the random data is extended to also double as a
-      counter.  This monotonic random can be thought of as a "randomly
-      seeded counter" which MUST be incremented in the least significant
-      position for each UUID created on a given timestamp tick.  This is
-      similar to the Fixed-Length Dedicated Counter Bits (Position B)
-      method described in the previous bullets but does not suffer from
-      rollover issues, length problems, or wasted entropy bits plagued
-      by both fixed-length counter bit positions.  As such, UUIDv7E
-      SHOULD utilize this method to handle batch UUID generation during
-      a single timestamp tick.
-
    Implementations MAY use the following logic to ensure UUIDs featuring
    embedded counters are monotonic in nature:
 
@@ -921,6 +1163,20 @@ Internet-Draft               new-uuid-format                  March 2022
        re-initialize the counter to the new timestamp and generate new
        random bytes (if the bytes were frozen or being used as the seed
        for a monotonic counter).
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 21]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    Implementations SHOULD check if the the currently generated UUID is
    greater than the previously generated UUID.  If this is not the case
@@ -934,7 +1190,7 @@ Internet-Draft               new-uuid-format                  March 2022
    in the form of "clock sequence" bits.  The usage of the clock
    sequence will remain as defined in [RFC4122], Section 4.1.5.
 
-5.3.  Distributed UUID Generation
+8.3.  Distributed UUID Generation
 
    Some implementations MAY desire to utilize multi-node, clustered,
    applications which involve two or more applications independently
@@ -944,15 +1200,6 @@ Internet-Draft               new-uuid-format                  March 2022
    the likelihood of a collision.  This section will detail the
    approaches that MAY be utilized by multi-node UUID implementations in
    distributed environments.
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 17]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Shared Knowledge System:
       With this method all nodes tasked with creating UUIDs consult a
@@ -969,8 +1216,8 @@ Internet-Draft               new-uuid-format                  March 2022
       conflict with any other UUID created by another node with a
       different node id.  Implementations that choose to leverage an
       embedded node id SHOULD utilize UUIDv8E.  The node id SHOULD NOT
-      be an IEEE 802 MAC address as per Section 7.  The location and bit
-      length are up to implements and outside the scope of this
+      be an IEEE 802 MAC address as per Section 10.  The location and
+      bit length are up to implements and outside the scope of this
       specification.  Furthermore, the creation and negotiation of a
       node id among distributed nodes is also out of scope for this
       specification.
@@ -980,14 +1227,21 @@ Internet-Draft               new-uuid-format                  March 2022
    implementations SHOULD utilize one of the two aforementioned methods
    if distributed UUID generation is a requirements.
 
-5.4.  Collision Resistance
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 22]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+8.4.  Collision Resistance
 
    Implementations SHOULD weigh the importance of a collision within
    their application and take this into account when making a selections
    around the total entropy (random) to dedicated to a UUID layout
-   versus the other components such as Section 5.1 and Section 5.2.
+   versus the other components such as Section 8.1 and Section 8.2.
    This is especially true for distributed node collision resistance as
-   defined by Section 5.3.
+   defined by Section 8.3.
 
    There are two example scenarios below which help illustrate the
    varying seriousness of a collision within an application.
@@ -1002,19 +1256,11 @@ Internet-Draft               new-uuid-format                  March 2022
       A duplicate key causes an airplane to receive the wrong course
       which puts people's lives at risk.  In this scenario there is no
       margin for error.  Collisions MUST be avoided and failure is
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 18]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
       unacceptable.  As such applications dealing with this type of
       scenario MUST employ as much collision resistance as possible
       within the given application context.
 
-5.5.  Global and Local Uniqueness
+8.5.  Global and Local Uniqueness
 
    UUIDs created by this specification MAY be used to provide local
    uniqueness guarantees.  For example, ensuring UUIDs created within a
@@ -1026,25 +1272,32 @@ Internet-Draft               new-uuid-format                  March 2022
    Although true global uniqueness is impossible to guarantee without
    shared knowledge scheme; a shared knowledge scheme is not required by
    UUID to provide uniqueness guarantees.  Implementations MAY implement
-   a shared knowledge scheme introduced in Section 5.3 as they see fit
+   a shared knowledge scheme introduced in Section 8.3 as they see fit
    to extend the uniqueness guaranteed this specification and [RFC4122].
 
-5.6.  Unguessability
+8.6.  Unguessability
 
    Implementations SHOULD utilize a cryptographically secure pseudo-
    random number generator (CSPRNG) to provide values that are both
    difficult to predict ("unguessable") and have a low likelihood of
-   collision ("unique").  CSPRNG ensures the best of Section 5.4 and
-   Section 7 are present in modern UUIDs.
+   collision ("unique").  CSPRNG ensures the best of Section 8.4 and
+   Section 10 are present in modern UUIDs.
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 23]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    Advice on generating cryptographic-quality random numbers can be
    found in [RFC4086]
 
-5.7.  Sorting
+8.7.  Sorting
 
-   UUIDv6 and UUIDv7E are designed so that implementations that require
-   sorting (e.g. database indexes) SHOULD sort as opaque raw bytes,
-   without examining the contents at all.
+   UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that
+   require sorting (e.g. database indexes) SHOULD sort as opaque raw
+   bytes, without examining the contents at all.
 
    Time ordered monotonic UUIDs benefit from greater index locality
    because the new values are near each other in the index.  As a result
@@ -1059,14 +1312,15 @@ Internet-Draft               new-uuid-format                  March 2022
    order (network byte order) in mind.  If Little-endian style is
    required a custom UUID format SHOULD be created using UUIDv8E.
 
+8.8.  Opacity
 
+   UUIDs SHOULD be treated as opaque values and implementations SHOULD
+   NOT examine the bits in a UUID to whatever extent is possible.
+   However, where necessary inspectors please review Section 4 for more
+   information on determining a UUID version based on the inspected
+   variant bits.
 
-Peabody & Davis         Expires 5 September 2022               [Page 19]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-5.8.  Storing UUIDs, Opacity
+8.9.  DBMS and Database Considerations
 
    For many applications, such as databases, storing UUIDs as the text
    is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID
@@ -1085,22 +1339,33 @@ Internet-Draft               new-uuid-format                  March 2022
       translation if the resulting text form is to be used after
       retrieval and thus maybe simpler to implement.
 
-   UUIDs SHOULD be treated as opaque values and implementations SHOULD
-   NOT examine the bits in a UUID to whatever extent is possible.
-   However, where necessary inspectors please review Section 4.1 for
-   more information on determining a UUID version based on the inspected
-   variant bits.
 
-6.  IANA Considerations
+
+Peabody & Davis         Expires 10 September 2022              [Page 24]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   DBMS vendors are encouraged to provide functionality to generate and
+   store UUID formats defined by this specification for use as
+   identifiers such as (but not limited to) primary keys, surrogate keys
+   for temporal databases, foreign keys included in polymorphic
+   relationships, and keys for key-value pairs in JSON key-value
+   databases.  If database is monolithic than database side UUID
+   generation ensures best UUID monotonicity in the database tables and
+   in indexes.  In addition to UUIDs, additional identifiers MAY be used
+   to ensure integrity and feedback.
+
+9.  IANA Considerations
 
    This document has no IANA actions.
 
-7.  Security Considerations
+10.  Security Considerations
 
    MAC addresses pose inherent security risks and SHOULD not be used
    within a UUID.  Instead CSPRNG data SHOULD selected from a source
    with sufficient entropy to ensure guaranteed uniqueness among UUID
-   generation.  See Section 5.6 for more information.
+   generation.  See Section 8.6 for more information.
 
    Timestamps embedded in the UUID do pose a very small attack surface.
    The timestamp in conjunction with an embedded counter does signal the
@@ -1110,19 +1375,7 @@ Internet-Draft               new-uuid-format                  March 2022
    within an application context in any shape or form then [RFC4122]
    UUIDv4 SHOULD be utilized.
 
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 20]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
-8.  Acknowledgements
+11.  Acknowledgements
 
    The authors gratefully acknowledge the contributions of Ben Campbell,
    Ben Ramsey, Fabio Lima, Gonzalo Salgueiro, Martin Thomson, Murray S.
@@ -1131,7 +1384,7 @@ Internet-Draft               new-uuid-format                  March 2022
    those in the IETF community and on GitHub to who contributed to the
    discussions which resulted in this document.
 
-9.  Normative References
+12.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -1141,6 +1394,13 @@ Internet-Draft               new-uuid-format                  March 2022
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 25]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    [RFC4122]  Leach, P., Mealling, M., and R. Salz, "A Universally
               Unique IDentifier (UUID) URN Namespace", RFC 4122,
@@ -1152,7 +1412,11 @@ Internet-Draft               new-uuid-format                  March 2022
               DOI 10.17487/RFC4086, June 2005,
               <https://www.rfc-editor.org/info/rfc4122>.
 
-10.  Informative References
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <https://www.rfc-editor.org/info/rfc4122>.
+
+13.  Informative References
 
    [LexicalUUID]
               Twitter, "A Scala client for Cassandra", commit f6da4e0,
@@ -1170,14 +1434,6 @@ Internet-Draft               new-uuid-format                  March 2022
               service in Erlang", Commit 15c933a, February 2017,
               <https://github.com/boundary/flake>.
 
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 21]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    [ShardingID]
               Instagram Engineering, "Sharding & IDs at Instagram",
               December 2012, <https://instagram-engineering.com/
@@ -1193,6 +1449,14 @@ Internet-Draft               new-uuid-format                  March 2022
 
    [FlakeID]  Pawlak, T., "Flake ID Generator", Commit fcd6a2f, April
               2020, <https://github.com/T-PWK/flake-idgen>.
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 26]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    [Sonyflake]
               Sony, "A distributed unique ID generator inspired by
@@ -1227,13 +1491,6 @@ Internet-Draft               new-uuid-format                  March 2022
               <https://docs.mongodb.com/manual/reference/method/
               ObjectId/>.
 
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 22]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    [CUID]     Elliott, E., "Collision-resistant ids optimized for
               horizontal scaling and performance.", Commit 215b27b,
               October 2020, <https://github.com/ericelliott/cuid>.
@@ -1248,6 +1505,14 @@ A.1.  Creating a UUIDv6 Value
 
    This section details a function in C which converts from a UUID
    version 1 to version 6:
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 27]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    #include <stdio.h>
    #include <stdint.h>
@@ -1279,18 +1544,31 @@ A.1.  Creating a UUIDv6 Value
 
    }
 
-                       Figure 7: UUIDv6 Function in C
+                      Figure 11: UUIDv6 Function in C
+
+A.2.  Creating a UUIDv7E Value
 
 
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 23]
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 28]
 
 Internet-Draft               new-uuid-format                  March 2022
 
-
-A.2.  Creating a UUIDv7E Value
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1336,12 +1614,14 @@ fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random by
 
 u[8] = 0xE7; // set var-ver field
 
-                   Figure 8: UUIDv7E Function in C
+                   Figure 12: UUIDv7E Function in C
 
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 24]
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 29]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1370,7 +1650,7 @@ A.3.  Creating a UUIDv8E Value
      return 0;
    }
 
-                       Figure 9: UUID8 Function in C
+                       Figure 13: UUID8 Function in C
 
 Appendix B.  Test Vectors
 
@@ -1397,26 +1677,26 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 25]
+Peabody & Davis         Expires 10 September 2022              [Page 30]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
-gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
+gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 
 # Gregorian to Unix Offset:
 # The number of 100-ns intervals between the
 # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-# gregorian_unix_offset = 0x01b21dd213814000 or 122192928000000000
+# gregorian_Unix_offset = 0x01b21dd213814000 or 122192928000000000
 
 # Unix 64 bit Nanosecond Timestamp:
 # Unix NS: Tuesday, February 22, 2022 2:22:22 PM GMT-05:00
-# unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
+# Unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
 
 # Work:
 # gregorian_100_ns = (1645557742000000000 / 100) + 122192928000000000
-# (138648505420000000 - 122192928000000000) * 100 = unix_64_bit_nanoseconds
+# (138648505420000000 - 122192928000000000) * 100 = Unix_64_bit_nanoseconds
 
 # Final:
 # gregorian_100_ns = 0x1EC9414C232AB00 or 138648505420000000
@@ -1425,7 +1705,7 @@ gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
 # UUIDv1:   11000010001100101010101100000000|1001010000010100|0001|000111101100
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 
-             Figure 10: Test Vector Timestamp Pseudo-code
+             Figure 14: Test Vector Timestamp Pseudo-code
 
 B.1.  Example of a UUIDv6 Value
 
@@ -1443,7 +1723,7 @@ B.1.  Example of a UUIDv6 Value
    ----------------------------------------------
    final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 
-                   Figure 11: UUIDv1 Example Test Vector
+                   Figure 15: UUIDv1 Example Test Vector
 
 
 
@@ -1453,7 +1733,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 5 September 2022               [Page 26]
+Peabody & Davis         Expires 10 September 2022              [Page 31]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1472,14 +1752,47 @@ Internet-Draft               new-uuid-format                  March 2022
    -----------------------------------------------
    final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 
-                   Figure 12: UUIDv6 Example Test Vector
+                   Figure 16: UUIDv6 Example Test Vector
 
-B.2.  Example of a UUIDv7E Value
+B.2.  Example of a UUIDv7 Value
 
-   This example UUIDv7E test vector utilizes a well-known 32-bit unix
+   This example UUIDv7 test vector utilizes a well-known 32-bit Unix
    epoch with additional millisecond precision to fill the first 48 bits
 
    rand_a and rand_b are filled with random data.
+
+   The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00
+   represented as 0x17F21CFD130 or 1645539742000
+
+   -------------------------------
+   field      bits    value
+   -------------------------------
+   unix_ts_ms   48    0x017F21CFD130
+   var           4    0x7
+   rand_a       12    0xCC3
+   var           2    b10
+   rand_b       62    0x18C4DC0C0C07398F
+   -------------------------------
+   total       128
+   -------------------------------
+   final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
+
+                   Figure 17: UUIDv7 Example Test Vector
+
+B.3.  Example of a UUIDv7E Value
+
+   This example UUIDv7E test vector utilizes a well-known 32-bit Unix
+   epoch with additional millisecond precision to fill the first 48 bits
+
+   rand_a and rand_b are filled with random data.
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 32]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00
    represented as 0x17F21CFD130 or 1645539742000
@@ -1492,27 +1805,58 @@ B.2.  Example of a UUIDv7E Value
    var_ver       8    0xE7
    rand_b       56    0xD6A139DC9535C5
    -------------------------------
-   total        128
+   total       128
    -------------------------------
    final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
 
-                   Figure 13: UUIDv7E Example Test Vector
+                   Figure 18: UUIDv7E Example Test Vector
 
-B.3.  Example of a UUIDv8E Value
+B.4.  Example of a UUIDv8 Value
 
-   This example UUIDv8E test vector utilizes a well-known 64-bit unix
+   This example UUIDv8 test vector utilizes a well-known 64-bit Unix
+   epoch with nanosecond precision, truncated to the least-significant
+   (right-most) bits to fill the first 48 bits through version.
+
+   The next two segments of custom_b and custmo_c are are filled with
+   random data.
+
+   Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00
+   represented as 0x16D6320C3D4DCC00 or 1645557742000000000
+
+   It should be noted that this example is just to illustrate one
+   scenario for UUIDv8E.  Test vectors will likely be implementation
+   specific and vary greatly from this simple example.
+
+   -------------------------------
+   field      bits    value
+   -------------------------------
+   custom_a     48    0x320C3D4DCC00
+   ver           4    0x8
+   custom_b     12    0x75B
+   var           2    b10
+   custom_c     62    0xEC932D5F69181C0
+   -------------------------------
+   total       128
+   -------------------------------
+   final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
+
+                   Figure 19: UUIDv8E Example Test Vector
+
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 33]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+B.5.  Example of a UUIDv8E Value
+
+   This example UUIDv8E test vector utilizes a well-known 64-bit Unix
    epoch with nanosecond precision to fill the first 64 bits through
    ver_var.
 
    The final 56 bits are filled with random data.
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 27]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00
    represented as 0x16D6320C3D4DCC00 or 1645557742000000000
@@ -1528,11 +1872,11 @@ Internet-Draft               new-uuid-format                  March 2022
    var_ver       8    0xE8
    custom_b     56    0x3C2D06302FC417
    -------------------------------
-   total        128
+   total       128
    -------------------------------
    final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 
-                   Figure 14: UUIDv8E Example Test Vector
+                   Figure 20: UUIDv8E Example Test Vector
 
 Appendix C.  Version and Variant Tables
 
@@ -1554,6 +1898,14 @@ C.1.  Variant 10xx Versions
    | 0    | 0    | 1    | 1    | 3       | The name-based version     |
    |      |      |      |      |         | specified in [RFC4122],    |
    |      |      |      |      |         | Section 4.1.3 that uses    |
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 34]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    |      |      |      |      |         | MD5 hashing.               |
    +------+------+------+------+---------+----------------------------+
    | 0    | 1    | 0    | 0    | 4       | The randomly or pseudo-    |
@@ -1562,14 +1914,6 @@ C.1.  Variant 10xx Versions
    |      |      |      |      |         | Section 4.1.3.             |
    +------+------+------+------+---------+----------------------------+
    | 0    | 1    | 0    | 1    | 5       | The name-based version     |
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 28]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    |      |      |      |      |         | specified in [RFC4122],    |
    |      |      |      |      |         | Section 4.1.3 that uses    |
    |      |      |      |      |         | SHA-1 hashing.             |
@@ -1578,11 +1922,13 @@ Internet-Draft               new-uuid-format                  March 2022
    |      |      |      |      |         | based UUID specified in    |
    |      |      |      |      |         | this document.             |
    +------+------+------+------+---------+----------------------------+
-   | 0    | 1    | 1    | 1    | 7       | Reserved for future        |
-   |      |      |      |      |         | definition.                |
+   | 0    | 1    | 1    | 1    | 7       | Unix Epoch time-based UUID |
+   |      |      |      |      |         | specified in this          |
+   |      |      |      |      |         | document.                  |
    +------+------+------+------+---------+----------------------------+
-   | 1    | 0    | 0    | 0    | 8       | Reserved for future        |
-   |      |      |      |      |         | definition.                |
+   | 1    | 0    | 0    | 0    | 8       | Reserved for custom UUID   |
+   |      |      |      |      |         | formats specified in this  |
+   |      |      |      |      |         | document.                  |
    +------+------+------+------+---------+----------------------------+
    | 1    | 0    | 0    | 1    | 9       | Reserved for future        |
    |      |      |      |      |         | definition.                |
@@ -1608,6 +1954,14 @@ Internet-Draft               new-uuid-format                  March 2022
 
            Table 5: All UUID variant 10xx version definitions.
 
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 35]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
 C.2.  Variant 1110 Versions
 
    +------+------+------+------+---------+-----------------------------+
@@ -1618,14 +1972,6 @@ C.2.  Variant 1110 Versions
    +------+------+------+------+---------+-----------------------------+
    | 0    | 0    | 0    | 1    | 1E      | Reserved for future         |
    |      |      |      |      |         | definition.                 |
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 29]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    +------+------+------+------+---------+-----------------------------+
    | 0    | 0    | 1    | 0    | 2E      | Reserved for future         |
    |      |      |      |      |         | definition.                 |
@@ -1642,13 +1988,14 @@ Internet-Draft               new-uuid-format                  March 2022
    | 0    | 1    | 1    | 0    | 6E      | Reserved for future         |
    |      |      |      |      |         | definition.                 |
    +------+------+------+------+---------+-----------------------------+
-   | 0    | 1    | 1    | 1    | 7E      | Unix Epoch time-based       |
-   |      |      |      |      |         | UUID specified in this      |
-   |      |      |      |      |         | document.                   |
+   | 0    | 1    | 1    | 1    | 7E      | Alternate Unix Epoch        |
+   |      |      |      |      |         | time-based UUID specified   |
+   |      |      |      |      |         | in this document.           |
    +------+------+------+------+---------+-----------------------------+
-   | 1    | 0    | 0    | 0    | 8E      | Reserved for custom         |
-   |      |      |      |      |         | UUID formats specified      |
-   |      |      |      |      |         | in this document            |
+   | 1    | 0    | 0    | 0    | 8E      | Alternate reservation for   |
+   |      |      |      |      |         | custom UUID formats         |
+   |      |      |      |      |         | specified in this           |
+   |      |      |      |      |         | document.                   |
    +------+------+------+------+---------+-----------------------------+
    | 1    | 0    | 0    | 1    | 9E      | Reserved for future         |
    |      |      |      |      |         | definition.                 |
@@ -1663,6 +2010,14 @@ Internet-Draft               new-uuid-format                  March 2022
    |      |      |      |      |         | definition.                 |
    +------+------+------+------+---------+-----------------------------+
    | 1    | 1    | 0    | 1    | 13E     | Reserved for future         |
+
+
+
+Peabody & Davis         Expires 10 September 2022              [Page 36]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    |      |      |      |      |         | definition.                 |
    +------+------+------+------+---------+-----------------------------+
    | 1    | 1    | 1    | 0    | 14E     | Reserved for future         |
@@ -1673,14 +2028,6 @@ Internet-Draft               new-uuid-format                  March 2022
    +------+------+------+------+---------+-----------------------------+
 
             Table 6: All UUID variant 1110 version definitions.
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 30]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
 Authors' Addresses
 
@@ -1722,15 +2069,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 5 September 2022               [Page 31]
+Peabody & Davis         Expires 10 September 2022              [Page 37]

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -34,14 +34,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 		<keyword>uuid</keyword>
 		<abstract>
 			<t>
-				This document presents three new Universally Unique Identifier (UUID) formats.
-			</t>
-			<t>
-				A common case for modern applications is to create a unique identifier for use as a database key.
-				This identifier usually implements an embedded timestamp that is sortable using the monotonic creation time in the most significant bits. 
-				In addition the identifier is highly collision resistant, difficult to guess, and provides minimal security attack surfaces.
-				None of the existing UUID versions, including UUIDv1, fulfill each of these requirements in the most efficient possible way.
-				This document is a proposal to update <xref target="RFC4122"/> with three new UUID versions that address these concerns, each with different trade-offs.
+				This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
 			</t>
 		</abstract>
 	</front>
@@ -53,7 +46,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 				Modern applications have a need to create and utilize UUIDs as the primary
 				identifier for a variety of different items in complex computational systems,
 				including but not limited to database keys, file names, machine
-				or system names, identifiers for transactions or other objects or processes.
+				or system names, identifiers for event-driven transactions, and other objects or processes.
 			</t>
 
 			<t>
@@ -82,17 +75,22 @@ please see http://xml.resource.org/authoring/README.html. -->
 				<li><t>
 					Introspection/parsing is required to order by time sequence; as opposed to being able to perform a simple byte-by-byte comparison.
 				</t></li>
-
+				<li><t>
+					The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.
+				</t></li>
+				<li><t>
+					The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.
+				</t></li>
 				<li><t>
 					Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
 					Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
 					information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.
 				</t></li>
 				<li><t>
-					Many implementation details are specified in <xref target="RFC4122"/> but some of the decisions made involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.
+					Many of the implementation details specified in <xref target="RFC4122"/> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.
 				</t></li>
 				<li><t>
-					The previous specification also does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are different.
+					<xref target="RFC4122"/> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.
 				</t></li>
 			</ol>
 
@@ -142,6 +140,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 					<dt>CSPRNG</dt><dd>Cryptographically Secure Pseudo-Random Number Generator</dd>
 					<dt>MAC</dt><dd>Media Access Control</dd>
 					<dt>MSB</dt><dd>Most Significant Bit</dd>
+					<dt>DBMS</dt><dd>Database Management System</dd>
 				</dl>
 			</section>
 		</section>
@@ -150,12 +149,22 @@ please see http://xml.resource.org/authoring/README.html. -->
 				The following UUIDs are hereby introduced:
 			</t>
 
-			<ol spacing="compact">
-				<li><t>UUID version 6: A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <xref target="uuidv6"/></t></li>
-				<li><t>UUID version 7E: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <xref target="uuidv7"/></t></li>
-				<li><t>UUID version 8E: A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <xref target="uuidv8"/></t></li>
-				<li><t>Max UUID: A specialized UUID which is the inverse of <xref target="RFC4122" sectionFormat="comma" section="4.1.7"/> See <xref target="maxuuid"/></t></li>
-			</ol>
+			<dl newline="true">
+				<dt>UUID version 6 (UUIDv6)</dt> 
+					<dd>A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <xref target="uuidv6"/></dd>
+				<dt>UUID version 7 (UUIDv7)</dt> 
+					<dd>An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <xref target="v7"/></dd>
+				<dt>UUID version 7E (UUIDv7E)</dt> 
+					<dd>An alternate variant for UUIDv7. See <xref target="uuidv7"/></dd>
+				<dt>UUID version 8 (UUIDv8)</dt> 
+					<dd>A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <xref target="v8"/></dd>
+				<dt>UUID version 8E (UUIDv8E)</dt> 
+					<dd>An alternate variant for UUIDv8. See <xref target="uuidv8"/></dd>
+				<dt>Max UUID</dt> 
+					<dd>A specialized UUID which is the inverse of <xref target="RFC4122" sectionFormat="comma" section="4.1.7"/> See <xref target="maxuuid"/></dd>
+				<dt>UUID Long</dt> 
+					<dd>An extension of the base UUID with variable length beyond 128 bits. See <xref target="uuid_long"/></dd>
+			</dl>
 
 			<section anchor="changelog" title="changelog">
 				<t>RFC EDITOR PLEASE DELETE THIS SECTION.</t>
@@ -163,9 +172,12 @@ please see http://xml.resource.org/authoring/README.html. -->
 				<ul spacing="compact" empty="true">
 					<li><t>- Reworked the draft body to make the content more concise</t></li>
 					<li><t>- UUIDv6 section reworked to just the reorder of the timestamp</t></li>
-					<li><t>- UUIDv7E changed to simplify timestamp mechanism to just millisecond unix timestamp</t></li>
-					<li><t>- UUIDv8E relaxed to be custom in all elements except version and variant</t></li>
+					<li><t>- UUIDv7 changed to simplify timestamp mechanism to just millisecond Unix timestamp</t></li>
+					<li><t>- UUIDv8 relaxed to be custom in all elements except version and variant</t></li>
 					<li><t>- Changed UUIDv7E and UUIDv8E to use Variant 111.</t></li>
+					<li><t>- Introduced Max UUID.</t></li>
+					<li><t>- Re-introduced variable length UUIDs as UUID Long.</t></li>
+					<li><t>- Re-introduced alternate encoding techniques for all UUIDs.</t></li>
 					<li><t>- Added C code samples in Appendix.</t></li>
 					<li><t>- Added test vectors in Appendix.</t></li>
 					<li><t>- Version and Variant section combined into one section.</t></li>
@@ -173,7 +185,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 					<li><t>- Split Encoding and Storage renamed Storing UUIDs, Opacity</t></li>
 					<li><t>- Reworked Global Uniqueness under new section Global and Local Uniqueness</t></li>
 					<li><t>- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.</t></li>
-					<li><t>- Node verbiage only used in UUIDv6 and v7E and v8E reference random instead</t></li>
+					<li><t>- Node verbiage only used in UUIDv6 all others reference random/rand instead</t></li>
 					<li><t>- Clock sequence verbiage changed simply to counter in any section other than UUIDv6</t></li>
 					<li><t>- Added Abbreviations section</t></li>
 					<li><t>- Updated IETF Draft XML Layout</t></li>
@@ -188,8 +200,8 @@ please see http://xml.resource.org/authoring/README.html. -->
 					<li><t>- Changed all instances of "motonic" to "monotonic"</t></li>
 					<li><t>- Changed all instances of "#-bit" to "# bit"</t></li>
 					<li><t>- Changed "proceeding" verbiage to "after" in section 7</t></li>
-					<li><t>- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7</t></li>
-					<li><t>- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7</t></li>
+					<li><t>- Added details on how to pad 32 bit Unix timestamp to 36 bits in UUIDv7</t></li>
+					<li><t>- Added details on how to truncate 64 bit Unix timestamp to 36 bits in UUIDv7</t></li>
 					<li><t>- Added forward reference and bullet to UUIDv8 if truncating 64 bit Unix Epoch is not an option.</t></li>
 					<li><t>- Fixed bad reference to non-existent "time_or_node" in section 4.5.4</t></li>
 				</ul>
@@ -203,11 +215,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 				</ul>
 			</section>
 		</section>
-		<section anchor="format" title="Format">
-			<t>
-				The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.
-			</t>
-			<section anchor="variant_and_version_fields" title="Variant and Version Fields">
+		<section anchor="variant_and_version_fields" title="Variant and Version Fields">
 				<t>
 					The variant bits utilized by UUIDs in this specification 
 					remain in the same octet as originally defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>. 
@@ -232,7 +240,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 				</thead>
 				<tbody>
 					<tr><td>1</td><td>0</td><td>x</td><td>x</td><td>8/9/A/B</td><td>The variant specified by <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>.</td></tr>
-					<tr><td>1</td><td>1</td><td>1</td><td>0</td><td>E</td><td>The variant specified in this document.</td></tr>
+					<tr><td>1</td><td>1</td><td>1</td><td>0</td><td>E</td><td>The new variant specified in this document.</td></tr>
 					<tr><td>1</td><td>1</td><td>1</td><td>1</td><td>F</td><td>Reserved for future definition.</td></tr>
 				</tbody>
 				</table>
@@ -242,22 +250,24 @@ please see http://xml.resource.org/authoring/README.html. -->
 				</t>
 
 				<t>
-					The next table details Variant 10xx and the new versions defined by this specification. 
+					The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
 					A complete guide to all versions within this variant has been includes in <xref target="old_var_table"/>.
 				</t>
 
 				<table>
-					<name>New UUID variant 10xx versions defined by this specification</name>
+					<name>New UUID variant 10xx (8/9/A/B) versions defined by this specification</name>
 					<thead>
 						<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
 					</thead>
 					<tbody>
 						<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6</td><td>Reordered Gregorian time-based UUID specified in this document.</td></tr>
+						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7</td><td>Unix Epoch time-based UUID specified in this document.</td></tr>
+						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8</td><td>Reserved for custom UUID formats specified in this document</td></tr>
 					</tbody>
 				</table>
 				
 				<t>
-					For UUIDv6 the version and variant field placement from <xref target="RFC4122"/> are unchanged and a new version (0110b [6]) has been added.
+					For UUID version 6, 7 and 8 the variant field placement from <xref target="RFC4122"/> are unchanged.
 					An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.
 				</t>
 				
@@ -273,18 +283,18 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
                 </figure>
 				
 				<t>
-					The next table details Variant 110 and the new versions defined by this specification.
+					The next table details Variant 1110 (E) and the new versions defined by this specification.
 					A complete guide to all versions within this variant has been includes in <xref target="new_var_table"/>.
 				</t>
 				
 				<table>
-					<name>UUID variant 1110 versions defined by this specification</name>
+					<name>UUID variant 1110 (E) versions defined by this specification</name>
 					<thead>
 						<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
 					</thead>
 					<tbody>
-						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Unix Epoch time-based UUID specified in this document.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Reserved for custom UUID formats specified in this document</td></tr>
+						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
+						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
 					</tbody>
 				</table>
 				
@@ -304,12 +314,16 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
                     ]]></artwork>
                 </figure>
 				
-			</section>
+		</section>
+		<section anchor="format" title="New Formats">
+			<t>
+				The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.
+			</t>
 			<section anchor="uuidv6" title="UUID Version 6">
 				<t>
 					UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
 					It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
-					Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7E instead.
+					Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.
 				</t>
 
 				<t>
@@ -366,7 +380,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
             Occupies bits 80 through 127 (octets 10-15)</dd>
 		</dl>
 		
-						<t>
+				<t>
 				With UUIDv6 the steps for splitting the timestamp into time_high and time_mid are OPTIONAL
 				since the 48 bits of time_high and time_mid will remain in the same order.
 				An extra step of splitting the first 48 bits of the timestamp into the most significant 
@@ -384,11 +398,99 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 					<tr><td>time_high</td><td>12</td><td>time_low</td></tr>
 				</tbody>
 				</table>
+				
 			</section>
+			<section anchor="v7" title="UUID Version 7">
+				<t>
+					UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.
+				</t>
+				<t>
+					Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible. 
+				</t>
+				<figure>
+					<name>UUIDv7 Field and Bit Layout</name>
+					<artwork><![CDATA[
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           unix_ts_ms                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          unix_ts_ms           |  ver  |       rand_a          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                        rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+					]]></artwork>
+
+				</figure>
+
+				<dl newline="true">
+					<dt>unix_ts_ms:</dt> <dd>48 bit big-endian unsigned number of Unix epoch timestamp as per <xref target="timestamp_granularity"/>.</dd>
+					<dt>ver:</dt> <dd>4 bit UUIDv7 version set as per <xref target="variant_and_version_fields"/></dd>
+					<dt>rand_a:</dt> <dd>12 bits pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
+					<dt>var:</dt> <dd>The 2 bit variant defined by <xref target="variant_and_version_fields"/>.</dd>
+					<dt>rand_b:</dt> <dd>The final 62 bits of pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
+				</dl>
+				
+			</section>
+			<section anchor="v8" title="UUID Version 8">
+				<t>
+					UUID version 8 provides an RFC-compatible format for experimental or vendor-specific use cases.
+					The only requirement is that the variant and version bits MUST be set as defined in <xref target="variant_and_version_fields"/>. 
+					UUIDv8's uniqueness will be implementation-specific and SHOULD NOT be assumed.
+				</t>
+				<t>
+				The only explicitly defined bits are the Version and Variant leaving 120 bits
+				for implementation specific time-based UUIDs. To be clear:
+				UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
+				filled with random data.
+				</t>
+				<t>
+				Some example situations in which UUIDv8 usage could occur:
+				</t>
+				<ul>
+					<li><t>An implementation would like to embed extra information
+					  within the UUID other than what is defined in this document.</t></li>
+					<li><t>An implementation has other application/language restrictions which
+					  inhibit the use of one of the current UUIDs.</t></li>
+				</ul>
+				<figure>
+					<name>UUIDv8 Field and Bit Layout</name>
+					<artwork><![CDATA[
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_a                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          custom_a             |  ver  |       custom_b        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                       custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+					]]></artwork>
+
+				</figure>
+				<dl newline="true">
+					<dt>custom_a:</dt> <dd>The first 48 bits of the layout that can be filled as an implementation sees fit.</dd>
+					<dt>ver:</dt> <dd>The 4 bit version field as defined by <xref target="variant_and_version_fields"/></dd>
+					<dt>custom_b:</dt> <dd>12 more bits of the layout that can be filled as an implementation sees fit.</dd>
+					<dt>var:</dt> <dd>The 2 bit variant field as defined by <xref target="variant_and_version_fields"/>.</dd>
+					<dt>custom_c:</dt> <dd>The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.</dd>
+				</dl>
+			</section>		
+		</section>
+		<section anchor="alternate_uuid_variants" title="Alternate Variants">
+			<t>
+				This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.
+			</t>
 			<section anchor="uuidv7" title="UUID Version 7E">
 				<t>
-					UUID version 7E features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.
-					Implementations SHOULD utilize UUID version 7E over UUID version 1 and 6 if possible. 
+					UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.
+				</t>
+				<t>
+					With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.
 				</t>
 				<figure>
 					<name>UUIDv7E Field and Bit Layout</name>
@@ -409,7 +511,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 				</figure>
 
 				<dl newline="true">
-					<dt>unix_ts_ms:</dt> <dd>48 bit big-endian unsigned number of unix epoch timestamp as per <xref target="timestamp_granularity"/>.</dd>
+					<dt>unix_ts_ms:</dt> <dd>48 bit big-endian unsigned number of Unix epoch timestamp as per <xref target="timestamp_granularity"/>.</dd>
 					<dt>rand_a:</dt> <dd>16 bits pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
 					<dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE7 as defined by <xref target="variant_and_version_fields"/>.</dd>
 					<dt>rand_b:</dt> <dd>The final 56 bits of pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
@@ -418,28 +520,11 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 			</section>
 			<section anchor="uuidv8" title="UUID Version 8E">
 				<t>
-					UUID version 8E provides an RFC-compatible format for experimental or vendor-specific use cases.
-					The only requirement is that the variant and version bits MUST be set as defined in <xref target="variant_and_version_fields"/>. 
-					UUIDv8E's uniqueness will be implementation-specific and SHOULD NOT be assumed.
+					UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.
 				</t>
 				<t>
-				UUIDv8E SHOULD only be utilized if an implementation cannot utilize another UUID in this document or <xref target="RFC4122"/>.
+					With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.
 				</t>
-				<t>
-				The only explicitly defined bits are the Version and Variant leaving 120 bits
-				for implementation specific time-based UUIDs. To be clear:
-				UUIDv8E is not a replacement for UUIDv4 where all 122 extra bits are
-				filled with random data.
-				</t>
-				<t>
-				Some example situations in which UUIDv8E usage could occur:
-				</t>
-				<ul>
-					<li><t>An implementation would like to embed extra information
-					  within the UUID other than what is defined in this document.</t></li>
-					<li><t>An implementation has other application/language restrictions which
-					  inhibit the use of one of the current UUIDs.</t></li>
-				</ul>
 				<figure>
 					<name>UUIDv8E Field and Bit Layout</name>
 					<artwork><![CDATA[
@@ -462,9 +547,15 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 					<dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE8 as defined by <xref target="variant_and_version_fields"/>.</dd>
 					<dt>custom_b:</dt> <dd>The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.</dd>
 				</dl>
-			</section>
+			</section>	
+		</section>
+
+		<section anchor="alternate_uuid_formats" title="Alternate Formats">
+			<t>
+				This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <xref target="RFC4122"/>.
+			</t>
 			<section anchor="maxuuid" title="Max UUID">
-				<t>The Max UUID is special form of UUID that is specified to have all 128 bits set to 1.</t>
+				<t>The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.7"/></t>
 				<figure>
 					<name>Max UUID Format</name>
 					<artwork><![CDATA[
@@ -472,7 +563,64 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					]]></artwork>
 
 				</figure>
-			</section>			
+			</section>	
+			<section anchor="uuid_long" title="UUID Long">
+				<t>
+					UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:
+				</t>
+				<dl newline="true">
+					<dt>Increased Entropy:</dt>
+						<dd>While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<xref target="collision_resistance"/>) or guessability (<xref target="unguessability"/>).</dd>
+					<dt>Requirements for additional embedded items:</dt>
+						<dd>Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <xref target="distributed_shared_knowledge"/>.</dd>
+				</dl>
+				<t>
+					UUID Long is compatible with any UUID specified in this document and <xref target="RFC4122"/>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.
+				</t>
+				<figure>
+                    <name>UUID Long Examples</name>
+                    <artwork><![CDATA[
+UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
+   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
+  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
+                    ]]></artwork>
+                </figure>
+				<t>
+					Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.
+				</t>
+				<t>
+					When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.
+				</t>
+				
+			</section>
+			<section anchor="uuid_encoding" title="Alternate Encodings">
+				<t>
+					The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.
+				</t>
+				<t>
+					Where required, UUIDs defined by this specification and <xref target="RFC4122"/> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.
+				</t>
+				<t>
+					When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.
+				</t>
+				<t>
+					The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.
+				</t>
+				<figure>
+                    <name>Alternate Encoding Examples</name>
+                    <artwork><![CDATA[
+UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+UUIDv4 Int: 154072644812979270675542139334331768221
+UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
+UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
+UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
+                    ]]></artwork>
+                </figure>
+				<t>
+					For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <xref target="RFC4648"/>.
+				</t>
+			</section>
 		</section>
 
 		<section anchor="uuid_best_practices" title="UUID Best Practices">
@@ -493,17 +641,17 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					<dt>Reliability:</dt>
 						<dd>Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.</dd>
 					<dt>Source:</dt>
-						<dd>UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8E SHOULD be leveraged.</dd>
+						<dd>UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.</dd>
 					<dt>Sub-second Precision and Accuracy:</dt>
-						<dd>Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8E SHOULD be utilized.</dd>
+						<dd>Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.</dd>
 					<dt>Length:</dt>
-						<dd>The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7E features a 48 bit timestamp.</dd>
+						<dd>The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.</dd>
 					<dt>Fuzzing:</dt>
 						<dd>Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.</dd>
 					<dt>Padding:</dt>
-						<dd>When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7E.</dd>
+						<dd>When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.</dd>
 					<dt>Truncating:</dt>
-						<dd>Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit unix timestamp to the least significant, right-most 48 bits for UUIDv7E.</dd>
+						<dd>Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.</dd>
 				</dl>
 			</section>
 			<section anchor="monotonicity_counters" title="Monotonicity and Counters">
@@ -515,7 +663,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp. 
 				</t>
 				<t>
-					For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <xref target="distributed_shared_knowledge"/>
+					For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <xref target="distributed_shared_knowledge"/>
 				</t>
 				<t>
 					Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.
@@ -524,25 +672,26 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					<dt>Fixed-Length Dedicated Counter Bits (Method 1):</dt> 
 						<dd>
 						This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
-						Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits..
+						Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.
 						</dd>
-					<dt>Fixed-Length Dedicated Counter Bits (Method 2):</dt> 
+					<dt>Monotonic Random (Method 2):</dt> 
 						<dd>
-						An alternative approach to the previous method is to dedicate a number of bits in the least significant position of the UUID. With this alternative method, the random data MUST be frozen for a given timestamp tick else sorting will be impacted. UUIDs utilizing this method SHOULD be created using UUIDv8E.
+						With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.
 						</dd>
+				</dl>
+				<t>
+					The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:
+				</t>
+				<dl newline="true">
 					<dt>Fixed-Length Dedicated Counter Seeding:</dt> 
 						<dd>
-							Implementations utilizing either fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. A randomly seeded counter alongside Method 2 is more-or-less the same as Monotonic Random (Method 3). Implementations utilizing either fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.
+							Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.
 						</dd>
 					<dt>Fixed-Length Dedicated Counter Length</dt>
 						<dd>Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.</dd>
 					<dt>Fixed-Length Dedicated Counter Rollover Handling</dt>
 						<dd>
 						Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.
-						</dd>
-					<dt>Monotonic Random (Method 3):</dt> 
-						<dd>
-						With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits (Position B) method described in the previous bullets but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by both fixed-length counter bit positions. As such, UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.
 						</dd>
 				</dl>
 				<t>
@@ -614,7 +763,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 			</section>
 			<section anchor="sorting" title="Sorting">
 				<t>
-					UUIDv6 and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.
+					UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.
 				</t>
 				<t>
 					Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
@@ -628,7 +777,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.
 				</t>
 			</section>
-			<section anchor="storing_uuids_opacity" title="Storing UUIDs, Opacity">
+			<section anchor="opacity" title="Opacity">
+				<t>
+					UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <xref target="variant_and_version_fields"/> for more information on determining a UUID version based on the inspected variant bits.
+				</t>
+			</section>
+			<section anchor="database_considerations" title="DBMS and Database Considerations">
 				<t>
 				For many applications, such as databases, storing UUIDs as the text is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID value.
 				Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value. 
@@ -644,10 +798,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</t>
 				<ul spacing="compact">
 					<li><t>Storing as binary requires less space and may result in faster data access.</t></li>
-					<li><t>Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement. </t></li>
+					<li><t>Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.</t></li>
 				</ul>
 				<t>
-					UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <xref target="variant_and_version_fields"/> for more information on determining a UUID version based on the inspected variant bits.
+					DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+					If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
+					In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.
 				</t>
 			</section>
 		</section>
@@ -755,7 +911,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					<author initials="S." surname="Crocker" fullname="S. Crocker">
 						<organization/>
 					</author>
-					<date year="2005" month="JUne"/>
+					<date year="2005" month="June"/>
 					<abstract>
 						<t>Security systems are built on strong cryptographic algorithms that foil pattern analysis attempts. However, the security of these systems is dependent on generating secret quantities for passwords, cryptographic keys, and similar quantities. The use of pseudo-random processes to generate secret quantities can result in pseudo-security. A sophisticated attacker may find it easier to reproduce the environment that produced the secret quantities and to search the resulting small set of possibilities than to locate the quantities in the whole of the potential number space.</t>
 						<t>Choosing random quantities to foil a resourceful and motivated adversary is surprisingly difficult. This document points out many pitfalls in using poor entropy sources or traditional pseudo-random number generation techniques for generating such quantities. It recommends the use of truly random hardware techniques and shows that the existing hardware on many systems can be used for this purpose. It provides suggestions to ameliorate the problem when a hardware solution is not available, and it gives examples of how large such quantities need to be for some applications. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t>
@@ -763,6 +919,20 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</front>
 				<seriesInfo name="RFC" value="4086"/>
 				<seriesInfo name="DOI" value="10.17487/RFC4086"/>
+			</reference>
+			<reference anchor="RFC4648" target="https://www.rfc-editor.org/info/rfc4122">
+				<front>
+					<title>The Base16, Base32, and Base64 Data Encodings</title>
+					<author initials="S." surname="Josefsson" fullname="S. Josefsson">
+						<organization/>
+					</author>
+					<date year="2006" month="October"/>
+					<abstract>
+						<t> This document describes the commonly used base 64, base 32, and base 16 encoding schemes.  It also discusses the use of line-feeds in encoded data, use of padding in encoded data, use of non-alphabet characters in encoded data, use of different encoding alphabets, and canonical encodings.</t>
+					</abstract>
+				</front>
+				<seriesInfo name="RFC" value="4648"/>
+				<seriesInfo name="DOI" value="10.17487/RFC4648"/>
 			</reference>
 		</references>
 		<references title="Informative References">
@@ -1052,20 +1222,20 @@ int main() {
 					<name>Test Vector Timestamp Pseudo-code</name>
 					<artwork><![CDATA[
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
-gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
+gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 
 # Gregorian to Unix Offset:
 # The number of 100-ns intervals between the
 # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-# gregorian_unix_offset = 0x01b21dd213814000 or 122192928000000000
+# gregorian_Unix_offset = 0x01b21dd213814000 or 122192928000000000
 
 # Unix 64 bit Nanosecond Timestamp:
 # Unix NS: Tuesday, February 22, 2022 2:22:22 PM GMT-05:00
-# unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
+# Unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
 
 # Work:
 # gregorian_100_ns = (1645557742000000000 / 100) + 122192928000000000
-# (138648505420000000 - 122192928000000000) * 100 = unix_64_bit_nanoseconds
+# (138648505420000000 - 122192928000000000) * 100 = Unix_64_bit_nanoseconds
 
 # Final:
 # gregorian_100_ns = 0x1EC9414C232AB00 or 138648505420000000
@@ -1113,8 +1283,30 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="uuidv7_example" title="Example of a UUIDv7E Value">
-				<t>This example UUIDv7E test vector utilizes a well-known 32-bit unix epoch with additional millisecond precision to fill the first 48 bits</t>
+			<section anchor="uuidv7_example" title="Example of a UUIDv7 Value">
+				<t>This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
+				<t>rand_a and rand_b are filled with random data.</t>
+				<t>The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000</t>
+				<figure>
+					<name>UUIDv7 Example Test Vector</name>
+					<artwork><![CDATA[
+-------------------------------
+field      bits    value
+-------------------------------
+unix_ts_ms   48    0x017F21CFD130
+var           4    0x7
+rand_a       12    0xCC3
+var           2    b10
+rand_b       62    0x18C4DC0C0C07398F
+-------------------------------
+total       128               
+-------------------------------
+final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
+					]]></artwork>
+				</figure>
+			</section>
+			<section anchor="uuidv7E_example" title="Example of a UUIDv7E Value">
+				<t>This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
 				<t>rand_a and rand_b are filled with random data.</t>
 				<t>The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000</t>
 				<figure>
@@ -1128,14 +1320,37 @@ rand_a       16    0xF8B8
 var_ver       8    0xE7
 rand_b       56    0xD6A139DC9535C5
 -------------------------------
-total        128               
+total       128               
 -------------------------------
 final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="uuidv8_example" title="Example of a UUIDv8E Value">
-				<t>This example UUIDv8E test vector utilizes a well-known 64-bit unix epoch with nanosecond precision to fill the first 64 bits through ver_var.</t>
+			<section anchor="uuidv8_example" title="Example of a UUIDv8 Value">
+				<t>This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.</t>
+				<t>The next two segments of custom_b and custmo_c are are filled with random data.</t>
+				<t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
+				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
+				<figure>
+					<name>UUIDv8E Example Test Vector</name>
+					<artwork><![CDATA[
+-------------------------------
+field      bits    value
+-------------------------------
+custom_a     48    0x320C3D4DCC00
+ver           4    0x8
+custom_b     12    0x75B
+var           2    b10
+custom_c     62    0xEC932D5F69181C0
+-------------------------------
+total       128               
+-------------------------------
+final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
+					]]></artwork>
+				</figure>
+			</section>
+			<section anchor="uuidv8E_example" title="Example of a UUIDv8E Value">
+				<t>This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.</t>
 				<t>The final 56 bits are filled with random data.</t>
 				<t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
 				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
@@ -1149,7 +1364,7 @@ custom_a     64    0x16D6320C3D4DCC00
 var_ver       8    0xE8
 custom_b     56    0x3C2D06302FC417
 -------------------------------
-total        128               
+total       128               
 -------------------------------
 final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 					]]></artwork>
@@ -1171,8 +1386,8 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 						<tr><td>0</td><td>1</td><td>0</td><td>0</td><td>4</td><td>The randomly or pseudo-randomly generated version specified in <xref target="RFC4122" sectionFormat="comma" section="4.1.3"/>.</td></tr>
 						<tr><td>0</td><td>1</td><td>0</td><td>1</td><td>5</td><td>The name-based version specified in <xref target="RFC4122" sectionFormat="comma" section="4.1.3"/> that uses SHA-1 hashing.</td></tr>
 						<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6</td><td>Reordered Gregorian time-based UUID specified in this document.</td></tr>
-						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8</td><td>Reserved for future definition.</td></tr>
+						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7</td><td>Unix Epoch time-based UUID specified in this document.</td></tr>
+						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8</td><td>Reserved for custom UUID formats specified in this document.</td></tr>
 						<tr><td>1</td><td>0</td><td>0</td><td>1</td><td>9</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>0</td><td>1</td><td>0</td><td>10</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>0</td><td>1</td><td>1</td><td>11</td><td>Reserved for future definition.</td></tr>
@@ -1197,8 +1412,8 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 						<tr><td>0</td><td>1</td><td>0</td><td>0</td><td>4E</td><td>Reserved for future definition.</td></tr>
 						<tr><td>0</td><td>1</td><td>0</td><td>1</td><td>5E</td><td>Reserved for future definition.</td></tr>
 						<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Unix Epoch time-based UUID specified in this document.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Reserved for custom UUID formats specified in this document</td></tr>
+						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
+						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
 						<tr><td>1</td><td>0</td><td>0</td><td>1</td><td>9E</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>0</td><td>1</td><td>0</td><td>10E</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>0</td><td>1</td><td>1</td><td>11E</td><td>Reserved for future definition.</td></tr>

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -685,13 +685,16 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 				<dl newline="true">
 					<dt>Fixed-Length Dedicated Counter Seeding:</dt> 
 						<dd>
-							Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.
+							Implementations utilizing fixed-length counter method SHOULD randomly initialize the counter with each new timestamp tick. 
+							However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. 
+							When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. 
+							Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.
 						</dd>
 					<dt>Fixed-Length Dedicated Counter Length</dt>
-						<dd>Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.</dd>
+						<dd>Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.</dd>
 					<dt>Fixed-Length Dedicated Counter Rollover Handling</dt>
 						<dd>
-						Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.
+						Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
 						</dd>
 				</dl>
 				<t>

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -34,7 +34,7 @@ please see http://xml.resource.org/authoring/README.html. -->
 		<keyword>uuid</keyword>
 		<abstract>
 			<t>
-				This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
+				This document presents new Universally Unique Identifier (UUID) formats for use in modern applications and databases.
 			</t>
 		</abstract>
 	</front>
@@ -74,12 +74,6 @@ please see http://xml.resource.org/authoring/README.html. -->
 				</t></li>
 				<li><t>
 					Introspection/parsing is required to order by time sequence; as opposed to being able to perform a simple byte-by-byte comparison.
-				</t></li>
-				<li><t>
-					The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.
-				</t></li>
-				<li><t>
-					The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.
 				</t></li>
 				<li><t>
 					Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
@@ -154,16 +148,10 @@ please see http://xml.resource.org/authoring/README.html. -->
 					<dd>A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <xref target="uuidv6"/></dd>
 				<dt>UUID version 7 (UUIDv7)</dt> 
 					<dd>An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <xref target="v7"/></dd>
-				<dt>UUID version 7E (UUIDv7E)</dt> 
-					<dd>An alternate variant for UUIDv7. See <xref target="uuidv7"/></dd>
 				<dt>UUID version 8 (UUIDv8)</dt> 
 					<dd>A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <xref target="v8"/></dd>
-				<dt>UUID version 8E (UUIDv8E)</dt> 
-					<dd>An alternate variant for UUIDv8. See <xref target="uuidv8"/></dd>
 				<dt>Max UUID</dt> 
 					<dd>A specialized UUID which is the inverse of <xref target="RFC4122" sectionFormat="comma" section="4.1.7"/> See <xref target="maxuuid"/></dd>
-				<dt>UUID Long</dt> 
-					<dd>An extension of the base UUID with variable length beyond 128 bits. See <xref target="uuid_long"/></dd>
 			</dl>
 
 			<section anchor="changelog" title="changelog">
@@ -174,17 +162,14 @@ please see http://xml.resource.org/authoring/README.html. -->
 					<li><t>- UUIDv6 section reworked to just the reorder of the timestamp</t></li>
 					<li><t>- UUIDv7 changed to simplify timestamp mechanism to just millisecond Unix timestamp</t></li>
 					<li><t>- UUIDv8 relaxed to be custom in all elements except version and variant</t></li>
-					<li><t>- Changed UUIDv7E and UUIDv8E to use Variant 111.</t></li>
 					<li><t>- Introduced Max UUID.</t></li>
-					<li><t>- Re-introduced variable length UUIDs as UUID Long.</t></li>
-					<li><t>- Re-introduced alternate encoding techniques for all UUIDs.</t></li>
 					<li><t>- Added C code samples in Appendix.</t></li>
 					<li><t>- Added test vectors in Appendix.</t></li>
 					<li><t>- Version and Variant section combined into one section.</t></li>
 					<li><t>- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).</t></li>
-					<li><t>- Split Encoding and Storage renamed Storing UUIDs, Opacity</t></li>
-					<li><t>- Reworked Global Uniqueness under new section Global and Local Uniqueness</t></li>
 					<li><t>- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.</t></li>
+					<li><t>- Split Encoding and Storage into Opacity and DBMS and Database Considerations</t></li>
+					<li><t>- Reworked Global Uniqueness under new section Global and Local Uniqueness</t></li>
 					<li><t>- Node verbiage only used in UUIDv6 all others reference random/rand instead</t></li>
 					<li><t>- Clock sequence verbiage changed simply to counter in any section other than UUIDv6</t></li>
 					<li><t>- Added Abbreviations section</t></li>
@@ -221,39 +206,9 @@ please see http://xml.resource.org/authoring/README.html. -->
 					remain in the same octet as originally defined by <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>. 
 				</t>								
 				<t>
-					This specification makes use of the unused variant bits of 111 defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>.
-					This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
-					All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
-					The placement of the version within the same octet as the variant leaves room for a future variant as described below:
-				</t>								
-				<ul spacing="compact">
-					<li><t>UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.</t></li>
-					<li><t>Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.</t></li>
-				</ul>
-				<t>
-					The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.
-				</t>
-				<table>
-				<name>UUID Variant defined by this specification</name>
-				<thead>
-					<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Hex</td><td>Description</td></tr>
-				</thead>
-				<tbody>
-					<tr><td>1</td><td>0</td><td>x</td><td>x</td><td>8/9/A/B</td><td>The variant specified by <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>.</td></tr>
-					<tr><td>1</td><td>1</td><td>1</td><td>0</td><td>E</td><td>The new variant specified in this document.</td></tr>
-					<tr><td>1</td><td>1</td><td>1</td><td>1</td><td>F</td><td>Reserved for future definition.</td></tr>
-				</tbody>
-				</table>
-
-				<t>
-					UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.
-				</t>
-
-				<t>
 					The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
 					A complete guide to all versions within this variant has been includes in <xref target="old_var_table"/>.
 				</t>
-
 				<table>
 					<name>New UUID variant 10xx (8/9/A/B) versions defined by this specification</name>
 					<thead>
@@ -281,49 +236,17 @@ please see http://xml.resource.org/authoring/README.html. -->
 xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
                     ]]></artwork>
                 </figure>
-				
-				<t>
-					The next table details Variant 1110 (E) and the new versions defined by this specification.
-					A complete guide to all versions within this variant has been includes in <xref target="new_var_table"/>.
-				</t>
-				
-				<table>
-					<name>UUID variant 1110 (E) versions defined by this specification</name>
-					<thead>
-						<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
-					</thead>
-					<tbody>
-						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
-					</tbody>
-				</table>
-				
-                <t>
-                    For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
-					Since the bits of the variant remain in the same place as described in <xref target="RFC4122"/> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
-					An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.
-                </t>
-                <figure>
-                    <name>UUID version 7E and 8E Variant Examples</name>
-                    <artwork><![CDATA[
-00000000-0000-0000-E700-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-
-00000000-0000-0000-E800-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-                    ]]></artwork>
-                </figure>
-				
+							
 		</section>
 		<section anchor="format" title="New Formats">
 			<t>
-				The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.
+				The UUID format is 16 octets; the variant bits in conjunction with the version bits described in the next section in determine finer structure.
 			</t>
 			<section anchor="uuidv6" title="UUID Version 6">
 				<t>
 					UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
 					It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
-					Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.
+					Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 instead.
 				</t>
 
 				<t>
@@ -477,83 +400,9 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 					<dt>ver:</dt> <dd>The 4 bit version field as defined by <xref target="variant_and_version_fields"/></dd>
 					<dt>custom_b:</dt> <dd>12 more bits of the layout that can be filled as an implementation sees fit.</dd>
 					<dt>var:</dt> <dd>The 2 bit variant field as defined by <xref target="variant_and_version_fields"/>.</dd>
-					<dt>custom_c:</dt> <dd>The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.</dd>
-				</dl>
-			</section>		
-		</section>
-		<section anchor="alternate_uuid_variants" title="Alternate Variants">
-			<t>
-				This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.
-			</t>
-			<section anchor="uuidv7" title="UUID Version 7E">
-				<t>
-					UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.
-				</t>
-				<t>
-					With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.
-				</t>
-				<figure>
-					<name>UUIDv7E Field and Bit Layout</name>
-					<artwork><![CDATA[
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           unix_ts_ms                          |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|          unix_ts_ms           |            rand_a             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-					]]></artwork>
-
-				</figure>
-
-				<dl newline="true">
-					<dt>unix_ts_ms:</dt> <dd>48 bit big-endian unsigned number of Unix epoch timestamp as per <xref target="timestamp_granularity"/>.</dd>
-					<dt>rand_a:</dt> <dd>16 bits pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
-					<dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE7 as defined by <xref target="variant_and_version_fields"/>.</dd>
-					<dt>rand_b:</dt> <dd>The final 56 bits of pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
-				</dl>
-
-			</section>
-			<section anchor="uuidv8" title="UUID Version 8E">
-				<t>
-					UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.
-				</t>
-				<t>
-					With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.
-				</t>
-				<figure>
-					<name>UUIDv8E Field and Bit Layout</name>
-					<artwork><![CDATA[
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-					]]></artwork>
-
-				</figure>
-				<dl newline="true">
-					<dt>custom_a:</dt> <dd>The first 64 bits of the layout that can be filled as an implementation sees fit.</dd>
-					<dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE8 as defined by <xref target="variant_and_version_fields"/>.</dd>
-					<dt>custom_b:</dt> <dd>The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.</dd>
+					<dt>custom_c:</dt> <dd>The final 62 bits of the layout immediatly following the var field to be filled as an implementation sees fit.</dd>
 				</dl>
 			</section>	
-		</section>
-
-		<section anchor="alternate_uuid_formats" title="Alternate Formats">
-			<t>
-				This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <xref target="RFC4122"/>.
-			</t>
 			<section anchor="maxuuid" title="Max UUID">
 				<t>The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.7"/></t>
 				<figure>
@@ -564,65 +413,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 
 				</figure>
 			</section>	
-			<section anchor="uuid_long" title="UUID Long">
-				<t>
-					UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:
-				</t>
-				<dl newline="true">
-					<dt>Increased Entropy:</dt>
-						<dd>While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<xref target="collision_resistance"/>) or guessability (<xref target="unguessability"/>).</dd>
-					<dt>Requirements for additional embedded items:</dt>
-						<dd>Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <xref target="distributed_shared_knowledge"/>.</dd>
-				</dl>
-				<t>
-					UUID Long is compatible with any UUID specified in this document and <xref target="RFC4122"/>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.
-				</t>
-				<figure>
-                    <name>UUID Long Examples</name>
-                    <artwork><![CDATA[
-UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
-   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
-  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
-                    ]]></artwork>
-                </figure>
-				<t>
-					Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.
-				</t>
-				<t>
-					When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.
-				</t>
-				
-			</section>
-			<section anchor="uuid_encoding" title="Alternate Encodings">
-				<t>
-					The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.
-				</t>
-				<t>
-					Where required, UUIDs defined by this specification and <xref target="RFC4122"/> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.
-				</t>
-				<t>
-					When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.
-				</t>
-				<t>
-					The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.
-				</t>
-				<figure>
-                    <name>Alternate Encoding Examples</name>
-                    <artwork><![CDATA[
-UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-UUIDv4 Int: 154072644812979270675542139334331768221
-UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
-UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
-UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
-                    ]]></artwork>
-                </figure>
-				<t>
-					For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <xref target="RFC4648"/>.
-				</t>
-			</section>
 		</section>
-
 		<section anchor="uuid_best_practices" title="UUID Best Practices">
 				<t>
 					The minimum requirements for generating UUIDs are 
@@ -641,17 +432,17 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 					<dt>Reliability:</dt>
 						<dd>Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.</dd>
 					<dt>Source:</dt>
-						<dd>UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.</dd>
+						<dd>UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 SHOULD be leveraged.</dd>
 					<dt>Sub-second Precision and Accuracy:</dt>
-						<dd>Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.</dd>
+						<dd>Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 SHOULD be utilized.</dd>
 					<dt>Length:</dt>
-						<dd>The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.</dd>
+						<dd>The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 features a 48 bit timestamp.</dd>
 					<dt>Fuzzing:</dt>
 						<dd>Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.</dd>
 					<dt>Padding:</dt>
-						<dd>When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.</dd>
+						<dd>When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7.</dd>
 					<dt>Truncating:</dt>
-						<dd>Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.</dd>
+						<dd>Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7.</dd>
 				</dl>
 			</section>
 			<section anchor="monotonicity_counters" title="Monotonicity and Counters">
@@ -663,7 +454,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 					For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp. 
 				</t>
 				<t>
-					For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <xref target="distributed_shared_knowledge"/>
+					For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <xref target="distributed_shared_knowledge"/>
 				</t>
 				<t>
 					Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.
@@ -672,11 +463,11 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 					<dt>Fixed-Length Dedicated Counter Bits (Method 1):</dt> 
 						<dd>
 						This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
-						Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.
+						Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits.
 						</dd>
 					<dt>Monotonic Random (Method 2):</dt> 
 						<dd>
-						With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.
+						With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 SHOULD utilize this method to handle batch UUID generation during a single timestamp tick. Furthermore, with this method the actual increment of the counter MAY be a random integer of any desired length instead of using simplistic "plus one" logic found with Fixed Length Dedicated Counters. This random increment of the counter ensures the UUIDs retain the required level of unguessability characters provided by the underlying entropy.
 						</dd>
 				</dl>
 				<t>
@@ -694,7 +485,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 						<dd>Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.</dd>
 					<dt>Fixed-Length Dedicated Counter Rollover Handling</dt>
 						<dd>
-						Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
+						Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
 						</dd>
 				</dl>
 				<t>
@@ -725,7 +516,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 					<dt>Shared Knowledge System:</dt> 
 						<dd>With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.</dd>
 					<dt>Node IDs:</dt> 
-						<dd>With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <xref target="Security"/>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.</dd>
+						<dd>With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8. The node id SHOULD NOT be an IEEE 802 MAC address as per <xref target="Security"/>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.</dd>
 				</dl>
 				<t>
 					Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.
@@ -766,7 +557,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 			</section>
 			<section anchor="sorting" title="Sorting">
 				<t>
-					UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.
+					UUIDv6 and UUIDv7 are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.
 				</t>
 				<t>
 					Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
@@ -777,7 +568,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 					UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.
 				</t>
 				<t>
-					UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.
+					UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8.
 				</t>
 			</section>
 			<section anchor="opacity" title="Opacity">
@@ -1144,60 +935,18 @@ void uuidv1tov6(uuid_t u) {
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="creating_a_uuidv7_value" title="Creating a UUIDv7E Value">
+			<section anchor="creating_a_uuidv7_value" title="Creating a UUIDv7 Value">
 				<figure>
-					<name>UUIDv7E Function in C</name>
+					<name>UUIDv7 Function in C</name>
 					<artwork><![CDATA[
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
-#include <time.h>
-
-// ...
-
-// csprng data source
-FILE *rndf;
-rndf = fopen("/dev/urandom", "r");
-if (rndf == 0) {
-	printf("fopen /dev/urandom error\n");
-	return 1;
-}
-
-// ...
-
-// generate one UUIDv7E
-uint8_t u[16];
-struct timespec ts;
-int ret;
-
-ret = clock_gettime(CLOCK_REALTIME, &ts);
-if (ret != 0) {
-	printf("clock_gettime error: %d\n", ret);
-	return 1;
-}
-
-uint64_t tms;
-
-tms = ((uint64_t)ts.tv_sec) * 1000;
-tms += ((uint64_t)ts.tv_nsec) / 1000000;
-
-printf("tms: %lld\n", tms);
-
-memset(u, 0, 16);
-
-fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
-
-*((uint64_t*)(u)) |= htonll(tms << 16); // shift time into first 48 bits and OR into place
-
-u[8] = 0xE7; // set var-ver field
+TODO UUIDv7
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="creating_a_uuidv8_value" title="Creating a UUIDv8E Value">
-				<t>UUIDv8E will vary greatly from implementation to implementation. A good candidate use case for UUIDv8E is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.</t>
+			<section anchor="creating_a_uuidv8_value" title="Creating a UUIDv8 Value">
+				<t>UUIDv8 will vary greatly from implementation to implementation. A good candidate use case for UUIDv8 is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.</t>
 				<figure>
-					<name>UUID8 Function in C</name>
+					<name>UUIDv8 Function in C</name>
 					<artwork><![CDATA[
 #include <stdint.h>
 #include <stdio.h>
@@ -1308,34 +1057,13 @@ final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="uuidv7E_example" title="Example of a UUIDv7E Value">
-				<t>This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
-				<t>rand_a and rand_b are filled with random data.</t>
-				<t>The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000</t>
-				<figure>
-					<name>UUIDv7E Example Test Vector</name>
-					<artwork><![CDATA[
--------------------------------
-field      bits    value
--------------------------------
-unix_ts_ms   48    0x017F21CFD130
-rand_a       16    0xF8B8
-var_ver       8    0xE7
-rand_b       56    0xD6A139DC9535C5
--------------------------------
-total       128               
--------------------------------
-final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
-					]]></artwork>
-				</figure>
-			</section>
 			<section anchor="uuidv8_example" title="Example of a UUIDv8 Value">
 				<t>This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.</t>
 				<t>The next two segments of custom_b and custmo_c are are filled with random data.</t>
 				<t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
-				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
+				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
 				<figure>
-					<name>UUIDv8E Example Test Vector</name>
+					<name>UUIDv8 Example Test Vector</name>
 					<artwork><![CDATA[
 -------------------------------
 field      bits    value
@@ -1352,32 +1080,11 @@ final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
 					]]></artwork>
 				</figure>
 			</section>
-			<section anchor="uuidv8E_example" title="Example of a UUIDv8E Value">
-				<t>This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.</t>
-				<t>The final 56 bits are filled with random data.</t>
-				<t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
-				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
-				<figure>
-					<name>UUIDv8E Example Test Vector</name>
-					<artwork><![CDATA[
--------------------------------
-field      bits    value
--------------------------------
-custom_a     64    0x16D6320C3D4DCC00
-var_ver       8    0xE8
-custom_b     56    0x3C2D06302FC417
--------------------------------
-total       128               
--------------------------------
-final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
-					]]></artwork>
-				</figure>
-			</section>
 		</section>
 		<section anchor="var_tables" title="Version and Variant Tables">
 			<section anchor="old_var_table" title="Variant 10xx Versions">
                 <table>
-					<name>All UUID variant 10xx version definitions.</name>
+					<name>All UUID variant 10xx (8/9/A/B) version definitions.</name>
 					<thead>
 						<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
 					</thead>
@@ -1398,32 +1105,6 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 						<tr><td>1</td><td>1</td><td>0</td><td>1</td><td>13</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>1</td><td>1</td><td>0</td><td>14</td><td>Reserved for future definition.</td></tr>
 						<tr><td>1</td><td>1</td><td>1</td><td>1</td><td>15</td><td>Reserved for future definition.</td></tr>
-					</tbody>
-                </table>
-			</section>
-			<section anchor="new_var_table" title="Variant 1110 Versions">
-                <table>
-					<name>All UUID variant 1110 version definitions.</name>
-					<thead>
-						<tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
-					</thead>
-					<tbody>
-						<tr><td>0</td><td>0</td><td>0</td><td>0</td><td>0E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>0</td><td>0</td><td>1</td><td>1E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>0</td><td>1</td><td>0</td><td>2E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>0</td><td>1</td><td>1</td><td>3E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>1</td><td>0</td><td>0</td><td>4E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>1</td><td>0</td><td>1</td><td>5E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
-						<tr><td>1</td><td>0</td><td>0</td><td>1</td><td>9E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>0</td><td>1</td><td>0</td><td>10E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>0</td><td>1</td><td>1</td><td>11E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>1</td><td>0</td><td>0</td><td>12E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>1</td><td>0</td><td>1</td><td>13E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>1</td><td>1</td><td>0</td><td>14E</td><td>Reserved for future definition.</td></tr>
-						<tr><td>1</td><td>1</td><td>1</td><td>1</td><td>15E</td><td>Reserved for future definition.</td></tr>
 					</tbody>
                 </table>
 			</section>

--- a/editor-notes/e-var-alt-enc-uuid-long-backup.txt
+++ b/editor-notes/e-var-alt-enc-uuid-long-backup.txt
@@ -1,0 +1,339 @@
+                ### Intro
+                <li><t>
+                    The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.
+                </t></li>
+                <li><t>
+                    The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.
+                </t></li>
+
+                ### New
+                <dt>UUID version 7E (UUIDv7E)</dt> 
+                    <dd>An alternate variant for UUIDv7. See <xref target="uuidv7"/></dd>
+                <dt>UUID version 8E (UUIDv8E)</dt> 
+                    <dd>An alternate variant for UUIDv8. See <xref target="uuidv8"/></dd>
+                <dt>UUID Long</dt> 
+                    <dd>An extension of the base UUID with variable length beyond 128 bits. See <xref target="uuid_long"/></dd>
+
+                    ### Changelog
+                    <li><t>- Changed UUIDv7E and UUIDv8E to use Variant 111.</t></li>
+                    <li><t>- Re-introduced variable length UUIDs as UUID Long.</t></li>
+                    <li><t>- Re-introduced alternate encoding techniques for all UUIDs.</t></li>
+
+                ### New Variant
+                <t>
+                    This specification makes use of the unused variant bits of 111 defined in <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>.
+                    This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
+                    All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
+                    The placement of the version within the same octet as the variant leaves room for a future variant as described below:
+                </t>                                
+                <ul spacing="compact">
+                    <li><t>UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.</t></li>
+                    <li><t>Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.</t></li>
+                </ul>
+                <t>
+                    The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.
+                </t>
+                <table>
+                <name>UUID Variant defined by this specification</name>
+                <thead>
+                    <tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Hex</td><td>Description</td></tr>
+                </thead>
+                <tbody>
+                    <tr><td>1</td><td>0</td><td>x</td><td>x</td><td>8/9/A/B</td><td>The variant specified by <xref target="RFC4122" sectionFormat="comma" section="4.1.1"/>.</td></tr>
+                    <tr><td>1</td><td>1</td><td>1</td><td>0</td><td>E</td><td>The new variant specified in this document.</td></tr>
+                    <tr><td>1</td><td>1</td><td>1</td><td>1</td><td>F</td><td>Reserved for future definition.</td></tr>
+                </tbody>
+                </table>
+
+                <t>
+                    UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.
+                </t>
+
+                # Var E
+                <t>
+                    The next table details Variant 1110 (E) and the new versions defined by this specification.
+                    A complete guide to all versions within this variant has been includes in <xref target="new_var_table"/>.
+                </t>
+                
+                <table>
+                    <name>UUID variant 1110 (E) versions defined by this specification</name>
+                    <thead>
+                        <tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
+                        <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
+                    </tbody>
+                </table>
+                
+                <t>
+                    For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
+                    Since the bits of the variant remain in the same place as described in <xref target="RFC4122"/> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
+                    An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.
+                </t>
+                <figure>
+                    <name>UUID version 7E and 8E Variant Examples</name>
+                    <artwork><![CDATA[
+00000000-0000-0000-E700-000000000000
+xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
+
+00000000-0000-0000-E800-000000000000
+xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
+                    ]]></artwork>
+                </figure>
+
+                <section anchor="alternate_uuid_variants" title="Alternate Variants">
+            <t>
+                This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.
+            </t>
+            <section anchor="uuidv7" title="UUID Version 7E">
+                <t>
+                    UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.
+                </t>
+                <t>
+                    With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.
+                </t>
+                <figure>
+                    <name>UUIDv7E Field and Bit Layout</name>
+                    <artwork><![CDATA[
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           unix_ts_ms                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          unix_ts_ms           |            rand_a             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|    var_ver    |            rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                    ]]></artwork>
+
+                </figure>
+
+                <dl newline="true">
+                    <dt>unix_ts_ms:</dt> <dd>48 bit big-endian unsigned number of Unix epoch timestamp as per <xref target="timestamp_granularity"/>.</dd>
+                    <dt>rand_a:</dt> <dd>16 bits pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
+                    <dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE7 as defined by <xref target="variant_and_version_fields"/>.</dd>
+                    <dt>rand_b:</dt> <dd>The final 56 bits of pseudo-random data to provide uniqueness as per <xref target="monotonicity_counters"/> and <xref target="unguessability"/>.</dd>
+                </dl>
+
+            </section>
+            <section anchor="uuidv8" title="UUID Version 8E">
+                <t>
+                    UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.
+                </t>
+                <t>
+                    With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.
+                </t>
+                <figure>
+                    <name>UUIDv8E Field and Bit Layout</name>
+                    <artwork><![CDATA[
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_a                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_a                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|    var_ver    |           custom_b                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_b                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                    ]]></artwork>
+
+                </figure>
+                <dl newline="true">
+                    <dt>custom_a:</dt> <dd>The first 64 bits of the layout that can be filled as an implementation sees fit.</dd>
+                    <dt>var_ver:</dt> <dd>The 8 bit combined variant and version field with the value 0xE8 as defined by <xref target="variant_and_version_fields"/>.</dd>
+                    <dt>custom_b:</dt> <dd>The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.</dd>
+                </dl>
+            </section>  
+        </section>
+
+        ### Alt, Long
+        <section anchor="alternate_uuid_formats" title="Alternate Formats">
+            <t>
+                This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <xref target="RFC4122"/>.
+            </t>
+
+            <section anchor="uuid_long" title="UUID Long">
+                <t>
+                    UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:
+                </t>
+                <dl newline="true">
+                    <dt>Increased Entropy:</dt>
+                        <dd>While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<xref target="collision_resistance"/>) or guessability (<xref target="unguessability"/>).</dd>
+                    <dt>Requirements for additional embedded items:</dt>
+                        <dd>Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <xref target="distributed_shared_knowledge"/>.</dd>
+                </dl>
+                <t>
+                    UUID Long is compatible with any UUID specified in this document and <xref target="RFC4122"/>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.
+                </t>
+                <figure>
+                    <name>UUID Long Examples</name>
+                    <artwork><![CDATA[
+UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
+   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
+  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
+                    ]]></artwork>
+                </figure>
+                <t>
+                    Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.
+                </t>
+                <t>
+                    When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.
+                </t>
+                
+            </section>
+            <section anchor="uuid_encoding" title="Alternate Encodings">
+                <t>
+                    The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.
+                </t>
+                <t>
+                    Where required, UUIDs defined by this specification and <xref target="RFC4122"/> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.
+                </t>
+                <t>
+                    When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.
+                </t>
+                <t>
+                    The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.
+                </t>
+                <figure>
+                    <name>Alternate Encoding Examples</name>
+                    <artwork><![CDATA[
+UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+UUIDv4 Int: 154072644812979270675542139334331768221
+UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
+UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
+UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
+                    ]]></artwork>
+                </figure>
+                <t>
+                    For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <xref target="RFC4648"/>.
+                </t>
+            </section>
+        </section>
+
+        <section anchor="uuidv7E_example" title="Example of a UUIDv7E Value">
+                <t>This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
+                <t>rand_a and rand_b are filled with random data.</t>
+                <t>The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000</t>
+                <figure>
+                    <name>UUIDv7E Example Test Vector</name>
+                    <artwork><![CDATA[
+-------------------------------
+field      bits    value
+-------------------------------
+unix_ts_ms   48    0x017F21CFD130
+rand_a       16    0xF8B8
+var_ver       8    0xE7
+rand_b       56    0xD6A139DC9535C5
+-------------------------------
+total       128               
+-------------------------------
+final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
+                    ]]></artwork>
+                </figure>
+            </section>
+
+            <section anchor="uuidv8E_example" title="Example of a UUIDv8E Value">
+                <t>This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.</t>
+                <t>The final 56 bits are filled with random data.</t>
+                <t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
+                <t>It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>
+                <figure>
+                    <name>UUIDv8E Example Test Vector</name>
+                    <artwork><![CDATA[
+-------------------------------
+field      bits    value
+-------------------------------
+custom_a     64    0x16D6320C3D4DCC00
+var_ver       8    0xE8
+custom_b     56    0x3C2D06302FC417
+-------------------------------
+total       128               
+-------------------------------
+final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
+                    ]]></artwork>
+                </figure>
+            </section>
+
+            <section anchor="new_var_table" title="Variant 1110 Versions">
+                <table>
+                    <name>All UUID variant 1110 version definitions.</name>
+                    <thead>
+                        <tr><td>Msb0</td><td>Msb1</td><td>Msb2</td><td>Msb3</td><td>Version</td><td>Description</td></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>0</td><td>0</td><td>0</td><td>0</td><td>0E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>0</td><td>0</td><td>1</td><td>1E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>0</td><td>1</td><td>0</td><td>2E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>0</td><td>1</td><td>1</td><td>3E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>1</td><td>0</td><td>0</td><td>4E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>1</td><td>0</td><td>1</td><td>5E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>1</td><td>1</td><td>0</td><td>6E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>0</td><td>1</td><td>1</td><td>1</td><td>7E</td><td>Alternate Unix Epoch time-based UUID specified in this document.</td></tr>
+                        <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>8E</td><td>Alternate reservation for custom UUID formats specified in this document.</td></tr>
+                        <tr><td>1</td><td>0</td><td>0</td><td>1</td><td>9E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>0</td><td>1</td><td>0</td><td>10E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>0</td><td>1</td><td>1</td><td>11E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>1</td><td>0</td><td>0</td><td>12E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>1</td><td>0</td><td>1</td><td>13E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>1</td><td>1</td><td>0</td><td>14E</td><td>Reserved for future definition.</td></tr>
+                        <tr><td>1</td><td>1</td><td>1</td><td>1</td><td>15E</td><td>Reserved for future definition.</td></tr>
+                    </tbody>
+                </table>
+            </section>
+
+                        <section anchor="creating_a_uuidv7_value" title="Creating a UUIDv7 Value">
+                <figure>
+                    <name>UUIDv7 Function in C</name>
+                    <artwork><![CDATA[
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+// ...
+
+// csprng data source
+FILE *rndf;
+rndf = fopen("/dev/urandom", "r");
+if (rndf == 0) {
+    printf("fopen /dev/urandom error\n");
+    return 1;
+}
+
+// ...
+
+// generate one UUIDv7E
+uint8_t u[16];
+struct timespec ts;
+int ret;
+
+ret = clock_gettime(CLOCK_REALTIME, &ts);
+if (ret != 0) {
+    printf("clock_gettime error: %d\n", ret);
+    return 1;
+}
+
+uint64_t tms;
+
+tms = ((uint64_t)ts.tv_sec) * 1000;
+tms += ((uint64_t)ts.tv_nsec) / 1000000;
+
+printf("tms: %lld\n", tms);
+
+memset(u, 0, 16);
+
+fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
+
+*((uint64_t*)(u)) |= htonll(tms << 16); // shift time into first 48 bits and OR into place
+
+u[8] = 0xE7; // set var-ver field
+                    ]]></artwork>
+                </figure>
+            </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <meta content="Kyzer R. Davis" name="author">
 <meta content="
        
- This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
+ This document presents new Universally Unique Identifier (UUID) formats for use in modern applications and databases.
        
     " name="description">
 <meta content="xml2rfc 3.12.2" name="generator">
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/K22ubvQGu0.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/y9xSTrScnA.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 15 September 2022</td>
+<td class="center">Expires 17 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-14" class="published">14 March 2022</time>
+<time datetime="2022-03-16" class="published">16 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-15">15 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-17">17 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1229,7 +1229,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
- This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+ This document presents new Universally Unique Identifier (UUID) formats for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 15 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 17 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1316,127 +1316,96 @@ li > p:last-of-type {
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
                 <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-uuid-version-8" class="xref">UUID Version 8</a></p>
 </li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
+</li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-alternate-variants" class="xref">Alternate Variants</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.4">
+                <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.5">
+                <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.6">
+                <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.7">
+                <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.8">
+                <p id="section-toc.1-1.6.2.8.1"><a href="#section-6.8" class="xref">6.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.9">
+                <p id="section-toc.1-1.6.2.9.1"><a href="#section-6.9" class="xref">6.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-alternate-formats" class="xref">Alternate Formats</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
-                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
-                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
-                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
-                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
+                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
-                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
+                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7-value" class="xref">Creating a UUIDv7 Value</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.3">
-                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.4">
-                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.5">
-                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.6">
-                <p id="section-toc.1-1.8.2.6.1"><a href="#section-8.6" class="xref">8.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.7">
-                <p id="section-toc.1-1.8.2.7.1"><a href="#section-8.7" class="xref">8.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.8">
-                <p id="section-toc.1-1.8.2.8.1"><a href="#section-8.8" class="xref">8.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.9">
-                <p id="section-toc.1-1.8.2.9.1"><a href="#section-8.9" class="xref">8.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
+                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8-value" class="xref">Creating a UUIDv8 Value</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
-</li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#section-13" class="xref">13</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
+                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
+                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.3">
+                <p id="section-toc.1-1.13.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
+            <p id="section-toc.1-1.14.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
-                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
-                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
-                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
-            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.1">
-                <p id="section-toc.1-1.15.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.2">
-                <p id="section-toc.1-1.15.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.3">
-                <p id="section-toc.1-1.15.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.4">
-                <p id="section-toc.1-1.15.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.5">
-                <p id="section-toc.1-1.15.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
-</li>
-            </ul>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
-            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.1">
-                <p id="section-toc.1-1.16.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.2">
-                <p id="section-toc.1-1.16.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
-</li>
-            </ul>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
-            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.15.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1481,25 +1450,17 @@ li > p:last-of-type {
 </li>
         <li id="section-1-4.4">
           <p id="section-1-4.4.1">
- The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
+ Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
+ Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
+ information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.5">
           <p id="section-1-4.5.1">
- The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
+ Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.6">
           <p id="section-1-4.6.1">
- Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
- Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
- information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-1-4.7">
-          <p id="section-1-4.7.1">
- Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.7.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-1-4.8">
-          <p id="section-1-4.8.1">
- <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.8.1" class="pilcrow">¶</a></p>
+ <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-1-5">
@@ -1623,24 +1584,12 @@ li > p:last-of-type {
         <dd style="margin-left: 1.5em" id="section-3-2.4">An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#v7" class="xref">Section 5.2</a><a href="#section-3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate variant for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+<dt id="section-3-2.5">UUID version 8 (UUIDv8)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
-<dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.8">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.8" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate variant for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.11">Max UUID</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.12">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 7.1</a><a href="#section-3-2.12" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.13">UUID Long</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.14">An extension of the base UUID with variable length beyond 128 bits. See <a href="#uuid_long" class="xref">Section 7.2</a><a href="#section-3-2.14" class="pilcrow">¶</a>
+<dt id="section-3-2.7">Max UUID</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.8">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 5.4</a><a href="#section-3-2.8" class="pilcrow">¶</a>
 </dd>
       <dd class="break"></dd>
 </dl>
@@ -1665,52 +1614,43 @@ li > p:last-of-type {
             <p id="section-3.1-3.4.1">- UUIDv8 relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.5">
-            <p id="section-3.1-3.5.1">- Changed UUIDv7E and UUIDv8E to use Variant 111.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.5.1">- Introduced Max UUID.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.6">
-            <p id="section-3.1-3.6.1">- Introduced Max UUID.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.6.1">- Added C code samples in Appendix.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.7">
-            <p id="section-3.1-3.7.1">- Re-introduced variable length UUIDs as UUID Long.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.7.1">- Added test vectors in Appendix.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.8">
-            <p id="section-3.1-3.8.1">- Re-introduced alternate encoding techniques for all UUIDs.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.8.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.9">
-            <p id="section-3.1-3.9.1">- Added C code samples in Appendix.<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.9.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.10">
-            <p id="section-3.1-3.10.1">- Added test vectors in Appendix.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.10.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.11">
-            <p id="section-3.1-3.11.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.11.1">- Split Encoding and Storage into Opacity and DBMS and Database Considerations<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.12">
-            <p id="section-3.1-3.12.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.12.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.13">
-            <p id="section-3.1-3.13.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.13.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.14">
-            <p id="section-3.1-3.14.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.14.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.15">
-            <p id="section-3.1-3.15.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.15.1">- Added Abbreviations section<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.16">
-            <p id="section-3.1-3.16.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.16.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.17">
-            <p id="section-3.1-3.17.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.18">
-            <p id="section-3.1-3.18.1">- Added Abbreviations section<a href="#section-3.1-3.18.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.19">
-            <p id="section-3.1-3.19.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.19.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="compact ulEmpty" id="section-3.1-3.20">
-            <p id="section-3.1-3.20.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.20.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.17.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="section-3.1-4">draft-02<a href="#section-3.1-4" class="pilcrow">¶</a></p>
@@ -1780,70 +1720,11 @@ li > p:last-of-type {
  The variant bits utilized by UUIDs in this specification 
  remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4-1" class="pilcrow">¶</a></p>
 <p id="section-4-2">
- This specification makes use of the unused variant bits of 111 defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.
- This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
- All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
- The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4-2" class="pilcrow">¶</a></p>
-<ul class="compact">
-<li class="compact" id="section-4-3.1">
-          <p id="section-4-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4-3.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li class="compact" id="section-4-3.2">
-          <p id="section-4-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4-3.2.1" class="pilcrow">¶</a></p>
-</li>
-      </ul>
-<p id="section-4-4">
- The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4-4" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-defined-by-thi"></span><table class="center" id="table-1">
+ The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
+ A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-1">
         <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
-<a href="#name-uuid-variant-defined-by-thi" class="selfRef">UUID Variant defined by this specification</a>
-        </caption>
-<thead>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-            <td class="text-left" rowspan="1" colspan="1">Hex</td>
-            <td class="text-left" rowspan="1" colspan="1">Description</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">x</td>
-            <td class="text-left" rowspan="1" colspan="1">x</td>
-            <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
-            <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">E</td>
-            <td class="text-left" rowspan="1" colspan="1">The new variant specified in this document.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">F</td>
-            <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-          </tr>
-        </tbody>
-      </table>
-<p id="section-4-6">
- UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4-6" class="pilcrow">¶</a></p>
-<p id="section-4-7">
- The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
- A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-7" class="pilcrow">¶</a></p>
-<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
-        <caption>
-<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-new-uuid-variant-10xx-8-9-a" class="selfRef">New UUID variant 10xx (8/9/A/B) versions defined by this specification</a>
         </caption>
 <thead>
@@ -1883,11 +1764,11 @@ li > p:last-of-type {
           </tr>
         </tbody>
       </table>
-<p id="section-4-9">
+<p id="section-4-4">
  For UUID version 6, 7 and 8 the variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged.
- An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-9" class="pilcrow">¶</a></p>
+ An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-4" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-variant-examples"></span><figure id="figure-1">
-        <div class="alignLeft art-text artwork" id="section-4-10.1">
+        <div class="alignLeft art-text artwork" id="section-4-5.1">
 <pre>
 00000000-0000-6000-8000-000000000000
 00000000-0000-6000-9000-000000000000
@@ -1899,60 +1780,6 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
 <a href="#name-uuidv6-variant-examples" class="selfRef">UUIDv6 Variant Examples</a>
         </figcaption></figure>
-<p id="section-4-11">
- The next table details Variant 1110 (E) and the new versions defined by this specification.
- A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4-11" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-1110-e-version"></span><table class="center" id="table-3">
-        <caption>
-<a href="#table-3" class="selfRef">Table 3</a>:
-<a href="#name-uuid-variant-1110-e-version" class="selfRef">UUID variant 1110 (E) versions defined by this specification</a>
-        </caption>
-<thead>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-            <td class="text-left" rowspan="1" colspan="1">Version</td>
-            <td class="text-left" rowspan="1" colspan="1">Description</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">7E</td>
-            <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
-          </tr>
-          <tr>
-            <td class="text-left" rowspan="1" colspan="1">1</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">0</td>
-            <td class="text-left" rowspan="1" colspan="1">8E</td>
-            <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
-          </tr>
-        </tbody>
-      </table>
-<p id="section-4-13">
-                    For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
- Since the bits of the variant remain in the same place as described in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
- An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4-13" class="pilcrow">¶</a></p>
-<span id="name-uuid-version-7e-and-8e-vari"></span><figure id="figure-2">
-        <div class="alignLeft art-text artwork" id="section-4-14.1">
-<pre>
-00000000-0000-0000-E700-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-
-00000000-0000-0000-E800-000000000000
-xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
-</pre>
-</div>
-<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
-<a href="#name-uuid-version-7e-and-8e-vari" class="selfRef">UUID version 7E and 8E Variant Examples</a>
-        </figcaption></figure>
 </section>
 </div>
 <div id="format">
@@ -1961,7 +1788,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <a href="#section-5" class="section-number selfRef">5. </a><a href="#name-new-formats" class="section-name selfRef">New Formats</a>
       </h2>
 <p id="section-5-1">
- The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
+ The UUID format is 16 octets; the variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <div id="uuidv6">
 <section id="section-5.1">
         <h3 id="name-uuid-version-6">
@@ -1970,7 +1797,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <p id="section-5.1-1">
  UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
  It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
- Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+ Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
 <p id="section-5.1-2">
  Instead of splitting the timestamp into the low, mid and high sections from UUIDv1, UUIDv6 changes this sequence so timestamp bytes are stored from most to least significant.  
  That is, given a 60 bit timestamp value as specified for UUIDv1 in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>,
@@ -1979,10 +1806,10 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <p id="section-5.1-3">
  The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
 <p id="section-5.1-4">
- The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 10</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
+ The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 8</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
 <p id="section-5.1-5">
  The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-5.1-5" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-3">
+<span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-2">
           <div class="alignLeft art-text artwork" id="section-5.1-6.1">
 <pre>
      0                   1                   2                   3
@@ -1998,7 +1825,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
 <a href="#name-uuidv6-field-and-bit-layout" class="selfRef">UUIDv6 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.1-7">
@@ -2042,9 +1869,9 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
  32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
  In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
-<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-4">
+<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-2">
           <caption>
-<a href="#table-4" class="selfRef">Table 4</a>:
+<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-uuidv1-to-uuidv6-field-mapp" class="selfRef">UUIDv1 to UUIDv6 Field Mappings</a>
           </caption>
 <thead>
@@ -2083,7 +1910,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
  UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <p id="section-5.2-2">
  Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-4">
+<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-3">
           <div class="alignLeft art-text artwork" id="section-5.2-3.1">
 <pre>
  0                   1                   2                   3
@@ -2099,12 +1926,12 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
 <a href="#name-uuidv7-field-and-bit-layout" class="selfRef">UUIDv7 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.2-4">
           <dt id="section-5.2-4.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 6.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.3">ver:</dt>
@@ -2112,7 +1939,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.5">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 6.2</a> and <a href="#unguessability" class="xref">Section 6.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.7">var:</dt>
@@ -2120,7 +1947,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.2-4.9">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 6.2</a> and <a href="#unguessability" class="xref">Section 6.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -2152,7 +1979,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
    inhibit the use of one of the current UUIDs.<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-5">
+<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-4">
           <div class="alignLeft art-text artwork" id="section-5.3-5.1">
 <pre>
  0                   1                   2                   3
@@ -2168,7 +1995,7 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
 <a href="#name-uuidv8-field-and-bit-layout" class="selfRef">UUIDv8 Field and Bit Layout</a>
           </figcaption></figure>
 <span class="break"></span><dl class="dlNewline" id="section-5.3-6">
@@ -2189,488 +2016,311 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </dd>
           <dd class="break"></dd>
 <dt id="section-5.3-6.9">custom_c:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
-</section>
-</div>
-<div id="alternate_uuid_variants">
-<section id="section-6">
-      <h2 id="name-alternate-variants">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-alternate-variants" class="section-name selfRef">Alternate Variants</a>
-      </h2>
-<p id="section-6-1">
- This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.<a href="#section-6-1" class="pilcrow">¶</a></p>
-<div id="uuidv7">
-<section id="section-6.1">
-        <h3 id="name-uuid-version-7e">
-<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
-        </h3>
-<p id="section-6.1-1">
- UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
-<p id="section-6.1-2">
- With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-6">
-          <div class="alignLeft art-text artwork" id="section-6.1-3.1">
-<pre>
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           unix_ts_ms                          |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|          unix_ts_ms           |            rand_a             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            rand_b                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</pre>
-</div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
-<a href="#name-uuidv7e-field-and-bit-layou" class="selfRef">UUIDv7E Field and Bit Layout</a>
-          </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-6.1-4">
-          <dt id="section-6.1-4.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-6.1-4.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.3">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.5">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.1-4.6" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.1-4.7">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-4.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.8" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-</section>
-</div>
-<div id="uuidv8">
-<section id="section-6.2">
-        <h3 id="name-uuid-version-8e">
-<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
-        </h3>
-<p id="section-6.2-1">
- UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
-<p id="section-6.2-2">
- With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-7">
-          <div class="alignLeft art-text artwork" id="section-6.2-3.1">
-<pre>
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_a                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    var_ver    |           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           custom_b                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-</pre>
-</div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
-<a href="#name-uuidv8e-field-and-bit-layou" class="selfRef">UUIDv8E Field and Bit Layout</a>
-          </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-6.2-4">
-          <dt id="section-6.2-4.1">custom_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-6.2-4.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-4.3">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.2-4.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-4.5">custom_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-4.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-6.2-4.6" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-</section>
-</div>
-</section>
-</div>
-<div id="alternate_uuid_formats">
-<section id="section-7">
-      <h2 id="name-alternate-formats">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-alternate-formats" class="section-name selfRef">Alternate Formats</a>
-      </h2>
-<p id="section-7-1">
- This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-7-1" class="pilcrow">¶</a></p>
 <div id="maxuuid">
-<section id="section-7.1">
+<section id="section-5.4">
         <h3 id="name-max-uuid">
-<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
         </h3>
-<p id="section-7.1-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-7.1-1" class="pilcrow">¶</a></p>
-<span id="name-max-uuid-format"></span><figure id="figure-8">
-          <div class="alignLeft art-text artwork" id="section-7.1-2.1">
+<p id="section-5.4-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-5.4-1" class="pilcrow">¶</a></p>
+<span id="name-max-uuid-format"></span><figure id="figure-5">
+          <div class="alignLeft art-text artwork" id="section-5.4-2.1">
 <pre>
 FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
 <a href="#name-max-uuid-format" class="selfRef">Max UUID Format</a>
           </figcaption></figure>
-</section>
-</div>
-<div id="uuid_long">
-<section id="section-7.2">
-        <h3 id="name-uuid-long">
-<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
-        </h3>
-<p id="section-7.2-1">
- UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-7.2-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-7.2-2">
-          <dt id="section-7.2-2.1">Increased Entropy:</dt>
-          <dd style="margin-left: 1.5em" id="section-7.2-2.2">While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<a href="#collision_resistance" class="xref">Section 8.4</a>) or guessability (<a href="#unguessability" class="xref">Section 8.6</a>).<a href="#section-7.2-2.2" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-7.2-2.3">Requirements for additional embedded items:</dt>
-          <dd style="margin-left: 1.5em" id="section-7.2-2.4">Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-7.2-2.4" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-</dl>
-<p id="section-7.2-3">
- UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuid-long-examples"></span><figure id="figure-9">
-          <div class="alignLeft art-text artwork" id="section-7.2-4.1">
-<pre>
-UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
-   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
-  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
-</pre>
-</div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
-<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
-          </figcaption></figure>
-<p id="section-7.2-5">
- Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-7.2-5" class="pilcrow">¶</a></p>
-<p id="section-7.2-6">
- When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
-</section>
-</div>
-<div id="uuid_encoding">
-<section id="section-7.3">
-        <h3 id="name-alternate-encodings">
-<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
-        </h3>
-<p id="section-7.3-1">
- The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
-<p id="section-7.3-2">
- Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.<a href="#section-7.3-2" class="pilcrow">¶</a></p>
-<p id="section-7.3-3">
- When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.<a href="#section-7.3-3" class="pilcrow">¶</a></p>
-<p id="section-7.3-4">
- The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
-<span id="name-alternate-encoding-examples"></span><figure id="figure-10">
-          <div class="alignLeft art-text artwork" id="section-7.3-5.1">
-<pre>
-UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
-UUIDv4 Int: 154072644812979270675542139334331768221
-UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
-UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
-UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
-</pre>
-</div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
-<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
-          </figcaption></figure>
-<p id="section-7.3-6">
- For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="uuid_best_practices">
-<section id="section-8">
+<section id="section-6">
       <h2 id="name-uuid-best-practices">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
       </h2>
-<p id="section-8-1">
+<p id="section-6-1">
  The minimum requirements for generating UUIDs are 
  described in this document for each version.
  Everything else is an implementation detail and 
  up to the implementer to decide what is appropriate for a given 
  implementation. That being said, various relevant factors are covered
- below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-8-1" class="pilcrow">¶</a></p>
+ below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-6-1" class="pilcrow">¶</a></p>
 <div id="timestamp_granularity">
-<section id="section-8.1">
+<section id="section-6.1">
         <h3 id="name-timestamp-granularity">
-<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
         </h3>
-<p id="section-8.1-1">
- UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.1-2">
-          <dt id="section-8.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-8.1-2.2" class="pilcrow">¶</a>
+<p id="section-6.1-1">
+ UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.1-2">
+          <dt id="section-6.1-2.1">Reliability:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-6.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.3">Source:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.<a href="#section-8.1-2.4" class="pilcrow">¶</a>
+<dt id="section-6.1-2.3">Source:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 SHOULD be leveraged.<a href="#section-6.1-2.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.<a href="#section-8.1-2.6" class="pilcrow">¶</a>
+<dt id="section-6.1-2.5">Sub-second Precision and Accuracy:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.7">Length:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.<a href="#section-8.1-2.8" class="pilcrow">¶</a>
+<dt id="section-6.1-2.7">Length:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 features a 48 bit timestamp.<a href="#section-6.1-2.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.9">Fuzzing:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-8.1-2.10" class="pilcrow">¶</a>
+<dt id="section-6.1-2.9">Fuzzing:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-6.1-2.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.11">Padding:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.<a href="#section-8.1-2.12" class="pilcrow">¶</a>
+<dt id="section-6.1-2.11">Padding:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7.<a href="#section-6.1-2.12" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.1-2.13">Truncating:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-8.1-2.14" class="pilcrow">¶</a>
+<dt id="section-6.1-2.13">Truncating:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7.<a href="#section-6.1-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="monotonicity_counters">
-<section id="section-8.2">
+<section id="section-6.2">
         <h3 id="name-monotonicity-and-counters">
-<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
         </h3>
-<p id="section-8.2-1">
- Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
-<p id="section-8.2-2">
+<p id="section-6.2-1">
+ Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation of order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
-<p id="section-8.2-3">
- For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a><a href="#section-8.2-3" class="pilcrow">¶</a></p>
-<p id="section-8.2-4">
- Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-8.2-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.2-5">
-          <dt id="section-8.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-5.2">
+ For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<p id="section-6.2-3">
+ For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a><a href="#section-6.2-3" class="pilcrow">¶</a></p>
+<p id="section-6.2-4">
+ Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-6.2-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-5">
+          <dt id="section-6.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.2">
  This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
- Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.<a href="#section-8.2-5.2" class="pilcrow">¶</a>
+ Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits.<a href="#section-6.2-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-5.3">Monotonic Random (Method 2):</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-5.4">
- With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-8.2-5.4" class="pilcrow">¶</a>
+<dt id="section-6.2-5.3">Monotonic Random (Method 2):</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.4">
+ With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 SHOULD utilize this method to handle batch UUID generation during a single timestamp tick. Furthermore, with this method the actual increment of the counter MAY be a random integer of any desired length instead of using simplistic "plus one" logic found with Fixed Length Dedicated Counters. This random increment of the counter ensures the UUIDs retain the required level of unguessability characters provided by the underlying entropy.<a href="#section-6.2-5.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.2-6">
- The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-8.2-6" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.2-7">
-          <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.2">
+<p id="section-6.2-6">
+ The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-6.2-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-7">
+          <dt id="section-6.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.2">
  Implementations utilizing fixed-length counter method SHOULD randomly initialize the counter with each new timestamp tick. 
  However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. 
  When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. 
- Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+ Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-6.2-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+<dt id="section-6.2-7.3">Fixed-Length Dedicated Counter Length</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-6.2-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+<dt id="section-6.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.6">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-6.2-7.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.2-8">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-8.2-8" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-8.2-9">
- <li id="section-8.2-9.1">
-            <p id="section-8.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-8.2-9.1.1" class="pilcrow">¶</a></p>
+<p id="section-6.2-8">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-6.2-9">
+ <li id="section-6.2-9.1">
+            <p id="section-6.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-8.2-9.2">
-            <p id="section-8.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-8.2-9.2.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-9.2">
+            <p id="section-6.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-6.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-8.2-9.3">
-            <p id="section-8.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-8.2-9.3.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-9.3">
+            <p id="section-6.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-9.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-8.2-10">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-8.2-10" class="pilcrow">¶</a></p>
-<p id="section-8.2-11">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-8.2-11" class="pilcrow">¶</a></p>
+<p id="section-6.2-10">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-10" class="pilcrow">¶</a></p>
+<p id="section-6.2-11">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
-<section id="section-8.3">
+<section id="section-6.3">
         <h3 id="name-distributed-uuid-generation">
-<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
         </h3>
-<p id="section-8.3-1">
+<p id="section-6.3-1">
  Some implementations MAY desire to utilize multi-node, clustered, applications which involve two or more 
  applications independently generating UUIDs that will be stored in a common location. 
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
- This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.3-2">
-          <dt id="section-8.3-2.1">Shared Knowledge System:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-8.3-2.2" class="pilcrow">¶</a>
+ This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.3-2">
+          <dt id="section-6.3-2.1">Shared Knowledge System:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-6.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.3-2.3">Node IDs:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 10</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-8.3-2.4" class="pilcrow">¶</a>
+<dt id="section-6.3-2.3">Node IDs:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 8</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-6.3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-8.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-8.3-3" class="pilcrow">¶</a></p>
+<p id="section-6.3-3">
+ Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
-<section id="section-8.4">
+<section id="section-6.4">
         <h3 id="name-collision-resistance">
-<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
+<a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
-<p id="section-8.4-1">
- Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 8.1</a> and <a href="#monotonicity_counters" class="xref">Section 8.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
-<p id="section-8.4-2">
- There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-8.4-3">
-          <dt id="section-8.4-3.1">Low Impact</dt>
-          <dd style="margin-left: 1.5em" id="section-8.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-8.4-3.2" class="pilcrow">¶</a>
+<p id="section-6.4-1">
+ Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a>.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
+<p id="section-6.4-2">
+ There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-6.4-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.4-3">
+          <dt id="section-6.4-3.1">Low Impact</dt>
+          <dd style="margin-left: 1.5em" id="section-6.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-6.4-3.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-8.4-3.3">High Impact:</dt>
-          <dd style="margin-left: 1.5em" id="section-8.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-8.4-3.4" class="pilcrow">¶</a>
+<dt id="section-6.4-3.3">High Impact:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-6.4-3.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="global_local_uniqueness">
-<section id="section-8.5">
+<section id="section-6.5">
         <h3 id="name-global-and-local-uniqueness">
-<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
+<a href="#section-6.5" class="section-number selfRef">6.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
         </h3>
-<p id="section-8.5-1">
+<p id="section-6.5-1">
  UUIDs created by this specification MAY be used to provide local uniqueness guarantees. 
- For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
-<p id="section-8.5-2">
+ For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-6.5-1" class="pilcrow">¶</a></p>
+<p id="section-6.5-2">
  Although true global uniqueness is impossible to guarantee without shared knowledge scheme; a shared knowledge scheme is not required by UUID to provide uniqueness guarantees.
- Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
+ Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-6.5-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="unguessability">
-<section id="section-8.6">
+<section id="section-6.6">
         <h3 id="name-unguessability">
-<a href="#section-8.6" class="section-number selfRef">8.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
+<a href="#section-6.6" class="section-number selfRef">6.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
         </h3>
-<p id="section-8.6-1">
+<p id="section-6.6-1">
  Implementations SHOULD utilize a cryptographically secure pseudo-random number generator (CSPRNG) to provide values that are both difficult to predict ("unguessable") and have a low likelihood of collision ("unique").
- CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 8.4</a> and <a href="#Security" class="xref">Section 10</a> are present in modern UUIDs.<a href="#section-8.6-1" class="pilcrow">¶</a></p>
-<p id="section-8.6-2">
- Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-8.6-2" class="pilcrow">¶</a></p>
+ CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 6.4</a> and <a href="#Security" class="xref">Section 8</a> are present in modern UUIDs.<a href="#section-6.6-1" class="pilcrow">¶</a></p>
+<p id="section-6.6-2">
+ Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-6.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sorting">
-<section id="section-8.7">
+<section id="section-6.7">
         <h3 id="name-sorting">
-<a href="#section-8.7" class="section-number selfRef">8.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
+<a href="#section-6.7" class="section-number selfRef">6.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
         </h3>
-<p id="section-8.7-1">
- UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-8.7-1" class="pilcrow">¶</a></p>
-<p id="section-8.7-2">
+<p id="section-6.7-1">
+ UUIDv6 and UUIDv7 are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
+<p id="section-6.7-2">
  Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
  As a result objects can much more easily be clustered together for better performance.  
- The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-8.7-2" class="pilcrow">¶</a></p>
-<p id="section-8.7-3">
- UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-8.7-3" class="pilcrow">¶</a></p>
-<p id="section-8.7-4">
- UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-8.7-4" class="pilcrow">¶</a></p>
+ The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-6.7-2" class="pilcrow">¶</a></p>
+<p id="section-6.7-3">
+ UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-6.7-3" class="pilcrow">¶</a></p>
+<p id="section-6.7-4">
+ UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8.<a href="#section-6.7-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="opacity">
-<section id="section-8.8">
+<section id="section-6.8">
         <h3 id="name-opacity">
-<a href="#section-8.8" class="section-number selfRef">8.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
+<a href="#section-6.8" class="section-number selfRef">6.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
         </h3>
-<p id="section-8.8-1">
- UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-8.8-1" class="pilcrow">¶</a></p>
+<p id="section-6.8-1">
+ UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-6.8-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="database_considerations">
-<section id="section-8.9">
+<section id="section-6.9">
         <h3 id="name-dbms-and-database-considera">
-<a href="#section-8.9" class="section-number selfRef">8.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
+<a href="#section-6.9" class="section-number selfRef">6.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
         </h3>
-<p id="section-8.9-1">
+<p id="section-6.9-1">
  For many applications, such as databases, storing UUIDs as the text is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID value.
- Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-8.9-1" class="pilcrow">¶</a></p>
+ Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-6.9-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-8.9-2.1">
-            <p id="section-8.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-8.9-2.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-6.9-2.1">
+            <p id="section-6.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-6.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-8.9-2.2">
-            <p id="section-8.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-8.9-2.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-6.9-2.2">
+            <p id="section-6.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-6.9-2.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-8.9-3">
+<p id="section-6.9-3">
  
  For other systems, UUIDs MAY be stored in binary form or as text, as appropriate. 
- The trade offs to both approaches are as such:<a href="#section-8.9-3" class="pilcrow">¶</a></p>
+ The trade offs to both approaches are as such:<a href="#section-6.9-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-8.9-4.1">
-            <p id="section-8.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-8.9-4.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-6.9-4.1">
+            <p id="section-6.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-6.9-4.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-8.9-4.2">
-            <p id="section-8.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-8.9-4.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-6.9-4.2">
+            <p id="section-6.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-6.9-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-8.9-5">
+<p id="section-6.9-5">
  DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
  If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
- In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-8.9-5" class="pilcrow">¶</a></p>
+ In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-6.9-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="IANA">
-<section id="section-9">
+<section id="section-7">
       <h2 id="name-iana-considerations">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-9-1">This document has no IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
+<p id="section-7-1">This document has no IANA actions.<a href="#section-7-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Security">
-<section id="section-10">
+<section id="section-8">
       <h2 id="name-security-considerations">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-10-1"> 
+<p id="section-8-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
  Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
- uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 8.6</a> for more information.<a href="#section-10-1" class="pilcrow">¶</a></p>
-<p id="section-10-2">
+ uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 6.6</a> for more information.<a href="#section-8-1" class="pilcrow">¶</a></p>
+<p id="section-8-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 
  an embedded counter does signal the order of creation for a given UUID and it's corresponding data but 
  does not define anything about the data itself or the application as a whole. If UUIDs are required for
- use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-10-2" class="pilcrow">¶</a></p>
+ use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-8-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Acknowledgements">
-<section id="section-11">
+<section id="section-9">
       <h2 id="name-acknowledgements">
-<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-11-1">The authors gratefully acknowledge the contributions of 
+<p id="section-9-1">The authors gratefully acknowledge the contributions of 
  Ben Campbell,
  Ben Ramsey,
  Fabio Lima,
@@ -2684,12 +2334,12 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
  Robert Kieffer,
  sergeyprokhorenko,
  LiosK
- As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-11-1" class="pilcrow">¶</a></p>
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-12">
+<section id="section-10">
       <h2 id="name-normative-references">
-<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
       </h2>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -2714,9 +2364,9 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-13">
+<section id="section-11">
       <h2 id="name-informative-references">
-<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
       </h2>
 <dl class="references">
 <dt id="LexicalUUID">[LexicalUUID]</dt>
@@ -2800,7 +2450,7 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-creating-a-uuidv6-value" class="section-name selfRef">Creating a UUIDv6 Value</a>
         </h3>
 <p id="appendix-A.1-1">This section details a function in C which converts from a UUID version 1 to version 6:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-function-in-c"></span><figure id="figure-11">
+<span id="name-uuidv6-function-in-c"></span><figure id="figure-6">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2834,76 +2484,34 @@ void uuidv1tov6(uuid_t u) {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-uuidv6-function-in-c" class="selfRef">UUIDv6 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="creating_a_uuidv7_value">
 <section id="appendix-A.2">
-        <h3 id="name-creating-a-uuidv7e-value">
-<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7e-value" class="section-name selfRef">Creating a UUIDv7E Value</a>
+        <h3 id="name-creating-a-uuidv7-value">
+<a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7-value" class="section-name selfRef">Creating a UUIDv7 Value</a>
         </h3>
-<span id="name-uuidv7e-function-in-c"></span><figure id="figure-12">
+<span id="name-uuidv7-function-in-c"></span><figure id="figure-7">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
-#include &lt;stdio.h&gt;
-#include &lt;stdlib.h&gt;
-#include &lt;stdint.h&gt;
-#include &lt;string.h&gt;
-#include &lt;time.h&gt;
-
-// ...
-
-// csprng data source
-FILE *rndf;
-rndf = fopen("/dev/urandom", "r");
-if (rndf == 0) {
-        printf("fopen /dev/urandom error\n");
-        return 1;
-}
-
-// ...
-
-// generate one UUIDv7E
-uint8_t u[16];
-struct timespec ts;
-int ret;
-
-ret = clock_gettime(CLOCK_REALTIME, &amp;ts);
-if (ret != 0) {
-        printf("clock_gettime error: %d\n", ret);
-        return 1;
-}
-
-uint64_t tms;
-
-tms = ((uint64_t)ts.tv_sec) * 1000;
-tms += ((uint64_t)ts.tv_nsec) / 1000000;
-
-printf("tms: %lld\n", tms);
-
-memset(u, 0, 16);
-
-fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
-
-*((uint64_t*)(u)) |= htonll(tms &lt;&lt; 16); // shift time into first 48 bits and OR into place
-
-u[8] = 0xE7; // set var-ver field
+TODO UUIDv7
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
-<a href="#name-uuidv7e-function-in-c" class="selfRef">UUIDv7E Function in C</a>
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<a href="#name-uuidv7-function-in-c" class="selfRef">UUIDv7 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="creating_a_uuidv8_value">
 <section id="appendix-A.3">
-        <h3 id="name-creating-a-uuidv8e-value">
-<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8e-value" class="section-name selfRef">Creating a UUIDv8E Value</a>
+        <h3 id="name-creating-a-uuidv8-value">
+<a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8-value" class="section-name selfRef">Creating a UUIDv8 Value</a>
         </h3>
-<p id="appendix-A.3-1">UUIDv8E will vary greatly from implementation to implementation. A good candidate use case for UUIDv8E is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuid8-function-in-c"></span><figure id="figure-13">
+<p id="appendix-A.3-1">UUIDv8 will vary greatly from implementation to implementation. A good candidate use case for UUIDv8 is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
+<span id="name-uuidv8-function-in-c"></span><figure id="figure-8">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 #include &lt;stdint.h&gt;
@@ -2923,8 +2531,8 @@ int main() {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
-<a href="#name-uuid8-function-in-c" class="selfRef">UUID8 Function in C</a>
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<a href="#name-uuidv8-function-in-c" class="selfRef">UUIDv8 Function in C</a>
           </figcaption></figure>
 </section>
 </div>
@@ -2937,7 +2545,7 @@ int main() {
       </h2>
 <p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
-<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-14">
+<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-9">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
 <pre>
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
@@ -2964,7 +2572,7 @@ gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
 <a href="#name-test-vector-timestamp-pseud" class="selfRef">Test Vector Timestamp Pseudo-code</a>
         </figcaption></figure>
 <div id="uuidv6_example">
@@ -2972,7 +2580,7 @@ gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
         <h3 id="name-example-of-a-uuidv6-value">
 <a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-example-of-a-uuidv6-value" class="section-name selfRef">Example of a UUIDv6 Value</a>
         </h3>
-<span id="name-uuidv1-example-test-vector"></span><figure id="figure-15">
+<span id="name-uuidv1-example-test-vector"></span><figure id="figure-10">
           <div class="alignLeft art-text artwork" id="appendix-B.1-1.1">
 <pre>
 ----------------------------------------------
@@ -2990,10 +2598,10 @@ total                128
 final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
 <a href="#name-uuidv1-example-test-vector" class="selfRef">UUIDv1 Example Test Vector</a>
           </figcaption></figure>
-<span id="name-uuidv6-example-test-vector"></span><figure id="figure-16">
+<span id="name-uuidv6-example-test-vector"></span><figure id="figure-11">
           <div class="alignLeft art-text artwork" id="appendix-B.1-2.1">
 <pre>
 -----------------------------------------------
@@ -3011,7 +2619,7 @@ total                 128
 final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-uuidv6-example-test-vector" class="selfRef">UUIDv6 Example Test Vector</a>
           </figcaption></figure>
 </section>
@@ -3024,7 +2632,7 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 <p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7-example-test-vector"></span><figure id="figure-17">
+<span id="name-uuidv7-example-test-vector"></span><figure id="figure-12">
           <div class="alignLeft art-text artwork" id="appendix-B.2-4.1">
 <pre>
 -------------------------------
@@ -3041,51 +2649,22 @@ total       128
 final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
 </pre>
 </div>
-<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-uuidv7-example-test-vector" class="selfRef">UUIDv7 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
-<div id="uuidv7E_example">
-<section id="appendix-B.3">
-        <h3 id="name-example-of-a-uuidv7e-value">
-<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
-        </h3>
-<p id="appendix-B.3-1">This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-18">
-          <div class="alignLeft art-text artwork" id="appendix-B.3-4.1">
-<pre>
--------------------------------
-field      bits    value
--------------------------------
-unix_ts_ms   48    0x017F21CFD130
-rand_a       16    0xF8B8
-var_ver       8    0xE7
-rand_b       56    0xD6A139DC9535C5
--------------------------------
-total       128
--------------------------------
-final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
-</pre>
-</div>
-<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
-<a href="#name-uuidv7e-example-test-vector" class="selfRef">UUIDv7E Example Test Vector</a>
-          </figcaption></figure>
-</section>
-</div>
 <div id="uuidv8_example">
-<section id="appendix-B.4">
+<section id="appendix-B.3">
         <h3 id="name-example-of-a-uuidv8-value">
-<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.4-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.4-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.4-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.4-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.4-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.4-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-19">
-          <div class="alignLeft art-text artwork" id="appendix-B.4-5.1">
+<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8-example-test-vector"></span><figure id="figure-13">
+          <div class="alignLeft art-text artwork" id="appendix-B.3-5.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -3101,37 +2680,8 @@ total       128
 final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
 </pre>
 </div>
-<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
-<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
-          </figcaption></figure>
-</section>
-</div>
-<div id="uuidv8E_example">
-<section id="appendix-B.5">
-        <h3 id="name-example-of-a-uuidv8e-value">
-<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
-        </h3>
-<p id="appendix-B.5-1">This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.5-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-2">The final 56 bits are filled with random data.<a href="#appendix-B.5-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.5-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.5-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.5-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector-2"></span><figure id="figure-20">
-          <div class="alignLeft art-text artwork" id="appendix-B.5-5.1">
-<pre>
--------------------------------
-field      bits    value
--------------------------------
-custom_a     64    0x16D6320C3D4DCC00
-var_ver       8    0xE8
-custom_b     56    0x3C2D06302FC417
--------------------------------
-total       128
--------------------------------
-final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
-</pre>
-</div>
-<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
-<a href="#name-uuidv8e-example-test-vector-2" class="selfRef">UUIDv8E Example Test Vector</a>
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<a href="#name-uuidv8-example-test-vector" class="selfRef">UUIDv8 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
@@ -3147,10 +2697,10 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
         <h3 id="name-variant-10xx-versions">
 <a href="#appendix-C.1" class="section-number selfRef">C.1. </a><a href="#name-variant-10xx-versions" class="section-name selfRef">Variant 10xx Versions</a>
         </h3>
-<span id="name-all-uuid-variant-10xx-versi"></span><table class="center" id="table-5">
+<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-3">
           <caption>
-<a href="#table-5" class="selfRef">Table 5</a>:
-<a href="#name-all-uuid-variant-10xx-versi" class="selfRef">All UUID variant 10xx version definitions.</a>
+<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#name-all-uuid-variant-10xx-8-9-a" class="selfRef">All UUID variant 10xx (8/9/A/B) version definitions.</a>
           </caption>
 <thead>
             <tr>
@@ -3291,159 +2841,6 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">15</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-          </tbody>
-        </table>
-</section>
-</div>
-<div id="new_var_table">
-<section id="appendix-C.2">
-        <h3 id="name-variant-1110-versions">
-<a href="#appendix-C.2" class="section-number selfRef">C.2. </a><a href="#name-variant-1110-versions" class="section-name selfRef">Variant 1110 Versions</a>
-        </h3>
-<span id="name-all-uuid-variant-1110-versi"></span><table class="center" id="table-6">
-          <caption>
-<a href="#table-6" class="selfRef">Table 6</a>:
-<a href="#name-all-uuid-variant-1110-versi" class="selfRef">All UUID variant 1110 version definitions.</a>
-          </caption>
-<thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">2E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">3E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">4E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">5E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">6E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">9E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">10E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">11E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">12E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">13E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">14E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">15E</td>
               <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/Zff8bBwAJZ.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/K22ubvQGu0.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 10 September 2022</td>
+<td class="center">Expires 15 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-09" class="published">9 March 2022</time>
+<time datetime="2022-03-14" class="published">14 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-10">10 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-15">15 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 15 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1624,7 +1624,7 @@ li > p:last-of-type {
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate format for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate variant for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
@@ -1632,7 +1632,7 @@ li > p:last-of-type {
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate format for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
+        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate variant for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 <dt id="section-3-2.11">Max UUID</dt>
@@ -2474,16 +2474,19 @@ UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
 <span class="break"></span><dl class="dlNewline" id="section-8.2-7">
           <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
           <dd style="margin-left: 1.5em" id="section-8.2-7.2">
- Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+ Implementations utilizing fixed-length counter method SHOULD randomly initialize the counter with each new timestamp tick. 
+ However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. 
+ When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. 
+ Implementations utilizing fixed-length counter method MAY also choose to randomly initialize a portion counter rather than the entire counter. For example, a 24 bit counter could have the 23 bits in least-significant, right-most, position randomly initialized. The remaining most significant, left-most counter bits are initialized as zero for the sole purpose of guarding against counter rollovers.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits but can be longer. Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
           <dd style="margin-left: 1.5em" id="section-8.2-7.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken. The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -9,14 +9,7 @@
 <meta content="Kyzer R. Davis" name="author">
 <meta content="
        
- This document presents three new Universally Unique Identifier (UUID) formats.
-       
-       
- A common case for modern applications is to create a unique identifier for use as a database key.
- This identifier usually implements an embedded timestamp that is sortable using the monotonic creation time in the most significant bits. 
- In addition the identifier is highly collision resistant, difficult to guess, and provides minimal security attack surfaces.
- None of the existing UUID versions, including UUIDv1, fulfill each of these requirements in the most efficient possible way.
- This document is a proposal to update   with three new UUID versions that address these concerns, each with different trade-offs.
+ This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.
        
     " name="description">
 <meta content="xml2rfc 3.12.2" name="generator">
@@ -40,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/h0xIfLwVNj.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/Zff8bBwAJZ.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1199,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 5 September 2022</td>
+<td class="center">Expires 10 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1215,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-04" class="published">4 March 2022</time>
+<time datetime="2022-03-09" class="published">9 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-05">5 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-10">10 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1236,13 +1229,7 @@ li > p:last-of-type {
 <section id="section-abstract">
       <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
 <p id="section-abstract-1">
- This document presents three new Universally Unique Identifier (UUID) formats.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
-<p id="section-abstract-2">
- A common case for modern applications is to create a unique identifier for use as a database key.
- This identifier usually implements an embedded timestamp that is sortable using the monotonic creation time in the most significant bits. 
- In addition the identifier is highly collision resistant, difficult to guess, and provides minimal security attack surfaces.
- None of the existing UUID versions, including UUIDv1, fulfill each of these requirements in the most efficient possible way.
- This document is a proposal to update <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> with three new UUID versions that address these concerns, each with different trade-offs.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
+ This document presents new Universally Unique Identifier (UUID) formats, variants, and encoding techniques for use in modern applications and databases.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1263,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 5 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 10 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1315,110 +1302,141 @@ li > p:last-of-type {
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-format" class="xref">Format</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
-                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-variant-and-version-fields" class="xref">Variant and Version Fields</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
-                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="xref">4.2</a>.  <a href="#name-uuid-version-6" class="xref">UUID Version 6</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.3">
-                <p id="section-toc.1-1.4.2.3.1"><a href="#section-4.3" class="xref">4.3</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.4">
-                <p id="section-toc.1-1.4.2.4.1"><a href="#section-4.4" class="xref">4.4</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.5">
-                <p id="section-toc.1-1.4.2.5.1"><a href="#section-4.5" class="xref">4.5</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-variant-and-version-fields" class="xref">Variant and Version Fields</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-new-formats" class="xref">New Formats</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
-                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="xref">5.1</a>.  <a href="#name-uuid-version-6" class="xref">UUID Version 6</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
-                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="xref">5.2</a>.  <a href="#name-uuid-version-7" class="xref">UUID Version 7</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
-                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
-                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="xref">5.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.5">
-                <p id="section-toc.1-1.5.2.5.1"><a href="#section-5.5" class="xref">5.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.6">
-                <p id="section-toc.1-1.5.2.6.1"><a href="#section-5.6" class="xref">5.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.7">
-                <p id="section-toc.1-1.5.2.7.1"><a href="#section-5.7" class="xref">5.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.8">
-                <p id="section-toc.1-1.5.2.8.1"><a href="#section-5.8" class="xref">5.8</a>.  <a href="#name-storing-uuids-opacity" class="xref">Storing UUIDs, Opacity</a></p>
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="xref">5.3</a>.  <a href="#name-uuid-version-8" class="xref">UUID Version 8</a></p>
 </li>
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-alternate-variants" class="xref">Alternate Variants</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-uuid-version-7e" class="xref">UUID Version 7E</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-uuid-version-8e" class="xref">UUID Version 8E</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-alternate-formats" class="xref">Alternate Formats</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-max-uuid" class="xref">Max UUID</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.3">
+                <p id="section-toc.1-1.7.2.3.1"><a href="#section-7.3" class="xref">7.3</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-uuid-best-practices" class="xref">UUID Best Practices</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.1">
+                <p id="section-toc.1-1.8.2.1.1"><a href="#section-8.1" class="xref">8.1</a>.  <a href="#name-timestamp-granularity" class="xref">Timestamp Granularity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.2">
+                <p id="section-toc.1-1.8.2.2.1"><a href="#section-8.2" class="xref">8.2</a>.  <a href="#name-monotonicity-and-counters" class="xref">Monotonicity and Counters</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.3">
+                <p id="section-toc.1-1.8.2.3.1"><a href="#section-8.3" class="xref">8.3</a>.  <a href="#name-distributed-uuid-generation" class="xref">Distributed UUID Generation</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.4">
+                <p id="section-toc.1-1.8.2.4.1"><a href="#section-8.4" class="xref">8.4</a>.  <a href="#name-collision-resistance" class="xref">Collision Resistance</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.5">
+                <p id="section-toc.1-1.8.2.5.1"><a href="#section-8.5" class="xref">8.5</a>.  <a href="#name-global-and-local-uniqueness" class="xref">Global and Local Uniqueness</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.6">
+                <p id="section-toc.1-1.8.2.6.1"><a href="#section-8.6" class="xref">8.6</a>.  <a href="#name-unguessability" class="xref">Unguessability</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.7">
+                <p id="section-toc.1-1.8.2.7.1"><a href="#section-8.7" class="xref">8.7</a>.  <a href="#name-sorting" class="xref">Sorting</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.8">
+                <p id="section-toc.1-1.8.2.8.1"><a href="#section-8.8" class="xref">8.8</a>.  <a href="#name-opacity" class="xref">Opacity</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8.2.9">
+                <p id="section-toc.1-1.8.2.9.1"><a href="#section-8.9" class="xref">8.9</a>.  <a href="#name-dbms-and-database-considera" class="xref">DBMS and Database Considerations</a></p>
+</li>
+            </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-normative-references" class="xref">Normative References</a></p>
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
-            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
-                <p id="section-toc.1-1.11.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
-                <p id="section-toc.1-1.11.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.3">
-                <p id="section-toc.1-1.11.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.11.1"><a href="#section-11" class="xref">11</a>. <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
-            <p id="section-toc.1-1.12.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.1">
-                <p id="section-toc.1-1.12.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.2">
-                <p id="section-toc.1-1.12.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12.2.3">
-                <p id="section-toc.1-1.12.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.12.1"><a href="#section-12" class="xref">12</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13">
-            <p id="section-toc.1-1.13.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.1">
-                <p id="section-toc.1-1.13.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
+            <p id="section-toc.1-1.13.1"><a href="#section-13" class="xref">13</a>. <a href="#name-informative-references" class="xref">Informative References</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.13.2.2">
-                <p id="section-toc.1-1.13.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
+            <p id="section-toc.1-1.14.1"><a href="#appendix-A" class="xref">Appendix A</a>.  <a href="#name-example-code" class="xref">Example Code</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.1">
+                <p id="section-toc.1-1.14.2.1.1"><a href="#appendix-A.1" class="xref">A.1</a>.  <a href="#name-creating-a-uuidv6-value" class="xref">Creating a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.2">
+                <p id="section-toc.1-1.14.2.2.1"><a href="#appendix-A.2" class="xref">A.2</a>.  <a href="#name-creating-a-uuidv7e-value" class="xref">Creating a UUIDv7E Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14.2.3">
+                <p id="section-toc.1-1.14.2.3.1"><a href="#appendix-A.3" class="xref">A.3</a>.  <a href="#name-creating-a-uuidv8e-value" class="xref">Creating a UUIDv8E Value</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.14">
-            <p id="section-toc.1-1.14.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15">
+            <p id="section-toc.1-1.15.1"><a href="#appendix-B" class="xref">Appendix B</a>.  <a href="#name-test-vectors" class="xref">Test Vectors</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.1">
+                <p id="section-toc.1-1.15.2.1.1"><a href="#appendix-B.1" class="xref">B.1</a>.  <a href="#name-example-of-a-uuidv6-value" class="xref">Example of a UUIDv6 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.2">
+                <p id="section-toc.1-1.15.2.2.1"><a href="#appendix-B.2" class="xref">B.2</a>.  <a href="#name-example-of-a-uuidv7-value" class="xref">Example of a UUIDv7 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.3">
+                <p id="section-toc.1-1.15.2.3.1"><a href="#appendix-B.3" class="xref">B.3</a>.  <a href="#name-example-of-a-uuidv7e-value" class="xref">Example of a UUIDv7E Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.4">
+                <p id="section-toc.1-1.15.2.4.1"><a href="#appendix-B.4" class="xref">B.4</a>.  <a href="#name-example-of-a-uuidv8-value" class="xref">Example of a UUIDv8 Value</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.15.2.5">
+                <p id="section-toc.1-1.15.2.5.1"><a href="#appendix-B.5" class="xref">B.5</a>.  <a href="#name-example-of-a-uuidv8e-value" class="xref">Example of a UUIDv8E Value</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16">
+            <p id="section-toc.1-1.16.1"><a href="#appendix-C" class="xref">Appendix C</a>.  <a href="#name-version-and-variant-tables" class="xref">Version and Variant Tables</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.1">
+                <p id="section-toc.1-1.16.2.1.1"><a href="#appendix-C.1" class="xref">C.1</a>.  <a href="#name-variant-10xx-versions" class="xref">Variant 10xx Versions</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.16.2.2">
+                <p id="section-toc.1-1.16.2.2.1"><a href="#appendix-C.2" class="xref">C.2</a>.  <a href="#name-variant-1110-versions" class="xref">Variant 1110 Versions</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.17">
+            <p id="section-toc.1-1.17.1"><a href="#appendix-D" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1434,7 +1452,7 @@ li > p:last-of-type {
  Modern applications have a need to create and utilize UUIDs as the primary
  identifier for a variety of different items in complex computational systems,
  including but not limited to database keys, file names, machine
- or system names, identifiers for transactions or other objects or processes.<a href="#section-1-1" class="pilcrow">¶</a></p>
+ or system names, identifiers for event-driven transactions, and other objects or processes.<a href="#section-1-1" class="pilcrow">¶</a></p>
 <p id="section-1-2">
  A specific use case for UUIDs which has gained popularity is as database keys.
  The motivation for this stems primarily from the fact that applications
@@ -1463,17 +1481,25 @@ li > p:last-of-type {
 </li>
         <li id="section-1-4.4">
           <p id="section-1-4.4.1">
- Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
- Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
- information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
+ The textual representation of existing UUIDs utilized for storage or transport is oftentimes unnecessarily verbose.<a href="#section-1-4.4.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.5">
           <p id="section-1-4.5.1">
- Many implementation details are specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but some of the decisions made involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
+ The 128 bit length of current UUIDs oftentimes leads to alternative unique identifier solutions featuring longer bit lengths.<a href="#section-1-4.5.1" class="pilcrow">¶</a></p>
 </li>
         <li id="section-1-4.6">
           <p id="section-1-4.6.1">
- The previous specification also does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are different.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
+ Privacy and network security issues arise from using a MAC address in the node field of Version 1 UUIDs.
+ Exposed MAC addresses can be used as an attack surface to locate machines and reveal various other
+ information about such machines (minimally manufacturer, potentially other details). Additionally, with the advent of virtual machines and containers, MAC address uniqueness is no longer guaranteed.<a href="#section-1-4.6.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-1-4.7">
+          <p id="section-1-4.7.1">
+ Many of the implementation details specified in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> involve trade offs that are neither possible to specify for all applications nor necessary to produce interoperable implementations.<a href="#section-1-4.7.1" class="pilcrow">¶</a></p>
+</li>
+        <li id="section-1-4.8">
+          <p id="section-1-4.8.1">
+ <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> does not distinguish between the requirements for generation of a UUID versus an application which simply stores one, which are often different.<a href="#section-1-4.8.1" class="pilcrow">¶</a></p>
 </li>
       </ol>
 <p id="section-1-5">
@@ -1572,6 +1598,10 @@ li > p:last-of-type {
 <dt id="section-2.2-2.7">MSB</dt>
           <dd style="margin-left: 7.0em" id="section-2.2-2.8">Most Significant Bit<a href="#section-2.2-2.8" class="pilcrow">¶</a>
 </dd>
+          <dd class="break"></dd>
+<dt id="section-2.2-2.9">DBMS</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.10">Database Management System<a href="#section-2.2-2.10" class="pilcrow">¶</a>
+</dd>
         <dd class="break"></dd>
 </dl>
 </section>
@@ -1584,20 +1614,36 @@ li > p:last-of-type {
       </h2>
 <p id="section-3-1">
  The following UUIDs are hereby introduced:<a href="#section-3-1" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-3-2">
- <li id="section-3-2.1">
-          <p id="section-3-2.1.1">UUID version 6: A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <a href="#uuidv6" class="xref">Section 4.2</a><a href="#section-3-2.1.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.2">
-          <p id="section-3-2.2.1">UUID version 7E: An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#uuidv7" class="xref">Section 4.3</a><a href="#section-3-2.2.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.3">
-          <p id="section-3-2.3.1">UUID version 8E: A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#uuidv8" class="xref">Section 4.4</a><a href="#section-3-2.3.1" class="pilcrow">¶</a></p>
-</li>
-        <li id="section-3-2.4">
-          <p id="section-3-2.4.1">Max UUID: A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 4.5</a><a href="#section-3-2.4.1" class="pilcrow">¶</a></p>
-</li>
-      </ol>
+<span class="break"></span><dl class="dlNewline" id="section-3-2">
+        <dt id="section-3-2.1">UUID version 6 (UUIDv6)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.2">A re-ordering of UUID version 1 so it is sortable as an opaque sequence of bytes.  Easy to implement given an existing UUIDv1 implementation. See <a href="#uuidv6" class="xref">Section 5.1</a><a href="#section-3-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.3">UUID version 7 (UUIDv7)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.4">An entirely new time-based UUID bit layout sourced from the widely implemented and well known Unix Epoch timestamp source. See <a href="#v7" class="xref">Section 5.2</a><a href="#section-3-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.5">UUID version 7E (UUIDv7E)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.6">An alternate format for UUIDv7. See <a href="#uuidv7" class="xref">Section 6.1</a><a href="#section-3-2.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.7">UUID version 8 (UUIDv8)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.8">A free-form UUID format which has no explicit requirements except maintaining backward compatibility. See <a href="#v8" class="xref">Section 5.3</a><a href="#section-3-2.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.9">UUID version 8E (UUIDv8E)</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.10">An alternate format for UUIDv8. See <a href="#uuidv8" class="xref">Section 6.2</a><a href="#section-3-2.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.11">Max UUID</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.12">A specialized UUID which is the inverse of <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span> See <a href="#maxuuid" class="xref">Section 7.1</a><a href="#section-3-2.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-3-2.13">UUID Long</dt>
+        <dd style="margin-left: 1.5em" id="section-3-2.14">An extension of the base UUID with variable length beyond 128 bits. See <a href="#uuid_long" class="xref">Section 7.2</a><a href="#section-3-2.14" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
 <div id="changelog">
 <section id="section-3.1">
         <h3 id="name-changelog">
@@ -1613,49 +1659,58 @@ li > p:last-of-type {
             <p id="section-3.1-3.2.1">- UUIDv6 section reworked to just the reorder of the timestamp<a href="#section-3.1-3.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.3">
-            <p id="section-3.1-3.3.1">- UUIDv7E changed to simplify timestamp mechanism to just millisecond unix timestamp<a href="#section-3.1-3.3.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.3.1">- UUIDv7 changed to simplify timestamp mechanism to just millisecond Unix timestamp<a href="#section-3.1-3.3.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.4">
-            <p id="section-3.1-3.4.1">- UUIDv8E relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.4.1">- UUIDv8 relaxed to be custom in all elements except version and variant<a href="#section-3.1-3.4.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.5">
             <p id="section-3.1-3.5.1">- Changed UUIDv7E and UUIDv8E to use Variant 111.<a href="#section-3.1-3.5.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.6">
-            <p id="section-3.1-3.6.1">- Added C code samples in Appendix.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.6.1">- Introduced Max UUID.<a href="#section-3.1-3.6.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.7">
-            <p id="section-3.1-3.7.1">- Added test vectors in Appendix.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.7.1">- Re-introduced variable length UUIDs as UUID Long.<a href="#section-3.1-3.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.8">
-            <p id="section-3.1-3.8.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.8.1">- Re-introduced alternate encoding techniques for all UUIDs.<a href="#section-3.1-3.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.9">
-            <p id="section-3.1-3.9.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.9.1">- Added C code samples in Appendix.<a href="#section-3.1-3.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.10">
-            <p id="section-3.1-3.10.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.10.1">- Added test vectors in Appendix.<a href="#section-3.1-3.10.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.11">
-            <p id="section-3.1-3.11.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.11.1">- Version and Variant section combined into one section.<a href="#section-3.1-3.11.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.12">
-            <p id="section-3.1-3.12.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.12.1">- Changed from pseudo-random number generators to cryptographically secure pseudo-random number generator (CSPRNG).<a href="#section-3.1-3.12.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.13">
-            <p id="section-3.1-3.13.1">- Node verbiage only used in UUIDv6 and v7E and v8E reference random instead<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.13.1">- Split Encoding and Storage renamed Storing UUIDs, Opacity<a href="#section-3.1-3.13.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.14">
-            <p id="section-3.1-3.14.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.14.1">- Reworked Global Uniqueness under new section Global and Local Uniqueness<a href="#section-3.1-3.14.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.15">
-            <p id="section-3.1-3.15.1">- Added Abbreviations section<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.15.1">- Combined redundant topics from all UUIDs into sections such as Timestamp granularity, Monotonicity and Counters, Collision Resistance, Sorting, and Unguessability, etc.<a href="#section-3.1-3.15.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.16">
-            <p id="section-3.1-3.16.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.16.1">- Node verbiage only used in UUIDv6 all others reference random/rand instead<a href="#section-3.1-3.16.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-3.17">
-            <p id="section-3.1-3.17.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-3.17.1">- Clock sequence verbiage changed simply to counter in any section other than UUIDv6<a href="#section-3.1-3.17.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.18">
+            <p id="section-3.1-3.18.1">- Added Abbreviations section<a href="#section-3.1-3.18.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.19">
+            <p id="section-3.1-3.19.1">- Updated IETF Draft XML Layout<a href="#section-3.1-3.19.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="compact ulEmpty" id="section-3.1-3.20">
+            <p id="section-3.1-3.20.1">- Added information about little-endian UUIDs<a href="#section-3.1-3.20.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
 <p id="section-3.1-4">draft-02<a href="#section-3.1-4" class="pilcrow">¶</a></p>
@@ -1682,10 +1737,10 @@ li > p:last-of-type {
             <p id="section-3.1-5.7.1">- Changed "proceeding" verbiage to "after" in section 7<a href="#section-3.1-5.7.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.8">
-            <p id="section-3.1-5.8.1">- Added details on how to pad 32 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.8.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-5.8.1">- Added details on how to pad 32 bit Unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.8.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.9">
-            <p id="section-3.1-5.9.1">- Added details on how to truncate 64 bit unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.9.1" class="pilcrow">¶</a></p>
+            <p id="section-3.1-5.9.1">- Added details on how to truncate 64 bit Unix timestamp to 36 bits in UUIDv7<a href="#section-3.1-5.9.1" class="pilcrow">¶</a></p>
 </li>
           <li class="compact ulEmpty" id="section-3.1-5.10">
             <p id="section-3.1-5.10.1">- Added forward reference and bullet to UUIDv8 if truncating 64 bit Unix Epoch is not an option.<a href="#section-3.1-5.10.1" class="pilcrow">¶</a></p>
@@ -1716,114 +1771,123 @@ li > p:last-of-type {
 </div>
 </section>
 </div>
-<div id="format">
+<div id="variant_and_version_fields">
 <section id="section-4">
-      <h2 id="name-format">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-format" class="section-name selfRef">Format</a>
+      <h2 id="name-variant-and-version-fields">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-variant-and-version-fields" class="section-name selfRef">Variant and Version Fields</a>
       </h2>
 <p id="section-4-1">
- The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<div id="variant_and_version_fields">
-<section id="section-4.1">
-        <h3 id="name-variant-and-version-fields">
-<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-variant-and-version-fields" class="section-name selfRef">Variant and Version Fields</a>
-        </h3>
-<p id="section-4.1-1">
  The variant bits utilized by UUIDs in this specification 
- remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4.1-1" class="pilcrow">¶</a></p>
-<p id="section-4.1-2">
+ remain in the same octet as originally defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">
  This specification makes use of the unused variant bits of 111 defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.
  This variant will move the 4-bit version to the same octet as the variant to overcoming many bit shuffling techniques found in UUID implementations.
  All UUIDs utilizing this variant SHOULD be referenced by their version number plus the uppercase E character to represent the hex character 0xE which will frequent the text representation of UUIDs.
- The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4.1-2" class="pilcrow">¶</a></p>
+ The placement of the version within the same octet as the variant leaves room for a future variant as described below:<a href="#section-4-2" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-4.1-3.1">
-            <p id="section-4.1-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4.1-3.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-4-3.1">
+          <p id="section-4-3.1.1">UUID Version 7E and 8E specified by this document MUST set the first 3 bits of octet 8 to 111 and the fourth bit to 0. The 4 bit version MUST follow the variant to fill out the final bits of octet 8.<a href="#section-4-3.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-4.1-3.2">
-            <p id="section-4.1-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4.1-3.2.1" class="pilcrow">¶</a></p>
+        <li class="compact" id="section-4-3.2">
+          <p id="section-4-3.2.1">Future specifications that wish to utilize variant 111 for a different version position (or any other bit layout position) MUST set the first 3 bits of octet 8 to 111 and then the fourth bit to 1.<a href="#section-4-3.2.1" class="pilcrow">¶</a></p>
 </li>
-        </ul>
-<p id="section-4.1-4">
- The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4.1-4" class="pilcrow">¶</a></p>
+      </ul>
+<p id="section-4-4">
+ The table below detail the three variants described in this document where the letter "x" indicates a "don't-care" value.<a href="#section-4-4" class="pilcrow">¶</a></p>
 <span id="name-uuid-variant-defined-by-thi"></span><table class="center" id="table-1">
-          <caption>
+        <caption>
 <a href="#table-1" class="selfRef">Table 1</a>:
 <a href="#name-uuid-variant-defined-by-thi" class="selfRef">UUID Variant defined by this specification</a>
-          </caption>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Hex</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">x</td>
-              <td class="text-left" rowspan="1" colspan="1">x</td>
-              <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
-              <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">E</td>
-              <td class="text-left" rowspan="1" colspan="1">The variant specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">F</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-6">
- UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4.1-6" class="pilcrow">¶</a></p>
-<p id="section-4.1-7">
- The next table details Variant 10xx and the new versions defined by this specification. 
- A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4.1-7" class="pilcrow">¶</a></p>
-<span id="name-new-uuid-variant-10xx-versi"></span><table class="center" id="table-2">
-          <caption>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Hex</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">x</td>
+            <td class="text-left" rowspan="1" colspan="1">x</td>
+            <td class="text-left" rowspan="1" colspan="1">8/9/A/B</td>
+            <td class="text-left" rowspan="1" colspan="1">The variant specified by <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.1" class="relref">Section 4.1.1</a></span>.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">E</td>
+            <td class="text-left" rowspan="1" colspan="1">The new variant specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">F</td>
+            <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-6">
+ UUID Versions defined within the RFC 4122 Variant are distinct from UUID versions defined by the new variant.<a href="#section-4-6" class="pilcrow">¶</a></p>
+<p id="section-4-7">
+ The next table details Variant 10xx (8/9/A/B) and the new versions defined by this specification. 
+ A complete guide to all versions within this variant has been includes in <a href="#old_var_table" class="xref">Appendix C.1</a>.<a href="#section-4-7" class="pilcrow">¶</a></p>
+<span id="name-new-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
+        <caption>
 <a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-new-uuid-variant-10xx-versi" class="selfRef">New UUID variant 10xx versions defined by this specification</a>
-          </caption>
+<a href="#name-new-uuid-variant-10xx-8-9-a" class="selfRef">New UUID variant 10xx (8/9/A/B) versions defined by this specification</a>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">6</td>
-              <td class="text-left" rowspan="1" colspan="1">Reordered Gregorian time-based UUID specified in this document.</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-9">
- For UUIDv6 the version and variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged and a new version (0110b [6]) has been added.
- An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4.1-9" class="pilcrow">¶</a></p>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Version</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">6</td>
+            <td class="text-left" rowspan="1" colspan="1">Reordered Gregorian time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">7</td>
+            <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">8</td>
+            <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-9">
+ For UUID version 6, 7 and 8 the variant field placement from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> are unchanged.
+ An example version/variant layout for UUIDv6 follows the table where M is the version and N is the variant.<a href="#section-4-9" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-variant-examples"></span><figure id="figure-1">
-          <div class="alignLeft art-text artwork" id="section-4.1-10.1">
+        <div class="alignLeft art-text artwork" id="section-4-10.1">
 <pre>
 00000000-0000-6000-8000-000000000000
 00000000-0000-6000-9000-000000000000
@@ -1834,50 +1898,50 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 </div>
 <figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
 <a href="#name-uuidv6-variant-examples" class="selfRef">UUIDv6 Variant Examples</a>
-          </figcaption></figure>
-<p id="section-4.1-11">
- The next table details Variant 110 and the new versions defined by this specification.
- A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4.1-11" class="pilcrow">¶</a></p>
-<span id="name-uuid-variant-1110-versions-"></span><table class="center" id="table-3">
-          <caption>
+        </figcaption></figure>
+<p id="section-4-11">
+ The next table details Variant 1110 (E) and the new versions defined by this specification.
+ A complete guide to all versions within this variant has been includes in <a href="#new_var_table" class="xref">Appendix C.2</a>.<a href="#section-4-11" class="pilcrow">¶</a></p>
+<span id="name-uuid-variant-1110-e-version"></span><table class="center" id="table-3">
+        <caption>
 <a href="#table-3" class="selfRef">Table 3</a>:
-<a href="#name-uuid-variant-1110-versions-" class="selfRef">UUID variant 1110 versions defined by this specification</a>
-          </caption>
+<a href="#name-uuid-variant-1110-e-version" class="selfRef">UUID variant 1110 (E) versions defined by this specification</a>
+        </caption>
 <thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">Msb0</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb1</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb2</td>
-              <td class="text-left" rowspan="1" colspan="1">Msb3</td>
-              <td class="text-left" rowspan="1" colspan="1">Version</td>
-              <td class="text-left" rowspan="1" colspan="1">Description</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">1</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">0</td>
-              <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
-            </tr>
-          </tbody>
-        </table>
-<p id="section-4.1-13">
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">Msb0</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb1</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb2</td>
+            <td class="text-left" rowspan="1" colspan="1">Msb3</td>
+            <td class="text-left" rowspan="1" colspan="1">Version</td>
+            <td class="text-left" rowspan="1" colspan="1">Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">7E</td>
+            <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
+          </tr>
+          <tr>
+            <td class="text-left" rowspan="1" colspan="1">1</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">0</td>
+            <td class="text-left" rowspan="1" colspan="1">8E</td>
+            <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
+          </tr>
+        </tbody>
+      </table>
+<p id="section-4-13">
                     For UUID versions 7E and 8E, the variant field has been incremented and the version field has been moved to the same octet as the variant. 
  Since the bits of the variant remain in the same place as described in <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> but utilized the previously reserved value 111, this allows a UUID to simply define octet 8 as var_ver, and the values 0xE7 and 0xE8 indicate UUID versions 7 and 8 respectively.
- An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4.1-13" class="pilcrow">¶</a></p>
+ An example version/variant layout for versions 7E and 8E follows the table where M is the version and N is the variant.<a href="#section-4-13" class="pilcrow">¶</a></p>
 <span id="name-uuid-version-7e-and-8e-vari"></span><figure id="figure-2">
-          <div class="alignLeft art-text artwork" id="section-4.1-14.1">
+        <div class="alignLeft art-text artwork" id="section-4-14.1">
 <pre>
 00000000-0000-0000-E700-000000000000
 xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
@@ -1888,31 +1952,38 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 </div>
 <figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
 <a href="#name-uuid-version-7e-and-8e-vari" class="selfRef">UUID version 7E and 8E Variant Examples</a>
-          </figcaption></figure>
+        </figcaption></figure>
 </section>
 </div>
+<div id="format">
+<section id="section-5">
+      <h2 id="name-new-formats">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-new-formats" class="section-name selfRef">New Formats</a>
+      </h2>
+<p id="section-5-1">
+ The UUID format is 16 octets; The variant bits in conjunction with the version bits described in the next section in determine finer structure.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <div id="uuidv6">
-<section id="section-4.2">
+<section id="section-5.1">
         <h3 id="name-uuid-version-6">
-<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-uuid-version-6" class="section-name selfRef">UUID Version 6</a>
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-uuid-version-6" class="section-name selfRef">UUID Version 6</a>
         </h3>
-<p id="section-4.2-1">
+<p id="section-5.1-1">
  UUID version 6 is a field-compatible version of UUIDv1, reordered for improved DB locality. 
  It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
- Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7E instead.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
-<p id="section-4.2-2">
+ Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 or UUIDv7E instead.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
+<p id="section-5.1-2">
  Instead of splitting the timestamp into the low, mid and high sections from UUIDv1, UUIDv6 changes this sequence so timestamp bytes are stored from most to least significant.  
  That is, given a 60 bit timestamp value as specified for UUIDv1 in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.4" class="relref">Section 4.1.4</a></span>,
  for UUIDv6, the first 48 most significant bits are stored
- first, followed by the 4 bit version (same position), followed by the remaining 12 bits of the original 60 bit timestamp.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
-<p id="section-4.2-3">
- The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-4.2-3" class="pilcrow">¶</a></p>
-<p id="section-4.2-4">
- The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 7</a><a href="#section-4.2-4" class="pilcrow">¶</a></p>
-<p id="section-4.2-5">
- The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-4.2-5" class="pilcrow">¶</a></p>
+ first, followed by the 4 bit version (same position), followed by the remaining 12 bits of the original 60 bit timestamp.<a href="#section-5.1-2" class="pilcrow">¶</a></p>
+<p id="section-5.1-3">
+ The clock sequence bits remain unchanged from their usage and position in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.1-3" class="pilcrow">¶</a></p>
+<p id="section-5.1-4">
+ The 48 bit node SHOULD be set to a pseudo-random value however implementations MAY choose retain the old MAC address behavior from <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.6" class="relref">Section 4.1.6</a></span> and <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.5" class="relref">Section 4.5</a></span>. For more information on MAC address usage within UUIDs see the <a href="#Security" class="xref">Section 10</a><a href="#section-5.1-4" class="pilcrow">¶</a></p>
+<p id="section-5.1-5">
+ The format for the 16-byte, 128 bit UUIDv6 is shown in Figure 1<a href="#section-5.1-5" class="pilcrow">¶</a></p>
 <span id="name-uuidv6-field-and-bit-layout"></span><figure id="figure-3">
-          <div class="alignLeft art-text artwork" id="section-4.2-6.1">
+          <div class="alignLeft art-text artwork" id="section-5.1-6.1">
 <pre>
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1930,47 +2001,47 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 <figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
 <a href="#name-uuidv6-field-and-bit-layout" class="selfRef">UUIDv6 Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.2-7">
-          <dt id="section-4.2-7.1">time_high:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.2">The most significant 32 bits of the 60 bit starting timestamp.
-            Occupies bits 0 through 31 (octets 0-3)<a href="#section-4.2-7.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-5.1-7">
+          <dt id="section-5.1-7.1">time_high:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.2">The most significant 32 bits of the 60 bit starting timestamp.
+            Occupies bits 0 through 31 (octets 0-3)<a href="#section-5.1-7.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.3">time_mid:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.4">The middle 16 bits of the 60 bit starting timestamp.
-            Occupies bits 32 through 47 (octets 4-5)<a href="#section-4.2-7.4" class="pilcrow">¶</a>
+<dt id="section-5.1-7.3">time_mid:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.4">The middle 16 bits of the 60 bit starting timestamp.
+            Occupies bits 32 through 47 (octets 4-5)<a href="#section-5.1-7.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.5">time_low_and_version:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.6">The first four most significant bits MUST contain
+<dt id="section-5.1-7.5">time_low_and_version:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.6">The first four most significant bits MUST contain
             the UUIDv6 version (0110) while the remaining 12 bits will contain
             the least significant 12 bits from the 60 bit starting timestamp.
-            Occupies bits 48 through 63 (octets 6-7)<a href="#section-4.2-7.6" class="pilcrow">¶</a>
+            Occupies bits 48 through 63 (octets 6-7)<a href="#section-5.1-7.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.7">clk_seq_hi_res:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.8">The first two bits MUST be set to the UUID variant (10)
+<dt id="section-5.1-7.7">clk_seq_hi_res:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.8">The first two bits MUST be set to the UUID variant (10)
             The remaining 6 bits contain the high portion of the clock sequence.
-            Occupies bits 64 through 71 (octet 8)<a href="#section-4.2-7.8" class="pilcrow">¶</a>
+            Occupies bits 64 through 71 (octet 8)<a href="#section-5.1-7.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.9">clock_seq_low:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.10">The 8 bit low portion of the clock sequence.
-            Occupies bits 72 through 79 (octet 9)<a href="#section-4.2-7.10" class="pilcrow">¶</a>
+<dt id="section-5.1-7.9">clock_seq_low:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.10">The 8 bit low portion of the clock sequence.
+            Occupies bits 72 through 79 (octet 9)<a href="#section-5.1-7.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.2-7.11">node:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.2-7.12">48 bit spatially unique identifier
-            Occupies bits 80 through 127 (octets 10-15)<a href="#section-4.2-7.12" class="pilcrow">¶</a>
+<dt id="section-5.1-7.11">node:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.1-7.12">48 bit spatially unique identifier
+            Occupies bits 80 through 127 (octets 10-15)<a href="#section-5.1-7.12" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-4.2-8">
+<p id="section-5.1-8">
  With UUIDv6 the steps for splitting the timestamp into time_high and time_mid are OPTIONAL
  since the 48 bits of time_high and time_mid will remain in the same order.
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
  32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
- In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-4.2-8" class="pilcrow">¶</a></p>
+ In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
 <span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-4">
           <caption>
 <a href="#table-4" class="selfRef">Table 4</a>:
@@ -2003,16 +2074,147 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
         </table>
 </section>
 </div>
-<div id="uuidv7">
-<section id="section-4.3">
-        <h3 id="name-uuid-version-7e">
-<a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
+<div id="v7">
+<section id="section-5.2">
+        <h3 id="name-uuid-version-7">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-uuid-version-7" class="section-name selfRef">UUID Version 7</a>
         </h3>
-<p id="section-4.3-1">
- UUID version 7E features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.
- Implementations SHOULD utilize UUID version 7E over UUID version 1 and 6 if possible.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-4">
-          <div class="alignLeft art-text artwork" id="section-4.3-2.1">
+<p id="section-5.2-1">
+ UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+<p id="section-5.2-2">
+ Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-4">
+          <div class="alignLeft art-text artwork" id="section-5.2-3.1">
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           unix_ts_ms                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          unix_ts_ms           |  ver  |       rand_a          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                        rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            rand_b                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-uuidv7-field-and-bit-layout" class="selfRef">UUIDv7 Field and Bit Layout</a>
+          </figcaption></figure>
+<span class="break"></span><dl class="dlNewline" id="section-5.2-4">
+          <dt id="section-5.2-4.1">unix_ts_ms:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-5.2-4.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.3">ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.4">4 bit UUIDv7 version set as per <a href="#variant_and_version_fields" class="xref">Section 4</a><a href="#section-5.2-4.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.5">rand_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.6">12 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.7">var:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.8">The 2 bit variant defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-5.2-4.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.2-4.9">rand_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.2-4.10">The final 62 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-5.2-4.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+<div id="v8">
+<section id="section-5.3">
+        <h3 id="name-uuid-version-8">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-uuid-version-8" class="section-name selfRef">UUID Version 8</a>
+        </h3>
+<p id="section-5.3-1">
+ UUID version 8 provides an RFC-compatible format for experimental or vendor-specific use cases.
+ The only requirement is that the variant and version bits MUST be set as defined in <a href="#variant_and_version_fields" class="xref">Section 4</a>. 
+ UUIDv8's uniqueness will be implementation-specific and SHOULD NOT be assumed.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
+<p id="section-5.3-2">
+ The only explicitly defined bits are the Version and Variant leaving 120 bits
+ for implementation specific time-based UUIDs. To be clear:
+ UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
+ filled with random data.<a href="#section-5.3-2" class="pilcrow">¶</a></p>
+<p id="section-5.3-3">
+ Some example situations in which UUIDv8 usage could occur:<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-5.3-4.1">
+            <p id="section-5.3-4.1.1">An implementation would like to embed extra information
+   within the UUID other than what is defined in this document.<a href="#section-5.3-4.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-5.3-4.2">
+            <p id="section-5.3-4.2.1">An implementation has other application/language restrictions which
+   inhibit the use of one of the current UUIDs.<a href="#section-5.3-4.2.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
+<span id="name-uuidv8-field-and-bit-layout"></span><figure id="figure-5">
+          <div class="alignLeft art-text artwork" id="section-5.3-5.1">
+<pre>
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_a                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          custom_a             |  ver  |       custom_b        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|var|                       custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           custom_c                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</pre>
+</div>
+<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<a href="#name-uuidv8-field-and-bit-layout" class="selfRef">UUIDv8 Field and Bit Layout</a>
+          </figcaption></figure>
+<span class="break"></span><dl class="dlNewline" id="section-5.3-6">
+          <dt id="section-5.3-6.1">custom_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.2">The first 48 bits of the layout that can be filled as an implementation sees fit.<a href="#section-5.3-6.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.3">ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.4">The 4 bit version field as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a><a href="#section-5.3-6.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.5">custom_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.6">12 more bits of the layout that can be filled as an implementation sees fit.<a href="#section-5.3-6.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.7">var:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.8">The 2 bit variant field as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-5.3-6.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-5.3-6.9">custom_c:</dt>
+          <dd style="margin-left: 1.5em" id="section-5.3-6.10">The final 62 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-5.3-6.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+</div>
+<div id="alternate_uuid_variants">
+<section id="section-6">
+      <h2 id="name-alternate-variants">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-alternate-variants" class="section-name selfRef">Alternate Variants</a>
+      </h2>
+<p id="section-6-1">
+ This section details alternate formats utilizing the newly defined "E" variant layout for use with UUID version 7 and version 8 of this document.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<div id="uuidv7">
+<section id="section-6.1">
+        <h3 id="name-uuid-version-7e">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-uuid-version-7e" class="section-name selfRef">UUID Version 7E</a>
+        </h3>
+<p id="section-6.1-1">
+ UUID version 7E is an alternative bit layout for UUIDv7 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2">
+ With UUIDv7E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce var_ver field populated with 0xE7.<a href="#section-6.1-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv7e-field-and-bit-layou"></span><figure id="figure-6">
+          <div class="alignLeft art-text artwork" id="section-6.1-3.1">
 <pre>
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -2027,59 +2229,40 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
 <a href="#name-uuidv7e-field-and-bit-layou" class="selfRef">UUIDv7E Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.3-3">
-          <dt id="section-4.3-3.1">unix_ts_ms:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.2">48 bit big-endian unsigned number of unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 5.1</a>.<a href="#section-4.3-3.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-6.1-4">
+          <dt id="section-6.1-4.1">unix_ts_ms:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.2">48 bit big-endian unsigned number of Unix epoch timestamp as per <a href="#timestamp_granularity" class="xref">Section 8.1</a>.<a href="#section-6.1-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.3">rand_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 5.2</a> and <a href="#unguessability" class="xref">Section 5.6</a>.<a href="#section-4.3-3.4" class="pilcrow">¶</a>
+<dt id="section-6.1-4.3">rand_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.4">16 bits pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.5">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4.1</a>.<a href="#section-4.3-3.6" class="pilcrow">¶</a>
+<dt id="section-6.1-4.5">var_ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.6">The 8 bit combined variant and version field with the value 0xE7 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.1-4.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.3-3.7">rand_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.3-3.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 5.2</a> and <a href="#unguessability" class="xref">Section 5.6</a>.<a href="#section-4.3-3.8" class="pilcrow">¶</a>
+<dt id="section-6.1-4.7">rand_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.1-4.8">The final 56 bits of pseudo-random data to provide uniqueness as per <a href="#monotonicity_counters" class="xref">Section 8.2</a> and <a href="#unguessability" class="xref">Section 8.6</a>.<a href="#section-6.1-4.8" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="uuidv8">
-<section id="section-4.4">
+<section id="section-6.2">
         <h3 id="name-uuid-version-8e">
-<a href="#section-4.4" class="section-number selfRef">4.4. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-uuid-version-8e" class="section-name selfRef">UUID Version 8E</a>
         </h3>
-<p id="section-4.4-1">
- UUID version 8E provides an RFC-compatible format for experimental or vendor-specific use cases.
- The only requirement is that the variant and version bits MUST be set as defined in <a href="#variant_and_version_fields" class="xref">Section 4.1</a>. 
- UUIDv8E's uniqueness will be implementation-specific and SHOULD NOT be assumed.<a href="#section-4.4-1" class="pilcrow">¶</a></p>
-<p id="section-4.4-2">
- UUIDv8E SHOULD only be utilized if an implementation cannot utilize another UUID in this document or <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-4.4-2" class="pilcrow">¶</a></p>
-<p id="section-4.4-3">
- The only explicitly defined bits are the Version and Variant leaving 120 bits
- for implementation specific time-based UUIDs. To be clear:
- UUIDv8E is not a replacement for UUIDv4 where all 122 extra bits are
- filled with random data.<a href="#section-4.4-3" class="pilcrow">¶</a></p>
-<p id="section-4.4-4">
- Some example situations in which UUIDv8E usage could occur:<a href="#section-4.4-4" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-4.4-5.1">
-            <p id="section-4.4-5.1.1">An implementation would like to embed extra information
-   within the UUID other than what is defined in this document.<a href="#section-4.4-5.1.1" class="pilcrow">¶</a></p>
-</li>
-          <li class="normal" id="section-4.4-5.2">
-            <p id="section-4.4-5.2.1">An implementation has other application/language restrictions which
-   inhibit the use of one of the current UUIDs.<a href="#section-4.4-5.2.1" class="pilcrow">¶</a></p>
-</li>
-        </ul>
-<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-5">
-          <div class="alignLeft art-text artwork" id="section-4.4-6.1">
+<p id="section-6.2-1">
+ UUID version 8E is an alternative bit layout for UUIDv8 which leverages the new simplified "E" variant introduced in this specification.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">
+ With UUIDv8E the first 64 bits of the UUID layout are unbroken and the version has been moved to the same octet as the variant to produce the var_ver field populated with 0xE8.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-field-and-bit-layou"></span><figure id="figure-7">
+          <div class="alignLeft art-text artwork" id="section-6.2-3.1">
 <pre>
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -2094,311 +2277,397 @@ xxxxxxxx-xxxx-xxxx-NMxx-xxxxxxxxxxxx
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 </pre>
 </div>
-<figcaption><a href="#figure-5" class="selfRef">Figure 5</a>:
+<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
 <a href="#name-uuidv8e-field-and-bit-layou" class="selfRef">UUIDv8E Field and Bit Layout</a>
           </figcaption></figure>
-<span class="break"></span><dl class="dlNewline" id="section-4.4-7">
-          <dt id="section-4.4-7.1">custom_a:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-4.4-7.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-4">
+          <dt id="section-6.2-4.1">custom_a:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.2">The first 64 bits of the layout that can be filled as an implementation sees fit.<a href="#section-6.2-4.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.4-7.3">var_ver:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4.1</a>.<a href="#section-4.4-7.4" class="pilcrow">¶</a>
+<dt id="section-6.2-4.3">var_ver:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.4">The 8 bit combined variant and version field with the value 0xE8 as defined by <a href="#variant_and_version_fields" class="xref">Section 4</a>.<a href="#section-6.2-4.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-4.4-7.5">custom_b:</dt>
-          <dd style="margin-left: 1.5em" id="section-4.4-7.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-4.4-7.6" class="pilcrow">¶</a>
+<dt id="section-6.2-4.5">custom_b:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.6">The final 56 bits of the layout immediatly following the var_var field to be filled as an implementation sees fit.<a href="#section-6.2-4.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
+</section>
+</div>
+<div id="alternate_uuid_formats">
+<section id="section-7">
+      <h2 id="name-alternate-formats">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-alternate-formats" class="section-name selfRef">Alternate Formats</a>
+      </h2>
+<p id="section-7-1">
+ This section details alternate UUID formats such as the Max UUID, a longer form of UUID aptly named "UUID Long" and some alternate encoding techniques applicable to all UUIDs in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-7-1" class="pilcrow">¶</a></p>
 <div id="maxuuid">
-<section id="section-4.5">
+<section id="section-7.1">
         <h3 id="name-max-uuid">
-<a href="#section-4.5" class="section-number selfRef">4.5. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-max-uuid" class="section-name selfRef">Max UUID</a>
         </h3>
-<p id="section-4.5-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1.<a href="#section-4.5-1" class="pilcrow">¶</a></p>
-<span id="name-max-uuid-format"></span><figure id="figure-6">
-          <div class="alignLeft art-text artwork" id="section-4.5-2.1">
+<p id="section-7.1-1">The Max UUID is special form of UUID that is specified to have all 128 bits set to 1. This UUID can be thought of as the inverse of Nil UUID defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.7" class="relref">Section 4.1.7</a></span><a href="#section-7.1-1" class="pilcrow">¶</a></p>
+<span id="name-max-uuid-format"></span><figure id="figure-8">
+          <div class="alignLeft art-text artwork" id="section-7.1-2.1">
 <pre>
 FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </pre>
 </div>
-<figcaption><a href="#figure-6" class="selfRef">Figure 6</a>:
+<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
 <a href="#name-max-uuid-format" class="selfRef">Max UUID Format</a>
           </figcaption></figure>
+</section>
+</div>
+<div id="uuid_long">
+<section id="section-7.2">
+        <h3 id="name-uuid-long">
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
+        </h3>
+<p id="section-7.2-1">
+ UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-7.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-7.2-2">
+          <dt id="section-7.2-2.1">Increased Entropy:</dt>
+          <dd style="margin-left: 1.5em" id="section-7.2-2.2">While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities (<a href="#collision_resistance" class="xref">Section 8.4</a>) or guessability (<a href="#unguessability" class="xref">Section 8.6</a>).<a href="#section-7.2-2.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-7.2-2.3">Requirements for additional embedded items:</dt>
+          <dd style="margin-left: 1.5em" id="section-7.2-2.4">Some implementations require more than 128 bits to properly embed all of the application specific data they require. Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-7.2-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-7.2-3">
+ UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex format to create 8-4-4-4-12-variable_length text format. The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-7.2-3" class="pilcrow">¶</a></p>
+<span id="name-uuid-long-examples"></span><figure id="figure-9">
+          <div class="alignLeft art-text artwork" id="section-7.2-4.1">
+<pre>
+UUIDv4: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+   +32: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-05FA17AAAC4F8954D9FAC2DF2FCE30F6
+   +64: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-02DF3F4BABC63A3B2775E27804528A6D23C679EED60FE31DF3F8B014E7915595
+  +128: 73E94FE0-E951-4153-AAF3-50E4E6089D9D-8FE05412F24CA9974637A10C0B372A7109FB810F61068C0074B480F09F18B30FE03AE7BF09C98B241E8C9C0D51516B963AC75ABE447DBFF34177093B4B781A46
+</pre>
+</div>
+<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
+          </figcaption></figure>
+<p id="section-7.2-5">
+ Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-7.2-5" class="pilcrow">¶</a></p>
+<p id="section-7.2-6">
+ When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.<a href="#section-7.2-6" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="uuid_encoding">
+<section id="section-7.3">
+        <h3 id="name-alternate-encodings">
+<a href="#section-7.3" class="section-number selfRef">7.3. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
+        </h3>
+<p id="section-7.3-1">
+ The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-7.3-1" class="pilcrow">¶</a></p>
+<p id="section-7.3-2">
+ Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUIDv7 and UUIDv7E and collision resistance provided by all UUIDs.<a href="#section-7.3-2" class="pilcrow">¶</a></p>
+<p id="section-7.3-3">
+ When utilizing alternate encoding techniques with other applications; the encoded UUID SHOULD be prefixed with "urn:uuid:" to signal that the value therein is that of a UUID.<a href="#section-7.3-3" class="pilcrow">¶</a></p>
+<p id="section-7.3-4">
+ The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-7.3-4" class="pilcrow">¶</a></p>
+<span id="name-alternate-encoding-examples"></span><figure id="figure-10">
+          <div class="alignLeft art-text artwork" id="section-7.3-5.1">
+<pre>
+UUIDv4 Hex: 73E94FE0-E951-4153-AAF3-50E4E6089D9D
+UUIDv4 Int: 154072644812979270675542139334331768221
+UUIDv4 Bin: 1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101
+UUIDv4 b32: urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT
+UUIDv4 b36: urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1
+</pre>
+</div>
+<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
+          </figcaption></figure>
+<p id="section-7.3-6">
+ For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-7.3-6" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="uuid_best_practices">
-<section id="section-5">
+<section id="section-8">
       <h2 id="name-uuid-best-practices">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-uuid-best-practices" class="section-name selfRef">UUID Best Practices</a>
       </h2>
-<p id="section-5-1">
+<p id="section-8-1">
  The minimum requirements for generating UUIDs are 
  described in this document for each version.
  Everything else is an implementation detail and 
  up to the implementer to decide what is appropriate for a given 
  implementation. That being said, various relevant factors are covered
- below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-5-1" class="pilcrow">¶</a></p>
+ below to help guide an implementer through the different trade-offs among differing UUID implementations.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <div id="timestamp_granularity">
-<section id="section-5.1">
+<section id="section-8.1">
         <h3 id="name-timestamp-granularity">
-<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
+<a href="#section-8.1" class="section-number selfRef">8.1. </a><a href="#name-timestamp-granularity" class="section-name selfRef">Timestamp Granularity</a>
         </h3>
-<p id="section-5.1-1">
- UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-5.1-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.1-2">
-          <dt id="section-5.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-5.1-2.2" class="pilcrow">¶</a>
+<p id="section-8.1-1">
+ UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-8.1-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.1-2">
+          <dt id="section-8.1-2.1">Reliability:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-8.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.3">Source:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8E SHOULD be leveraged.<a href="#section-5.1-2.4" class="pilcrow">¶</a>
+<dt id="section-8.1-2.3">Source:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.4">UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 and UUIDv7E utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 or  UUIDv8E SHOULD be leveraged.<a href="#section-8.1-2.4" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8E SHOULD be utilized.<a href="#section-5.1-2.6" class="pilcrow">¶</a>
+<dt id="section-8.1-2.5">Sub-second Precision and Accuracy:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 and UUIDv7E features fixed millisecond level of precision within the Unix epoch. If additional levels of precision are required UUIDv8 or UUIDv8E SHOULD be utilized.<a href="#section-8.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.7">Length:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7E features a 48 bit timestamp.<a href="#section-5.1-2.8" class="pilcrow">¶</a>
+<dt id="section-8.1-2.7">Length:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.8">The length of a given timestamp directly impacts how long a given UUID will be valid. Care should be given to ensure that the proper length is selected for a given timestamp. UUID version 1 and 6 utilize a 60 bit timestamp and UUIDv7 and UUIDv7E features a 48 bit timestamp.<a href="#section-8.1-2.8" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.9">Fuzzing:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-5.1-2.10" class="pilcrow">¶</a>
+<dt id="section-8.1-2.9">Fuzzing:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.10">Implementations MAY fuzz a timestamp. Some examples included security considerations around providing a real clock value within a UUID or to correct inaccurate clocks. This specification makes no requirement or guarantee about how close the clock value needs to be to actual time.<a href="#section-8.1-2.10" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.11">Padding:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7E.<a href="#section-5.1-2.12" class="pilcrow">¶</a>
+<dt id="section-8.1-2.11">Padding:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.12">When timestamp padding is required, implementations MUST pad the most significant bits (left-most) bits with zeros. An example is padding the most significant, left-most bits of a 32 bit Unix timestamp with zero's to fill out the 48 bit timestamp in UUIDv7 and UUIDv7E.<a href="#section-8.1-2.12" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.1-2.13">Truncating:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-5.1-2.14" class="pilcrow">¶</a>
+<dt id="section-8.1-2.13">Truncating:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.1-2.14">Similarly, when timestamps need to be truncated: the lower, least significant bits MUST be used. An example would be truncating a 64 bit Unix timestamp to the least significant, right-most 48 bits for UUIDv7E.<a href="#section-8.1-2.14" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="monotonicity_counters">
-<section id="section-5.2">
+<section id="section-8.2">
         <h3 id="name-monotonicity-and-counters">
-<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
+<a href="#section-8.2" class="section-number selfRef">8.2. </a><a href="#name-monotonicity-and-counters" class="section-name selfRef">Monotonicity and Counters</a>
         </h3>
-<p id="section-5.2-1">
- Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
-<p id="section-5.2-2">
+<p id="section-8.2-1">
+ Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-8.2-1" class="pilcrow">¶</a></p>
+<p id="section-8.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation of order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
-<p id="section-5.2-3">
- For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a><a href="#section-5.2-3" class="pilcrow">¶</a></p>
-<p id="section-5.2-4">
- Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-5.2-4" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.2-5">
-          <dt id="section-5.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.2">
+ For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-8.2-2" class="pilcrow">¶</a></p>
+<p id="section-8.2-3">
+ For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, 7, and 7E can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a><a href="#section-8.2-3" class="pilcrow">¶</a></p>
+<p id="section-8.2-4">
+ Implementations SHOULD choose one method for single-node UUID implementations that require batch UUID creation.<a href="#section-8.2-4" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.2-5">
+          <dt id="section-8.2-5.1">Fixed-Length Dedicated Counter Bits (Method 1):</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-5.2">
  This references the practice of allocating a specific number of bits in the UUID layout to the sole purpose of tallying the total number of UUIDs created during a given UUID timestamp tick.
- Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 MAY be utilized as fixed-length dedicated counter bits..<a href="#section-5.2-5.2" class="pilcrow">¶</a>
+ Positioning of a fixed bit-length counter SHOULD be immediatly after the embedded timestamp. This promotes sortability and allows random data generation for each counter increment. With this method the rand_a section of UUIDv7 and UUIDv7E MAY be utilized as fixed-length dedicated counter bits.<a href="#section-8.2-5.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.2-5.3">Fixed-Length Dedicated Counter Bits (Method 2):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.4">
- An alternative approach to the previous method is to dedicate a number of bits in the least significant position of the UUID. With this alternative method, the random data MUST be frozen for a given timestamp tick else sorting will be impacted. UUIDs utilizing this method SHOULD be created using UUIDv8E.<a href="#section-5.2-5.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.5">Fixed-Length Dedicated Counter Seeding:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.6">
- Implementations utilizing either fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. A randomly seeded counter alongside Method 2 is more-or-less the same as Monotonic Random (Method 3). Implementations utilizing either fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-5.2-5.6" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.7">Fixed-Length Dedicated Counter Length</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.8">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-5.2-5.8" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.9">Fixed-Length Dedicated Counter Rollover Handling</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.10">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-5.2-5.10" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-5.2-5.11">Monotonic Random (Method 3):</dt>
-          <dd style="margin-left: 1.5em" id="section-5.2-5.12">
- With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits (Position B) method described in the previous bullets but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by both fixed-length counter bit positions. As such, UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-5.2-5.12" class="pilcrow">¶</a>
+<dt id="section-8.2-5.3">Monotonic Random (Method 2):</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-5.4">
+ With this method the random data is extended to also double as a counter. This monotonic random can be thought of as a "randomly seeded counter" which MUST be incremented in the least significant position for each UUID created on a given timestamp tick. This is similar to the Fixed-Length Dedicated Counter Bits method described in the previous bullet but does not suffer from rollover issues, length problems, or wasted entropy bits plagued by fixed-length counter bit positions. As such, UUIDv7 and UUIDv7E SHOULD utilize this method to handle batch UUID generation during a single timestamp tick.<a href="#section-8.2-5.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-5.2-6">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-5.2-6" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-5.2-7">
- <li id="section-5.2-7.1">
-            <p id="section-5.2-7.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-5.2-7.1.1" class="pilcrow">¶</a></p>
+<p id="section-8.2-6">
+ The following sub-topics cover topics related solely with creating reliable fixed-length dedicated counters:<a href="#section-8.2-6" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.2-7">
+          <dt id="section-8.2-7.1">Fixed-Length Dedicated Counter Seeding:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.2">
+ Implementations utilizing fixed-length counter method MAY randomly initialize the counter with each new timestamp tick. However, when the timestamp has not incremented; the counter SHOULD be frozen and incremented by one. When utilizing a randomly seeded counter alongside Method 1; the random MAY be regenerated with each counter increment without impacting sortability. The downside is that Method 1 is prone to overflows if a counter of adequate length is not selected or the random data generated leaves little room for the required number of increments. Implementations utilizing fixed-length counter method MAY also choose to initialize the counter at zero to ensure the full bit-space is utilized and help avoid counter rollovers. This approach has less entropy and more guessibility but ensures the most of the counter bit space.<a href="#section-8.2-7.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-8.2-7.3">Fixed-Length Dedicated Counter Length</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.4">Care MUST be taken to select a counter bit-length that can properly handle the level of timestamp precision in use. For example, millisecond precision SHOULD require a larger counter than a timestamp with nanosecond precision. General Guidance is that the counter SHOULD be at least 12 bits and no more than a maximum of 24 bits.<a href="#section-8.2-7.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-8.2-7.5">Fixed-Length Dedicated Counter Rollover Handling</dt>
+          <dd style="margin-left: 1.5em" id="section-8.2-7.6">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. The general guidance is that applications SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-8.2-7.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-8.2-8">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-8.2-8" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-8.2-9">
+ <li id="section-8.2-9.1">
+            <p id="section-8.2-9.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-8.2-9.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-5.2-7.2">
-            <p id="section-5.2-7.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-5.2-7.2.1" class="pilcrow">¶</a></p>
+          <li id="section-8.2-9.2">
+            <p id="section-8.2-9.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter logic.<a href="#section-8.2-9.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-5.2-7.3">
-            <p id="section-5.2-7.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-5.2-7.3.1" class="pilcrow">¶</a></p>
+          <li id="section-8.2-9.3">
+            <p id="section-8.2-9.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the counter to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-8.2-9.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-5.2-8">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-5.2-8" class="pilcrow">¶</a></p>
-<p id="section-5.2-9">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-5.2-9" class="pilcrow">¶</a></p>
+<p id="section-8.2-10">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-8.2-10" class="pilcrow">¶</a></p>
+<p id="section-8.2-11">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-8.2-11" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
-<section id="section-5.3">
+<section id="section-8.3">
         <h3 id="name-distributed-uuid-generation">
-<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
+<a href="#section-8.3" class="section-number selfRef">8.3. </a><a href="#name-distributed-uuid-generation" class="section-name selfRef">Distributed UUID Generation</a>
         </h3>
-<p id="section-5.3-1">
+<p id="section-8.3-1">
  Some implementations MAY desire to utilize multi-node, clustered, applications which involve two or more 
  applications independently generating UUIDs that will be stored in a common location. 
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
- This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-5.3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.3-2">
-          <dt id="section-5.3-2.1">Shared Knowledge System:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-5.3-2.2" class="pilcrow">¶</a>
+ This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-8.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.3-2">
+          <dt id="section-8.3-2.1">Shared Knowledge System:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-8.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.3-2.3">Node IDs:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 7</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-5.3-2.4" class="pilcrow">¶</a>
+<dt id="section-8.3-2.3">Node IDs:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.3-2.4">With this method, a nondescript pseudo-random Node ID value is placed within the UUID layout. This identifier ensures the bit-space for a given node is unique resulting in UUIDs that do not conflict with any other UUID created by another node with a different node id. Implementations that choose to leverage an embedded node id SHOULD utilize UUIDv8E. The node id SHOULD NOT be an IEEE 802 MAC address as per <a href="#Security" class="xref">Section 10</a>. The location and bit length are up to implements and outside the scope of this specification. Furthermore, the creation and negotiation of a node id among distributed nodes is also out of scope for this specification.<a href="#section-8.3-2.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-5.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-5.3-3" class="pilcrow">¶</a></p>
+<p id="section-8.3-3">
+ Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirements.<a href="#section-8.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
-<section id="section-5.4">
+<section id="section-8.4">
         <h3 id="name-collision-resistance">
-<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
+<a href="#section-8.4" class="section-number selfRef">8.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
-<p id="section-5.4-1">
- Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 5.1</a> and <a href="#monotonicity_counters" class="xref">Section 5.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a>.<a href="#section-5.4-1" class="pilcrow">¶</a></p>
-<p id="section-5.4-2">
- There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-5.4-2" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlNewline" id="section-5.4-3">
-          <dt id="section-5.4-3.1">Low Impact</dt>
-          <dd style="margin-left: 1.5em" id="section-5.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-5.4-3.2" class="pilcrow">¶</a>
+<p id="section-8.4-1">
+ Implementations SHOULD weigh the importance of a collision within their application and take this into account when making a selections around the total entropy (random) to dedicated to a UUID layout versus the other components such as <a href="#timestamp_granularity" class="xref">Section 8.1</a> and <a href="#monotonicity_counters" class="xref">Section 8.2</a>. This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a>.<a href="#section-8.4-1" class="pilcrow">¶</a></p>
+<p id="section-8.4-2">
+ There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-8.4-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-8.4-3">
+          <dt id="section-8.4-3.1">Low Impact</dt>
+          <dd style="margin-left: 1.5em" id="section-8.4-3.2">A UUID collision generated a duplicate log entry which results in incorrect statistics derived from the data. Implementations that are not negatively affected by collisions may continue with the entropy and uniqueness provided by the traditional UUID format.<a href="#section-8.4-3.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-5.4-3.3">High Impact:</dt>
-          <dd style="margin-left: 1.5em" id="section-5.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-5.4-3.4" class="pilcrow">¶</a>
+<dt id="section-8.4-3.3">High Impact:</dt>
+          <dd style="margin-left: 1.5em" id="section-8.4-3.4"> A duplicate key causes an airplane to receive the wrong course which puts people's lives at risk. In this scenario there is no margin for error. Collisions MUST be avoided and failure is unacceptable. As such applications dealing with this type of scenario MUST employ as much collision resistance as possible within the given application context.<a href="#section-8.4-3.4" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
 </section>
 </div>
 <div id="global_local_uniqueness">
-<section id="section-5.5">
+<section id="section-8.5">
         <h3 id="name-global-and-local-uniqueness">
-<a href="#section-5.5" class="section-number selfRef">5.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
+<a href="#section-8.5" class="section-number selfRef">8.5. </a><a href="#name-global-and-local-uniqueness" class="section-name selfRef">Global and Local Uniqueness</a>
         </h3>
-<p id="section-5.5-1">
+<p id="section-8.5-1">
  UUIDs created by this specification MAY be used to provide local uniqueness guarantees. 
- For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-5.5-1" class="pilcrow">¶</a></p>
-<p id="section-5.5-2">
+ For example, ensuring UUIDs created within a local application context are unique within a database MAY be sufficient for some implementations where global uniqueness outside of the application context, in other applications, or around the world is not required.<a href="#section-8.5-1" class="pilcrow">¶</a></p>
+<p id="section-8.5-2">
  Although true global uniqueness is impossible to guarantee without shared knowledge scheme; a shared knowledge scheme is not required by UUID to provide uniqueness guarantees.
- Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 5.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-5.5-2" class="pilcrow">¶</a></p>
+ Implementations MAY implement a shared knowledge scheme introduced in <a href="#distributed_shared_knowledge" class="xref">Section 8.3</a> as they see fit to extend the uniqueness guaranteed this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-8.5-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="unguessability">
-<section id="section-5.6">
+<section id="section-8.6">
         <h3 id="name-unguessability">
-<a href="#section-5.6" class="section-number selfRef">5.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
+<a href="#section-8.6" class="section-number selfRef">8.6. </a><a href="#name-unguessability" class="section-name selfRef">Unguessability</a>
         </h3>
-<p id="section-5.6-1">
+<p id="section-8.6-1">
  Implementations SHOULD utilize a cryptographically secure pseudo-random number generator (CSPRNG) to provide values that are both difficult to predict ("unguessable") and have a low likelihood of collision ("unique").
- CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 5.4</a> and <a href="#Security" class="xref">Section 7</a> are present in modern UUIDs.<a href="#section-5.6-1" class="pilcrow">¶</a></p>
-<p id="section-5.6-2">
- Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-5.6-2" class="pilcrow">¶</a></p>
+ CSPRNG ensures the best of <a href="#collision_resistance" class="xref">Section 8.4</a> and <a href="#Security" class="xref">Section 10</a> are present in modern UUIDs.<a href="#section-8.6-1" class="pilcrow">¶</a></p>
+<p id="section-8.6-2">
+ Advice on generating cryptographic-quality random numbers can be found in <span>[<a href="#RFC4086" class="xref">RFC4086</a>]</span><a href="#section-8.6-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="sorting">
-<section id="section-5.7">
+<section id="section-8.7">
         <h3 id="name-sorting">
-<a href="#section-5.7" class="section-number selfRef">5.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
+<a href="#section-8.7" class="section-number selfRef">8.7. </a><a href="#name-sorting" class="section-name selfRef">Sorting</a>
         </h3>
-<p id="section-5.7-1">
- UUIDv6 and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-5.7-1" class="pilcrow">¶</a></p>
-<p id="section-5.7-2">
+<p id="section-8.7-1">
+ UUIDv6, UUIDv7, and UUIDv7E are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without examining the contents at all.<a href="#section-8.7-1" class="pilcrow">¶</a></p>
+<p id="section-8.7-2">
  Time ordered monotonic UUIDs benefit from greater index locality because the new values are near each other in the index. 
  As a result objects can much more easily be clustered together for better performance.  
- The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-5.7-2" class="pilcrow">¶</a></p>
-<p id="section-5.7-3">
- UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-5.7-3" class="pilcrow">¶</a></p>
-<p id="section-5.7-4">
- UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-5.7-4" class="pilcrow">¶</a></p>
+ The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-8.7-2" class="pilcrow">¶</a></p>
+<p id="section-8.7-3">
+ UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-8.7-3" class="pilcrow">¶</a></p>
+<p id="section-8.7-4">
+ UUIDs created by this specification are crafted with big-ending byte order (network byte order) in mind. If Little-endian style is required a custom UUID format SHOULD be created using UUIDv8E.<a href="#section-8.7-4" class="pilcrow">¶</a></p>
 </section>
 </div>
-<div id="storing_uuids_opacity">
-<section id="section-5.8">
-        <h3 id="name-storing-uuids-opacity">
-<a href="#section-5.8" class="section-number selfRef">5.8. </a><a href="#name-storing-uuids-opacity" class="section-name selfRef">Storing UUIDs, Opacity</a>
+<div id="opacity">
+<section id="section-8.8">
+        <h3 id="name-opacity">
+<a href="#section-8.8" class="section-number selfRef">8.8. </a><a href="#name-opacity" class="section-name selfRef">Opacity</a>
         </h3>
-<p id="section-5.8-1">
+<p id="section-8.8-1">
+ UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-8.8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="database_considerations">
+<section id="section-8.9">
+        <h3 id="name-dbms-and-database-considera">
+<a href="#section-8.9" class="section-number selfRef">8.9. </a><a href="#name-dbms-and-database-considera" class="section-name selfRef">DBMS and Database Considerations</a>
+        </h3>
+<p id="section-8.9-1">
  For many applications, such as databases, storing UUIDs as the text is unnecessarily verbose totaling 288 bits to convey the 128 bit UUID value.
- Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-5.8-1" class="pilcrow">¶</a></p>
+ Due to the this, where possible, UUIDs SHOULD be stored within database applications as the underlying 128 bit binary value.<a href="#section-8.9-1" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.8-2.1">
-            <p id="section-5.8-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-5.8-2.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-8.9-2.1">
+            <p id="section-8.9-2.1.1">8 bits for each of the 32 hex characters = 256 bits<a href="#section-8.9-2.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-5.8-2.2">
-            <p id="section-5.8-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-5.8-2.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-8.9-2.2">
+            <p id="section-8.9-2.2.1">8 bits for each of the 4 hyphens = 32 bits<a href="#section-8.9-2.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-5.8-3">
+<p id="section-8.9-3">
  
  For other systems, UUIDs MAY be stored in binary form or as text, as appropriate. 
- The trade offs to both approaches are as such:<a href="#section-5.8-3" class="pilcrow">¶</a></p>
+ The trade offs to both approaches are as such:<a href="#section-8.9-3" class="pilcrow">¶</a></p>
 <ul class="compact">
-<li class="compact" id="section-5.8-4.1">
-            <p id="section-5.8-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-5.8-4.1.1" class="pilcrow">¶</a></p>
+<li class="compact" id="section-8.9-4.1">
+            <p id="section-8.9-4.1.1">Storing as binary requires less space and may result in faster data access.<a href="#section-8.9-4.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="compact" id="section-5.8-4.2">
-            <p id="section-5.8-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-5.8-4.2.1" class="pilcrow">¶</a></p>
+          <li class="compact" id="section-8.9-4.2">
+            <p id="section-8.9-4.2.1">Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.<a href="#section-8.9-4.2.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-5.8-5">
- UUIDs SHOULD be treated as opaque values and implementations SHOULD NOT examine the bits in a UUID to whatever extent is possible. However, where necessary inspectors please review <a href="#variant_and_version_fields" class="xref">Section 4.1</a> for more information on determining a UUID version based on the inspected variant bits.<a href="#section-5.8-5" class="pilcrow">¶</a></p>
+<p id="section-8.9-5">
+ DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+ If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
+ In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-8.9-5" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
 </div>
 <div id="IANA">
-<section id="section-6">
+<section id="section-9">
       <h2 id="name-iana-considerations">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-6-1">This document has no IANA actions.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-9-1">This document has no IANA actions.<a href="#section-9-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Security">
-<section id="section-7">
+<section id="section-10">
       <h2 id="name-security-considerations">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-7-1"> 
+<p id="section-10-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
  Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
- uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 5.6</a> for more information.<a href="#section-7-1" class="pilcrow">¶</a></p>
-<p id="section-7-2">
+ uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 8.6</a> for more information.<a href="#section-10-1" class="pilcrow">¶</a></p>
+<p id="section-10-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 
  an embedded counter does signal the order of creation for a given UUID and it's corresponding data but 
  does not define anything about the data itself or the application as a whole. If UUIDs are required for
- use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-7-2" class="pilcrow">¶</a></p>
+ use with any security operation within an application context in any shape or form then <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> UUIDv4 SHOULD be utilized.<a href="#section-10-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="Acknowledgements">
-<section id="section-8">
+<section id="section-11">
       <h2 id="name-acknowledgements">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+<a href="#section-11" class="section-number selfRef">11. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<p id="section-8-1">The authors gratefully acknowledge the contributions of 
+<p id="section-11-1">The authors gratefully acknowledge the contributions of 
  Ben Campbell,
  Ben Ramsey,
  Fabio Lima,
@@ -2412,12 +2681,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Robert Kieffer,
  sergeyprokhorenko,
  LiosK
- As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-8-1" class="pilcrow">¶</a></p>
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-11-1" class="pilcrow">¶</a></p>
 </section>
 </div>
-<section id="section-9">
+<section id="section-12">
       <h2 id="name-normative-references">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-12" class="section-number selfRef">12. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
       </h2>
 <dl class="references">
 <dt id="RFC2119">[RFC2119]</dt>
@@ -2433,14 +2702,18 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC4086">[RFC4086]</dt>
-    <dd>
+      <dd>
 <span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4648">[RFC4648]</dt>
+    <dd>
+<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-10">
+<section id="section-13">
       <h2 id="name-informative-references">
-<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-13" class="section-number selfRef">13. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
       </h2>
 <dl class="references">
 <dt id="LexicalUUID">[LexicalUUID]</dt>
@@ -2524,7 +2797,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <a href="#appendix-A.1" class="section-number selfRef">A.1. </a><a href="#name-creating-a-uuidv6-value" class="section-name selfRef">Creating a UUIDv6 Value</a>
         </h3>
 <p id="appendix-A.1-1">This section details a function in C which converts from a UUID version 1 to version 6:<a href="#appendix-A.1-1" class="pilcrow">¶</a></p>
-<span id="name-uuidv6-function-in-c"></span><figure id="figure-7">
+<span id="name-uuidv6-function-in-c"></span><figure id="figure-11">
           <div class="alignLeft art-text artwork" id="appendix-A.1-2.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2558,7 +2831,7 @@ void uuidv1tov6(uuid_t u) {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
+<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
 <a href="#name-uuidv6-function-in-c" class="selfRef">UUIDv6 Function in C</a>
           </figcaption></figure>
 </section>
@@ -2568,7 +2841,7 @@ void uuidv1tov6(uuid_t u) {
         <h3 id="name-creating-a-uuidv7e-value">
 <a href="#appendix-A.2" class="section-number selfRef">A.2. </a><a href="#name-creating-a-uuidv7e-value" class="section-name selfRef">Creating a UUIDv7E Value</a>
         </h3>
-<span id="name-uuidv7e-function-in-c"></span><figure id="figure-8">
+<span id="name-uuidv7e-function-in-c"></span><figure id="figure-12">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
 #include &lt;stdio.h&gt;
@@ -2616,7 +2889,7 @@ fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with rando
 u[8] = 0xE7; // set var-ver field
 </pre>
 </div>
-<figcaption><a href="#figure-8" class="selfRef">Figure 8</a>:
+<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
 <a href="#name-uuidv7e-function-in-c" class="selfRef">UUIDv7E Function in C</a>
           </figcaption></figure>
 </section>
@@ -2627,7 +2900,7 @@ u[8] = 0xE7; // set var-ver field
 <a href="#appendix-A.3" class="section-number selfRef">A.3. </a><a href="#name-creating-a-uuidv8e-value" class="section-name selfRef">Creating a UUIDv8E Value</a>
         </h3>
 <p id="appendix-A.3-1">UUIDv8E will vary greatly from implementation to implementation. A good candidate use case for UUIDv8E is to embed exotic timestamps like the one found in this example which employs approximately 0.25 milliseconds and approximately 5 microseconds per timestamp tick as a 48 bit value.<a href="#appendix-A.3-1" class="pilcrow">¶</a></p>
-<span id="name-uuid8-function-in-c"></span><figure id="figure-9">
+<span id="name-uuid8-function-in-c"></span><figure id="figure-13">
           <div class="alignLeft art-text artwork" id="appendix-A.3-2.1">
 <pre>
 #include &lt;stdint.h&gt;
@@ -2647,7 +2920,7 @@ int main() {
 }
 </pre>
 </div>
-<figcaption><a href="#figure-9" class="selfRef">Figure 9</a>:
+<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
 <a href="#name-uuid8-function-in-c" class="selfRef">UUID8 Function in C</a>
           </figcaption></figure>
 </section>
@@ -2661,24 +2934,24 @@ int main() {
       </h2>
 <p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
-<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-10">
+<span id="name-test-vector-timestamp-pseud"></span><figure id="figure-14">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
 <pre>
 # Unix Nanosecond precision to Gregorian 100-nanosecond intervals
-gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
+gregorian_100_ns = (Unix_64_bit_nanoseconds / 100) + gregorian_Unix_offset
 
 # Gregorian to Unix Offset:
 # The number of 100-ns intervals between the
 # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-# gregorian_unix_offset = 0x01b21dd213814000 or 122192928000000000
+# gregorian_Unix_offset = 0x01b21dd213814000 or 122192928000000000
 
 # Unix 64 bit Nanosecond Timestamp:
 # Unix NS: Tuesday, February 22, 2022 2:22:22 PM GMT-05:00
-# unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
+# Unix_64_bit_nanoseconds = 0x16D6320C3D4DCC00 or 1645557742000000000
 
 # Work:
 # gregorian_100_ns = (1645557742000000000 / 100) + 122192928000000000
-# (138648505420000000 - 122192928000000000) * 100 = unix_64_bit_nanoseconds
+# (138648505420000000 - 122192928000000000) * 100 = Unix_64_bit_nanoseconds
 
 # Final:
 # gregorian_100_ns = 0x1EC9414C232AB00 or 138648505420000000
@@ -2688,7 +2961,7 @@ gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
 # UUIDv6:   00011110110010010100000101001100|0010001100101010|0110|101100000000
 </pre>
 </div>
-<figcaption><a href="#figure-10" class="selfRef">Figure 10</a>:
+<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
 <a href="#name-test-vector-timestamp-pseud" class="selfRef">Test Vector Timestamp Pseudo-code</a>
         </figcaption></figure>
 <div id="uuidv6_example">
@@ -2696,7 +2969,7 @@ gregorian_100_ns = (unix_64_bit_nanoseconds / 100) + gregorian_unix_offset
         <h3 id="name-example-of-a-uuidv6-value">
 <a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-example-of-a-uuidv6-value" class="section-name selfRef">Example of a UUIDv6 Value</a>
         </h3>
-<span id="name-uuidv1-example-test-vector"></span><figure id="figure-11">
+<span id="name-uuidv1-example-test-vector"></span><figure id="figure-15">
           <div class="alignLeft art-text artwork" id="appendix-B.1-1.1">
 <pre>
 ----------------------------------------------
@@ -2714,10 +2987,10 @@ total                128
 final_hex: C232AB00-9414-11EC-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-11" class="selfRef">Figure 11</a>:
+<figcaption><a href="#figure-15" class="selfRef">Figure 15</a>:
 <a href="#name-uuidv1-example-test-vector" class="selfRef">UUIDv1 Example Test Vector</a>
           </figcaption></figure>
-<span id="name-uuidv6-example-test-vector"></span><figure id="figure-12">
+<span id="name-uuidv6-example-test-vector"></span><figure id="figure-16">
           <div class="alignLeft art-text artwork" id="appendix-B.1-2.1">
 <pre>
 -----------------------------------------------
@@ -2735,21 +3008,51 @@ total                 128
 final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 </pre>
 </div>
-<figcaption><a href="#figure-12" class="selfRef">Figure 12</a>:
+<figcaption><a href="#figure-16" class="selfRef">Figure 16</a>:
 <a href="#name-uuidv6-example-test-vector" class="selfRef">UUIDv6 Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="uuidv7_example">
 <section id="appendix-B.2">
-        <h3 id="name-example-of-a-uuidv7e-value">
-<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
+        <h3 id="name-example-of-a-uuidv7-value">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7-value" class="section-name selfRef">Example of a UUIDv7 Value</a>
         </h3>
-<p id="appendix-B.2-1">This example UUIDv7E test vector utilizes a well-known 32-bit unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
-<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-13">
+<span id="name-uuidv7-example-test-vector"></span><figure id="figure-17">
           <div class="alignLeft art-text artwork" id="appendix-B.2-4.1">
+<pre>
+-------------------------------
+field      bits    value
+-------------------------------
+unix_ts_ms   48    0x017F21CFD130
+var           4    0x7
+rand_a       12    0xCC3
+var           2    b10
+rand_b       62    0x18C4DC0C0C07398F
+-------------------------------
+total       128
+-------------------------------
+final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
+</pre>
+</div>
+<figcaption><a href="#figure-17" class="selfRef">Figure 17</a>:
+<a href="#name-uuidv7-example-test-vector" class="selfRef">UUIDv7 Example Test Vector</a>
+          </figcaption></figure>
+</section>
+</div>
+<div id="uuidv7E_example">
+<section id="appendix-B.3">
+        <h3 id="name-example-of-a-uuidv7e-value">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv7e-value" class="section-name selfRef">Example of a UUIDv7E Value</a>
+        </h3>
+<p id="appendix-B.3-1">This example UUIDv7E test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
+<span id="name-uuidv7e-example-test-vector"></span><figure id="figure-18">
+          <div class="alignLeft art-text artwork" id="appendix-B.3-4.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -2759,27 +3062,58 @@ rand_a       16    0xF8B8
 var_ver       8    0xE7
 rand_b       56    0xD6A139DC9535C5
 -------------------------------
-total        128
+total       128
 -------------------------------
 final: 017F21CF-D130-F8B8-E7D6-A139DC9535C5
 </pre>
 </div>
-<figcaption><a href="#figure-13" class="selfRef">Figure 13</a>:
+<figcaption><a href="#figure-18" class="selfRef">Figure 18</a>:
 <a href="#name-uuidv7e-example-test-vector" class="selfRef">UUIDv7E Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
 <div id="uuidv8_example">
-<section id="appendix-B.3">
-        <h3 id="name-example-of-a-uuidv8e-value">
-<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
+<section id="appendix-B.4">
+        <h3 id="name-example-of-a-uuidv8-value">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.3-1">This example UUIDv8E test vector utilizes a well-known 64-bit unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-2">The final 56 bits are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
-<p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>
-<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-14">
-          <div class="alignLeft art-text artwork" id="appendix-B.3-5.1">
+<p id="appendix-B.4-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.4-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.4-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.4-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.4-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.4-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-example-test-vector"></span><figure id="figure-19">
+          <div class="alignLeft art-text artwork" id="appendix-B.4-5.1">
+<pre>
+-------------------------------
+field      bits    value
+-------------------------------
+custom_a     48    0x320C3D4DCC00
+ver           4    0x8
+custom_b     12    0x75B
+var           2    b10
+custom_c     62    0xEC932D5F69181C0
+-------------------------------
+total       128
+-------------------------------
+final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
+</pre>
+</div>
+<figcaption><a href="#figure-19" class="selfRef">Figure 19</a>:
+<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
+          </figcaption></figure>
+</section>
+</div>
+<div id="uuidv8E_example">
+<section id="appendix-B.5">
+        <h3 id="name-example-of-a-uuidv8e-value">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-example-of-a-uuidv8e-value" class="section-name selfRef">Example of a UUIDv8E Value</a>
+        </h3>
+<p id="appendix-B.5-1">This example UUIDv8E test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision to fill the first 64 bits through ver_var.<a href="#appendix-B.5-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-2">The final 56 bits are filled with random data.<a href="#appendix-B.5-2" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.5-3" class="pilcrow">¶</a></p>
+<p id="appendix-B.5-4">It should be noted that this example is just to illustrate one scenario for UUIDv8E. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.5-4" class="pilcrow">¶</a></p>
+<span id="name-uuidv8e-example-test-vector-2"></span><figure id="figure-20">
+          <div class="alignLeft art-text artwork" id="appendix-B.5-5.1">
 <pre>
 -------------------------------
 field      bits    value
@@ -2788,13 +3122,13 @@ custom_a     64    0x16D6320C3D4DCC00
 var_ver       8    0xE8
 custom_b     56    0x3C2D06302FC417
 -------------------------------
-total        128
+total       128
 -------------------------------
 final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
 </pre>
 </div>
-<figcaption><a href="#figure-14" class="selfRef">Figure 14</a>:
-<a href="#name-uuidv8e-example-test-vector" class="selfRef">UUIDv8E Example Test Vector</a>
+<figcaption><a href="#figure-20" class="selfRef">Figure 20</a>:
+<a href="#name-uuidv8e-example-test-vector-2" class="selfRef">UUIDv8E Example Test Vector</a>
           </figcaption></figure>
 </section>
 </div>
@@ -2890,7 +3224,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">7</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -2898,7 +3232,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">8</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for future definition.</td>
+              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -3043,7 +3377,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">1</td>
               <td class="text-left" rowspan="1" colspan="1">7E</td>
-              <td class="text-left" rowspan="1" colspan="1">Unix Epoch time-based UUID specified in this document.</td>
+              <td class="text-left" rowspan="1" colspan="1">Alternate Unix Epoch time-based UUID specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>
@@ -3051,7 +3385,7 @@ final: 16D6320C-3D4D-CC00-E83C-2D06302FC417
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">0</td>
               <td class="text-left" rowspan="1" colspan="1">8E</td>
-              <td class="text-left" rowspan="1" colspan="1">Reserved for custom UUID formats specified in this document</td>
+              <td class="text-left" rowspan="1" colspan="1">Alternate reservation for custom UUID formats specified in this document.</td>
             </tr>
             <tr>
               <td class="text-left" rowspan="1" colspan="1">1</td>


### PR DESCRIPTION
### 3-9-2022 changelog:
- Relaxed introduction to a single one-liner.
- Updated text everywhere for variable length UUID defined as UUID Long uuid6/new-uuid-encoding-techniques-ietf-draft#2 
- Updated text everywhere for alternate encodings in uuid6/new-uuid-encoding-techniques-ietf-draft#3 
- Renamed Section and moved Opacity to it's own section to resolve uuid6/uuid6-ietf-draft#79  
- Defined v7/v8 along with v7E/v8E as I stated in uuid6/uuid6-ietf-draft#26 
  - Also updated appendix for test vectors.
- Re-organized and dropped counter method 2 as per discussions on uuid6/uuid6-ietf-draft#60 
- Updated references for RFC 4648
- Moved variant and version out of formats and grouped UUIDs by new formats, alternate variants, and alternate formats.

--- 

Reviewers:
- Please discuss changes in this PR within the threads above to keep discussions grouped nicely together.