### PR TITLE
Draft 03 Phase 5

### DIFF
--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/vvOtkI4X6q.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/hjOnAxXORn.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 19 September 2022</td>
+<td class="center">Expires 22 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-18" class="published">18 March 2022</time>
+<time datetime="2022-03-21" class="published">21 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-19">19 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-22">22 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 19 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 22 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -2161,32 +2161,42 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. 
  This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-6.2-9.4" class="pilcrow">¶</a>
 </dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-9.5">Fixed-Length Dedicated Counter Rollover Handling:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-9.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. 
- The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.
- The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-6.2-9.6" class="pilcrow">¶</a>
-</dd>
         <dd class="break"></dd>
 </dl>
 <p id="section-6.2-10">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-6.2-11">
- <li id="section-6.2-11.1">
-            <p id="section-6.2-11.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-11.1.1" class="pilcrow">¶</a></p>
+ The following sub-topics cover rollover handling with either type of counter method:<a href="#section-6.2-10" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-11">
+          <dt id="section-6.2-11.1">Counter Rollover Guards:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-11.2">
+ The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
+ This same technique can be leveraged with Monotonic random counter methods by ensuring the total length of a possible increment in the least significant, right most position is less than the total length of the random being incremented.
+ As such the most significant, left-most, bits can be incremented as rollover guarding.<a href="#section-6.2-11.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-11.3">Counter Rollover Handling:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-11.4">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. 
+ The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-6.2-11.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-6.2-12">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-12" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-6.2-13">
+ <li id="section-6.2-13.1">
+            <p id="section-6.2-13.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-13.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-6.2-11.2">
-            <p id="section-6.2-11.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-11.2.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-13.2">
+            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-6.2-11.3">
-            <p id="section-6.2-11.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-11.3.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-13.3">
+            <p id="section-6.2-13.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-13.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-6.2-12">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-12" class="pilcrow">¶</a></p>
-<p id="section-6.2-13">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-13" class="pilcrow">¶</a></p>
+<p id="section-6.2-14">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-14" class="pilcrow">¶</a></p>
+<p id="section-6.2-15">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-15" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
@@ -2314,7 +2324,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </li>
         </ul>
 <p id="section-6.9-5">
- DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+ DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers or left parts of identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON columns and key-value databases.
  If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
  In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-6.9-5" class="pilcrow">¶</a></p>
 </section>
@@ -2385,12 +2395,8 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC4086">[RFC4086]</dt>
-      <dd>
-<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="RFC4648">[RFC4648]</dt>
     <dd>
-<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
@@ -2553,7 +2559,7 @@ int main() {
   clock_gettime(CLOCK_REALTIME, &amp;tp);
   uint64_t timestamp = (uint64_t)tp.tv_sec &lt;&lt; 12;
 
-  // compute 12-bit (~0.25 msec precision) fraction from nsecs
+  // compute 12 bit (~0.25 msec precision) fraction from nsecs
   timestamp |= ((uint64_t)tp.tv_nsec &lt;&lt; 12) / 1000000000;
 
   printf("%08llx-%04llx\n", timestamp &gt;&gt; 16, timestamp &amp; 0xFFFF);
@@ -2573,7 +2579,7 @@ int main() {
       <h2 id="name-test-vectors">
 <a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-test-vectors" class="section-name selfRef">Test Vectors</a>
       </h2>
-<p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60 bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
 <span id="name-test-vector-timestamp-pseud"></span><figure id="figure-9">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
@@ -2659,7 +2665,7 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
         <h3 id="name-example-of-a-uuidv7-value">
 <a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7-value" class="section-name selfRef">Example of a UUIDv7 Value</a>
         </h3>
-<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32 bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
 <span id="name-uuidv7-example-test-vector"></span><figure id="figure-12">
@@ -2689,7 +2695,7 @@ final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
         <h3 id="name-example-of-a-uuidv8-value">
 <a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64 bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                           18 March 2022
-Expires: 19 September 2022
+Intended status: Standards Track                           21 March 2022
+Expires: 22 September 2022
 
 
                             New UUID Formats
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 19 September 2022.
+   This Internet-Draft will expire on 22 September 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 1]
+Peabody & Davis         Expires 22 September 2022               [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -75,18 +75,18 @@ Table of Contents
    6.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  12
      6.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  12
      6.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  13
-     6.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  16
+     6.3.  Distributed UUID Generation . . . . . . . . . . . . . . .  17
      6.4.  Collision Resistance  . . . . . . . . . . . . . . . . . .  17
      6.5.  Global and Local Uniqueness . . . . . . . . . . . . . . .  18
      6.6.  Unguessability  . . . . . . . . . . . . . . . . . . . . .  18
      6.7.  Sorting . . . . . . . . . . . . . . . . . . . . . . . . .  18
      6.8.  Opacity . . . . . . . . . . . . . . . . . . . . . . . . .  19
      6.9.  DBMS and Database Considerations  . . . . . . . . . . . .  19
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  19
-   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  19
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  20
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  20
    9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  20
    10. Normative References  . . . . . . . . . . . . . . . . . . . .  20
-   11. Informative References  . . . . . . . . . . . . . . . . . . .  20
+   11. Informative References  . . . . . . . . . . . . . . . . . . .  21
    Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  22
      A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  22
      A.2.  Creating a UUIDv7 Value . . . . . . . . . . . . . . . . .  23
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 2]
+Peabody & Davis         Expires 22 September 2022               [Page 2]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -165,7 +165,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 3]
+Peabody & Davis         Expires 22 September 2022               [Page 3]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -221,7 +221,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 4]
+Peabody & Davis         Expires 22 September 2022               [Page 4]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -277,7 +277,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 5]
+Peabody & Davis         Expires 22 September 2022               [Page 5]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -333,7 +333,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 6]
+Peabody & Davis         Expires 22 September 2022               [Page 6]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -389,7 +389,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 7]
+Peabody & Davis         Expires 22 September 2022               [Page 7]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -445,7 +445,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 8]
+Peabody & Davis         Expires 22 September 2022               [Page 8]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -501,7 +501,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022               [Page 9]
+Peabody & Davis         Expires 22 September 2022               [Page 9]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -557,7 +557,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 10]
+Peabody & Davis         Expires 22 September 2022              [Page 10]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -613,7 +613,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 11]
+Peabody & Davis         Expires 22 September 2022              [Page 11]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -669,7 +669,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 12]
+Peabody & Davis         Expires 22 September 2022              [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -725,7 +725,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 13]
+Peabody & Davis         Expires 22 September 2022              [Page 13]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -781,7 +781,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 14]
+Peabody & Davis         Expires 22 September 2022              [Page 14]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -829,23 +829,36 @@ Internet-Draft               new-uuid-format                  March 2022
       of the UUID after the counter.  This entropy helps improve the
       unguessability characteristics of UUIDs created within the batch.
 
-   Fixed-Length Dedicated Counter Rollover Handling:
-      Counter rollovers SHOULD be handled by the application to avoid
-      sorting issues.  The general guidance is that applications that
-      care about absolute monotonicity and sortability SHOULD freeze the
-      counter and wait for the timestamp to advance which ensures
+   The following sub-topics cover rollover handling with either type of
+   counter method:
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 15]
+
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
 
-      monotonicity is not broken.  The technique from Fixed-Length
-      Dedicated Counter Seeding which describes allocating a segment of
-      the fixed-length counter as a rollover guard is also recommended
-      and SHOULD be employed to help mitigate counter rollover issues.
+   Counter Rollover Guards:
+      The technique from Fixed-Length Dedicated Counter Seeding which
+      describes allocating a segment of the fixed-length counter as a
+      rollover guard is also recommended and SHOULD be employed to help
+      mitigate counter rollover issues.  This same technique can be
+      leveraged with Monotonic random counter methods by ensuring the
+      total length of a possible increment in the least significant,
+      right most position is less than the total length of the random
+      being incremented.  As such the most significant, left-most, bits
+      can be incremented as rollover guarding.
+
+   Counter Rollover Handling:
+      Counter rollovers SHOULD be handled by the application to avoid
+      sorting issues.  The general guidance is that applications that
+      care about absolute monotonicity and sortability SHOULD freeze the
+      counter and wait for the timestamp to advance which ensures
+      monotonicity is not broken.
 
    Implementations MAY use the following logic to ensure UUIDs featuring
    embedded counters are monotonic in nature:
@@ -871,6 +884,20 @@ Internet-Draft               new-uuid-format                  March 2022
    in the form of "clock sequence" bits.  The usage of the clock
    sequence will remain as defined in [RFC4122], Section 4.1.5.
 
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 16]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
 6.3.  Distributed UUID Generation
 
    Some implementations MAY desire to utilize multi-node, clustered,
@@ -889,14 +916,6 @@ Internet-Draft               new-uuid-format                  March 2022
       could become a bottleneck and impact UUID generation in a negative
       way.  Utilization of shared knowledge schemes with central/global
       registries is outside the scope of this specification.
-
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 16]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Node IDs:
       With this method, a nondescript pseudo-random Node ID value is
@@ -928,6 +947,13 @@ Internet-Draft               new-uuid-format                  March 2022
    There are two example scenarios below which help illustrate the
    varying seriousness of a collision within an application.
 
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 17]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    Low Impact
       A UUID collision generated a duplicate log entry which results in
       incorrect statistics derived from the data.  Implementations that
@@ -941,18 +967,6 @@ Internet-Draft               new-uuid-format                  March 2022
       unacceptable.  As such applications dealing with this type of
       scenario MUST employ as much collision resistance as possible
       within the given application context.
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 17]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
 6.5.  Global and Local Uniqueness
 
@@ -986,6 +1000,16 @@ Internet-Draft               new-uuid-format                  March 2022
    sorting (e.g. database indexes) SHOULD sort as opaque raw bytes,
    without examining the contents at all.
 
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 18]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    Time ordered monotonic UUIDs benefit from greater index locality
    because the new values are near each other in the index.  As a result
    objects can much more easily be clustered together for better
@@ -998,17 +1022,6 @@ Internet-Draft               new-uuid-format                  March 2022
    UUIDs created by this specification are crafted with big-ending byte
    order (network byte order) in mind.  If Little-endian style is
    required a custom UUID format SHOULD be created using UUIDv8.
-
-
-
-
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 18]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
 6.8.  Opacity
 
@@ -1037,15 +1050,31 @@ Internet-Draft               new-uuid-format                  March 2022
       translation if the resulting text form is to be used after
       retrieval and thus maybe simpler to implement.
 
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 19]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    DBMS vendors are encouraged to provide functionality to generate and
    store UUID formats defined by this specification for use as
-   identifiers such as (but not limited to) primary keys, surrogate keys
-   for temporal databases, foreign keys included in polymorphic
-   relationships, and keys for key-value pairs in JSON key-value
-   databases.  If database is monolithic than database side UUID
-   generation ensures best UUID monotonicity in the database tables and
-   in indexes.  In addition to UUIDs, additional identifiers MAY be used
-   to ensure integrity and feedback.
+   identifiers or left parts of identifiers such as (but not limited to)
+   primary keys, surrogate keys for temporal databases, foreign keys
+   included in polymorphic relationships, and keys for key-value pairs
+   in JSON columns and key-value databases.  If database is monolithic
+   than database side UUID generation ensures best UUID monotonicity in
+   the database tables and in indexes.  In addition to UUIDs, additional
+   identifiers MAY be used to ensure integrity and feedback.
 
 7.  IANA Considerations
 
@@ -1057,14 +1086,6 @@ Internet-Draft               new-uuid-format                  March 2022
    within a UUID.  Instead CSPRNG data SHOULD selected from a source
    with sufficient entropy to ensure guaranteed uniqueness among UUID
    generation.  See Section 6.6 for more information.
-
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 19]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    Timestamps embedded in the UUID do pose a very small attack surface.
    The timestamp in conjunction with an embedded counter does signal the
@@ -1094,6 +1115,13 @@ Internet-Draft               new-uuid-format                  March 2022
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 20]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    [RFC4122]  Leach, P., Mealling, M., and R. Salz, "A Universally
               Unique IDentifier (UUID) URN Namespace", RFC 4122,
               DOI 10.17487/RFC4122, July 2005,
@@ -1104,23 +1132,12 @@ Internet-Draft               new-uuid-format                  March 2022
               DOI 10.17487/RFC4086, June 2005,
               <https://www.rfc-editor.org/info/rfc4122>.
 
-   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
-              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
-              <https://www.rfc-editor.org/info/rfc4122>.
-
 11.  Informative References
 
    [LexicalUUID]
               Twitter, "A Scala client for Cassandra", commit f6da4e0,
               November 2012,
               <https://github.com/twitter-archive/cassie>.
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 20]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    [Snowflake]
               Twitter, "Snowflake is a network service for generating
@@ -1154,6 +1171,13 @@ Internet-Draft               new-uuid-format                  March 2022
               Twitter's Snowflake", Commit 848d664, August 2020,
               <https://github.com/sony/sonyflake>.
 
+
+
+Peabody & Davis         Expires 22 September 2022              [Page 21]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
    [orderedUuid]
               Cabrera, IT., "Laravel: The mysterious "Ordered UUID"",
               January 2020, <https://itnext.io/laravel-the-mysterious-
@@ -1170,13 +1194,6 @@ Internet-Draft               new-uuid-format                  March 2022
    [SID]      Chilton, A., "sid : generate sortable identifiers",
               Commit 660e947, June 2019,
               <https://github.com/chilts/sid>.
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 21]
-
-Internet-Draft               new-uuid-format                  March 2022
-
 
    [pushID]   Google, "The 2^120 Ways to Ensure Unique Identifiers",
               February 2015, <https://firebase.googleblog.com/2015/02/
@@ -1212,24 +1229,7 @@ A.1.  Creating a UUIDv6 Value
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 19 September 2022              [Page 22]
+Peabody & Davis         Expires 22 September 2022              [Page 22]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1285,7 +1285,7 @@ A.3.  Creating a UUIDv8 Value
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 23]
+Peabody & Davis         Expires 22 September 2022              [Page 23]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1299,7 +1299,7 @@ Internet-Draft               new-uuid-format                  March 2022
      clock_gettime(CLOCK_REALTIME, &tp);
      uint64_t timestamp = (uint64_t)tp.tv_sec << 12;
 
-     // compute 12-bit (~0.25 msec precision) fraction from nsecs
+     // compute 12 bit (~0.25 msec precision) fraction from nsecs
      timestamp |= ((uint64_t)tp.tv_nsec << 12) / 1000000000;
 
      printf("%08llx-%04llx\n", timestamp >> 16, timestamp & 0xFFFF);
@@ -1310,7 +1310,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 Appendix B.  Test Vectors
 
-   Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit
+   Both UUIDv1 and UUIDv6 test vectors utilize the same 60 bit
    timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February
    22, 2022 2:22:22.000000 PM GMT-05:00
 
@@ -1341,7 +1341,7 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 24]
+Peabody & Davis         Expires 22 September 2022              [Page 24]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1397,7 +1397,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 25]
+Peabody & Davis         Expires 22 September 2022              [Page 25]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1420,7 +1420,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 B.2.  Example of a UUIDv7 Value
 
-   This example UUIDv7 test vector utilizes a well-known 32-bit Unix
+   This example UUIDv7 test vector utilizes a well-known 32 bit Unix
    epoch with additional millisecond precision to fill the first 48 bits
 
    rand_a and rand_b are filled with random data.
@@ -1445,7 +1445,7 @@ B.2.  Example of a UUIDv7 Value
 
 B.3.  Example of a UUIDv8 Value
 
-   This example UUIDv8 test vector utilizes a well-known 64-bit Unix
+   This example UUIDv8 test vector utilizes a well-known 64 bit Unix
    epoch with nanosecond precision, truncated to the least-significant
    (right-most) bits to fill the first 48 bits through version.
 
@@ -1453,7 +1453,7 @@ B.3.  Example of a UUIDv8 Value
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 26]
+Peabody & Davis         Expires 22 September 2022              [Page 26]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1509,7 +1509,7 @@ C.1.  Variant 10xx Versions
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 27]
+Peabody & Davis         Expires 22 September 2022              [Page 27]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1565,7 +1565,7 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 28]
+Peabody & Davis         Expires 22 September 2022              [Page 28]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1621,4 +1621,4 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 19 September 2022              [Page 29]
+Peabody & Davis         Expires 22 September 2022              [Page 29]

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -511,11 +511,21 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 							Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. 
 							This entropy helps improve the unguessability characteristics of UUIDs created within the batch.
 						</dd>
-					<dt>Fixed-Length Dedicated Counter Rollover Handling:</dt>
+				</dl>
+				<t>
+					The following sub-topics cover rollover handling with either type of counter method:
+				</t>
+				<dl newline="true">
+					<dt>Counter Rollover Guards:</dt>
+						<dd>
+							The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
+							This same technique can be leveraged with Monotonic random counter methods by ensuring the total length of a possible increment in the least significant, right most position is less than the total length of the random being incremented.
+							As such the most significant, left-most, bits can be incremented as rollover guarding. 
+						</dd>
+					<dt>Counter Rollover Handling:</dt>
 						<dd>
 							Counter rollovers SHOULD be handled by the application to avoid sorting issues. 
 							The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.
-							The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
 						</dd>
 				</dl>
 				<t>
@@ -625,7 +635,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 					<li><t>Storing as text requires more space but may require less translation if the resulting text form is to be used after retrieval and thus maybe simpler to implement.</t></li>
 				</ul>
 				<t>
-					DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+					DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers or left parts of identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON columns and key-value databases.
 					If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
 					In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.
 				</t>
@@ -743,20 +753,6 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</front>
 				<seriesInfo name="RFC" value="4086"/>
 				<seriesInfo name="DOI" value="10.17487/RFC4086"/>
-			</reference>
-			<reference anchor="RFC4648" target="https://www.rfc-editor.org/info/rfc4122">
-				<front>
-					<title>The Base16, Base32, and Base64 Data Encodings</title>
-					<author initials="S." surname="Josefsson" fullname="S. Josefsson">
-						<organization/>
-					</author>
-					<date year="2006" month="October"/>
-					<abstract>
-						<t> This document describes the commonly used base 64, base 32, and base 16 encoding schemes.  It also discusses the use of line-feeds in encoded data, use of padding in encoded data, use of non-alphabet characters in encoded data, use of different encoding alphabets, and canonical encodings.</t>
-					</abstract>
-				</front>
-				<seriesInfo name="RFC" value="4648"/>
-				<seriesInfo name="DOI" value="10.17487/RFC4648"/>
 			</reference>
 		</references>
 		<references title="Informative References">
@@ -987,7 +983,7 @@ int main() {
   clock_gettime(CLOCK_REALTIME, &tp);
   uint64_t timestamp = (uint64_t)tp.tv_sec << 12;
 
-  // compute 12-bit (~0.25 msec precision) fraction from nsecs
+  // compute 12 bit (~0.25 msec precision) fraction from nsecs
   timestamp |= ((uint64_t)tp.tv_nsec << 12) / 1000000000;
 
   printf("%08llx-%04llx\n", timestamp >> 16, timestamp & 0xFFFF);
@@ -998,7 +994,7 @@ int main() {
 			</section>
 		</section>
 		<section anchor="test_vectors" title="Test Vectors">
-			<t>Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00</t>
+			<t>Both UUIDv1 and UUIDv6 test vectors utilize the same 60 bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00</t>
 			<t>Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.</t>
 				<figure>
 					<name>Test Vector Timestamp Pseudo-code</name>
@@ -1066,7 +1062,7 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
 				</figure>
 			</section>
 			<section anchor="uuidv7_example" title="Example of a UUIDv7 Value">
-				<t>This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
+				<t>This example UUIDv7 test vector utilizes a well-known 32 bit Unix epoch with additional millisecond precision to fill the first 48 bits</t>
 				<t>rand_a and rand_b are filled with random data.</t>
 				<t>The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000</t>
 				<figure>
@@ -1088,7 +1084,7 @@ final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
 				</figure>
 			</section>
 			<section anchor="uuidv8_example" title="Example of a UUIDv8 Value">
-				<t>This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.</t>
+				<t>This example UUIDv8 test vector utilizes a well-known 64 bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.</t>
 				<t>The next two segments of custom_b and custmo_c are are filled with random data.</t>
 				<t>Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000</t>
 				<t>It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.</t>

--- a/editor-notes/e-var-alt-enc-uuid-long-backup.txt
+++ b/editor-notes/e-var-alt-enc-uuid-long-backup.txt
@@ -337,3 +337,18 @@ u[8] = 0xE7; // set var-ver field
                     ]]></artwork>
                 </figure>
             </section>
+			
+			<reference anchor="RFC4648" target="https://www.rfc-editor.org/info/rfc4122">
+				<front>
+					<title>The Base16, Base32, and Base64 Data Encodings</title>
+					<author initials="S." surname="Josefsson" fullname="S. Josefsson">
+						<organization/>
+					</author>
+					<date year="2006" month="October"/>
+					<abstract>
+						<t> This document describes the commonly used base 64, base 32, and base 16 encoding schemes.  It also discusses the use of line-feeds in encoded data, use of padding in encoded data, use of non-alphabet characters in encoded data, use of different encoding alphabets, and canonical encodings.</t>
+					</abstract>
+				</front>
+				<seriesInfo name="RFC" value="4648"/>
+				<seriesInfo name="DOI" value="10.17487/RFC4648"/>
+			</reference>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/vvOtkI4X6q.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/hjOnAxXORn.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 19 September 2022</td>
+<td class="center">Expires 22 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-18" class="published">18 March 2022</time>
+<time datetime="2022-03-21" class="published">21 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-19">19 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-22">22 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 19 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 22 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -2161,32 +2161,42 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Care SHOULD also be given to ensure that the counter length selected leaves room for sufficient entropy in the random portion of the UUID after the counter. 
  This entropy helps improve the unguessability characteristics of UUIDs created within the batch.<a href="#section-6.2-9.4" class="pilcrow">¶</a>
 </dd>
-          <dd class="break"></dd>
-<dt id="section-6.2-9.5">Fixed-Length Dedicated Counter Rollover Handling:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.2-9.6">
- Counter rollovers SHOULD be handled by the application to avoid sorting issues. 
- The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.
- The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.<a href="#section-6.2-9.6" class="pilcrow">¶</a>
-</dd>
         <dd class="break"></dd>
 </dl>
 <p id="section-6.2-10">
- Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-10" class="pilcrow">¶</a></p>
-<ol start="1" type="1" class="compact type-1" id="section-6.2-11">
- <li id="section-6.2-11.1">
-            <p id="section-6.2-11.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-11.1.1" class="pilcrow">¶</a></p>
+ The following sub-topics cover rollover handling with either type of counter method:<a href="#section-6.2-10" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6.2-11">
+          <dt id="section-6.2-11.1">Counter Rollover Guards:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-11.2">
+ The technique from Fixed-Length Dedicated Counter Seeding which describes allocating a segment of the fixed-length counter as a rollover guard is also recommended and SHOULD be employed to help mitigate counter rollover issues.
+ This same technique can be leveraged with Monotonic random counter methods by ensuring the total length of a possible increment in the least significant, right most position is less than the total length of the random being incremented.
+ As such the most significant, left-most, bits can be incremented as rollover guarding.<a href="#section-6.2-11.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-11.3">Counter Rollover Handling:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-11.4">
+ Counter rollovers SHOULD be handled by the application to avoid sorting issues. 
+ The general guidance is that applications that care about absolute monotonicity and sortability SHOULD freeze the counter and wait for the timestamp to advance which ensures monotonicity is not broken.<a href="#section-6.2-11.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-6.2-12">
+ Implementations MAY use the following logic to ensure UUIDs featuring embedded counters are monotonic in nature:<a href="#section-6.2-12" class="pilcrow">¶</a></p>
+<ol start="1" type="1" class="compact type-1" id="section-6.2-13">
+ <li id="section-6.2-13.1">
+            <p id="section-6.2-13.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-13.1.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-6.2-11.2">
-            <p id="section-6.2-11.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-11.2.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-13.2">
+            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li id="section-6.2-11.3">
-            <p id="section-6.2-11.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-11.3.1" class="pilcrow">¶</a></p>
+          <li id="section-6.2-13.3">
+            <p id="section-6.2-13.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-13.3.1" class="pilcrow">¶</a></p>
 </li>
         </ol>
-<p id="section-6.2-12">
- Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-12" class="pilcrow">¶</a></p>
-<p id="section-6.2-13">
- UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-13" class="pilcrow">¶</a></p>
+<p id="section-6.2-14">
+ Implementations SHOULD check if the the currently generated UUID is greater than the previously generated UUID. If this is not the case then any number of things could have occurred. Such as, but not limited to, clock rollbacks or counter rollovers. Applications SHOULD embed sufficient logic to catch these scenarios and correct the problem ensuring the next UUID generated is greater than the previous.<a href="#section-6.2-14" class="pilcrow">¶</a></p>
+<p id="section-6.2-15">
+ UUIDv1, and by extension UUIDv6, utilize a slightly different counter in the form of "clock sequence" bits. The usage of the clock sequence will remain as defined in <span>[<a href="#RFC4122" class="xref">RFC4122</a>], <a href="https://rfc-editor.org/rfc/rfc4122#section-4.1.5" class="relref">Section 4.1.5</a></span>.<a href="#section-6.2-15" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="distributed_shared_knowledge">
@@ -2314,7 +2324,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </li>
         </ul>
 <p id="section-6.9-5">
- DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON key-value databases.
+ DBMS vendors are encouraged to provide functionality to generate and store UUID formats defined by this specification for use as identifiers or left parts of identifiers such as (but not limited to) primary keys, surrogate keys for temporal databases, foreign keys included in polymorphic relationships, and keys for key-value pairs in JSON columns and key-value databases.
  If database is monolithic than database side UUID generation ensures best UUID monotonicity in the database tables and in indexes. 
  In addition to UUIDs, additional identifiers MAY be used to ensure integrity and feedback.<a href="#section-6.9-5" class="pilcrow">¶</a></p>
 </section>
@@ -2385,12 +2395,8 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC4086">[RFC4086]</dt>
-      <dd>
-<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
-<dd class="break"></dd>
-<dt id="RFC4648">[RFC4648]</dt>
     <dd>
-<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<span class="refAuthor">Eastlake 3rd, D.</span>, <span class="refAuthor">Schiller, J.</span>, and <span class="refAuthor">S. Crocker</span>, <span class="refTitle">"Randomness Requirements for Security"</span>, <span class="seriesInfo">RFC 4086</span>, <span class="seriesInfo">DOI 10.17487/RFC4086</span>, <time datetime="2005-06" class="refDate">June 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>
@@ -2553,7 +2559,7 @@ int main() {
   clock_gettime(CLOCK_REALTIME, &amp;tp);
   uint64_t timestamp = (uint64_t)tp.tv_sec &lt;&lt; 12;
 
-  // compute 12-bit (~0.25 msec precision) fraction from nsecs
+  // compute 12 bit (~0.25 msec precision) fraction from nsecs
   timestamp |= ((uint64_t)tp.tv_nsec &lt;&lt; 12) / 1000000000;
 
   printf("%08llx-%04llx\n", timestamp &gt;&gt; 16, timestamp &amp; 0xFFFF);
@@ -2573,7 +2579,7 @@ int main() {
       <h2 id="name-test-vectors">
 <a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-test-vectors" class="section-name selfRef">Test Vectors</a>
       </h2>
-<p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60-bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
+<p id="appendix-B-1">Both UUIDv1 and UUIDv6 test vectors utilize the same 60 bit timestamp: 0x1EC9414C232AB00 (138648505420000000) Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00<a href="#appendix-B-1" class="pilcrow">¶</a></p>
 <p id="appendix-B-2">Both UUIDv1 and UUIDv6 utilize the same values in clk_seq_hi_res, clock_seq_low, and node. All of which have been generated with random data.<a href="#appendix-B-2" class="pilcrow">¶</a></p>
 <span id="name-test-vector-timestamp-pseud"></span><figure id="figure-9">
         <div class="alignLeft art-text artwork" id="appendix-B-3.1">
@@ -2659,7 +2665,7 @@ final_hex: 1EC9414C-232A-6B00-B3C8-9E6BDECED846
         <h3 id="name-example-of-a-uuidv7-value">
 <a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-example-of-a-uuidv7-value" class="section-name selfRef">Example of a UUIDv7 Value</a>
         </h3>
-<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32-bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.2-1">This example UUIDv7 test vector utilizes a well-known 32 bit Unix epoch with additional millisecond precision to fill the first 48 bits<a href="#appendix-B.2-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-2">rand_a and rand_b are filled with random data.<a href="#appendix-B.2-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.2-3">The timestamp is Tuesday, February 22, 2022 2:22:22.00 PM GMT-05:00 represented as 0x17F21CFD130 or 1645539742000<a href="#appendix-B.2-3" class="pilcrow">¶</a></p>
 <span id="name-uuidv7-example-test-vector"></span><figure id="figure-12">
@@ -2689,7 +2695,7 @@ final: 017F21CF-D130-7CC3-98C4-DC0C0C07398F
         <h3 id="name-example-of-a-uuidv8-value">
 <a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-example-of-a-uuidv8-value" class="section-name selfRef">Example of a UUIDv8 Value</a>
         </h3>
-<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64-bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
+<p id="appendix-B.3-1">This example UUIDv8 test vector utilizes a well-known 64 bit Unix epoch with nanosecond precision, truncated to the least-significant (right-most) bits to fill the first 48 bits through version.<a href="#appendix-B.3-1" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-2">The next two segments of custom_b and custmo_c are are filled with random data.<a href="#appendix-B.3-2" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-3">Timestamp is Tuesday, February 22, 2022 2:22:22.000000 PM GMT-05:00 represented as 0x16D6320C3D4DCC00 or 1645557742000000000<a href="#appendix-B.3-3" class="pilcrow">¶</a></p>
 <p id="appendix-B.3-4">It should be noted that this example is just to illustrate one scenario for UUIDv8. Test vectors will likely be implementation specific and vary greatly from this simple example.<a href="#appendix-B.3-4" class="pilcrow">¶</a></p>

--- a/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.html
+++ b/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.html
@@ -1,0 +1,1621 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>New UUID Encoding Techniques</title>
+<meta content="Brad G. Peabody" name="author">
+<meta content="Kyzer R. Davis" name="author">
+<meta content="
+       
+ This document presents new Universally Unique Identifier (UUID) encoding techniques which facilitate greater efficiency in storage or transport versus the unnecessarily verbose text representation from  .
+ Furthermore UUID can now be been extended beyond 128 bits to facilitate enhanced collision resistance or for embedding additional data within a given UUID value.
+       
+    " name="description">
+<meta content="xml2rfc 3.12.2" name="generator">
+<meta content="uuid" name="keyword">
+<meta content="draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.12.2
+    Python 3.6.9
+    appdirs 1.4.4
+    ConfigArgParse 1.2.3
+    google-i18n-address 2.4.0
+    html5lib 1.1
+    intervaltree 3.1.0
+    Jinja2 2.11.2
+    kitchen 1.2.6
+    lxml 4.5.2
+    pycountry 20.7.3
+    pyflakes 2.2.0
+    PyYAML 5.3.1
+    requests 2.24.0
+    setuptools 40.6.2
+    six 1.15.0
+-->
+<link href="/tmp/QvTERtS8Xo.dir/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necssary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  border: none;
+  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
+     support flexbox yet.
+  */
+  display: table;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre, code {
+  background-color: #f9f9f9;
+  font-family: 'Roboto Mono', monospace;
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    float: none;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: "Noto Sans",Arial,Helvetica,sans-serif;
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The follwing is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre, code {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+pre.sourcecode,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact informatio look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background sligthtly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottim margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the comact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div:first-child > pre.sourcecode,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body>
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">new-uuid-format</td>
+<td class="right">March 2022</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Peabody &amp; Davis</td>
+<td class="center">Expires 22 September 2022</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">dispatch</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00</dd>
+<dt class="label-updates">Updates:</dt>
+<dd class="updates">
+<a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2022-03-21" class="published">21 March 2022</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2022-09-22">22 September 2022</time></dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">BGP. Peabody</div>
+</div>
+<div class="author">
+      <div class="author-name">K. Davis</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">New UUID Encoding Techniques</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">
+ This document presents new Universally Unique Identifier (UUID) encoding techniques which facilitate greater efficiency in storage or transport versus the unnecessarily verbose text representation from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
+ Furthermore UUID can now be been extended beyond 128 bits to facilitate enhanced collision resistance or for embedding additional data within a given UUID value.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 22 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2022 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Revised BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Revised BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-terminology" class="xref">Terminology</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-requirements-language" class="xref">Requirements Language</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-abbreviations" class="xref">Abbreviations</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-changelog" class="xref">changelog</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-extended-urn-uuid-namespace" class="xref">Extended URN UUID Namespace</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="Background">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">
+ The original "hex and dash", 8-4-4-4-12, format of UUIDs defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> represents a 128 bit UUID value as a 288 bit value. 
+ While this may be great for human readability; the only available UUID text representation suffers poorly for storage, transmission and application parsing.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">
+ Furthermore, UUIDs static length of 128 bits has lead to many alternative, non-standard, Globally Unique Identifiers which aim to pack more information into a larger bit space.<a href="#section-1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-2">
+      <h2 id="name-terminology">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+      </h2>
+<div id="requirements_language">
+<section id="section-2.1">
+        <h3 id="name-requirements-language">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-requirements-language" class="section-name selfRef">Requirements Language</a>
+        </h3>
+<p id="section-2.1-1">
+ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span> when, and only when, they appear in all capitals, as shown here.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="acronyms">
+<section id="section-2.2">
+        <h3 id="name-abbreviations">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-abbreviations" class="section-name selfRef">Abbreviations</a>
+        </h3>
+<p id="section-2.2-1">The following abbreviations are used in this document:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-2.2-2">
+          <dt id="section-2.2-2.1">UUID</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.2">Universally Unique Identifier <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span><a href="#section-2.2-2.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.2-2.3">URN</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.4">Uniform Resource Name <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span><a href="#section-2.2-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+<div id="changelog">
+<section id="section-3">
+      <h2 id="name-changelog">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-changelog" class="section-name selfRef">changelog</a>
+      </h2>
+<p id="section-3-1">RFC EDITOR PLEASE DELETE THIS SECTION.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">draft-00<a href="#section-3-2" class="pilcrow">¶</a></p>
+<ul class="compact ulEmpty">
+<li class="compact ulEmpty" id="section-3-3.1">
+          <p id="section-3-3.1.1">- Initial Release<a href="#section-3-3.1.1" class="pilcrow">¶</a></p>
+</li>
+      </ul>
+</section>
+</div>
+<div id="extended_uuid_namespace">
+<section id="section-4">
+      <h2 id="name-extended-urn-uuid-namespace">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-extended-urn-uuid-namespace" class="section-name selfRef">Extended URN UUID Namespace</a>
+      </h2>
+<p id="section-4-1">
+ The Existing UUID URN introduced by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> will remain as urn:uuid:{uuid_value} however a new, extended URN structures will be leveraged to convey finer topics introduced by this document.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">
+ The UUIDs defined by this document MUST leverage the extended URN UUID namespace such that the encoding technique and length of the UUID are easily parsable using <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span> compatible logic.
+ If an application does not care about parsing, converting, or otherwise ascertaining information from a given UUID value then that application MAY choose to simply store the actual UUID value in the desired format and omit any UUID URN information.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">
+ The Extended UUID namespace syntax is composed of the following parts:<a href="#section-4-3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-4-4">
+        <dt id="section-4-4.1">urn</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.2">Uniform Resource Name as defined by <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span><a href="#section-4-4.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.3">uuid</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.4">Universally Unique IDentifier as defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span><a href="#section-4-4.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.5">{uuid_value}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.6">The actual UUID Value which may have been encoded using <a href="#uuid_encoding" class="xref">Section 5</a> or longer than 128 bits as per <a href="#uuid_long" class="xref">Section 6</a>. Any colon character (:) within this field MUST be percent-encoded as "%3A"<a href="#section-4-4.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.7">{uuid_length}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.8">Variable entry which describes the total length of encoded UUID Value (uuid_value) as an integer value.<a href="#section-4-4.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.9">{uuid_encoding}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.10">Variable entry which describes the encoding of the UUID Value (uuid_value). This value MAY include dashes characters thus base32 is the same as base-32.<a href="#section-4-4.10" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-4-5">
+ The existing UUID URN is equivalent to an Extended UUID URN via the following syntax where "base16hd" is a shorthand key for the 128 bit, base16 "Hex and Dashes" format introduced by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-4-5" class="pilcrow">¶</a></p>
+<span id="name-extended-urn-uuid-example"></span><figure id="figure-1">
+        <div class="alignLeft art-text artwork" id="section-4-6.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+</pre>
+</div>
+<figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
+<a href="#name-extended-urn-uuid-example" class="selfRef">Extended URN UUID Example:</a>
+        </figcaption></figure>
+<p id="section-4-7">
+ The next section defines some other Extended UUID URN namespace usage examples for alternate encodings for the same UUID Version 4 example as Base 16 Hex and Dashes (base16hd), Base2 (Binary), and Base10 (Decimal) values.<a href="#section-4-7" class="pilcrow">¶</a></p>
+<span id="name-extended-urn-uuid-example-2"></span><figure id="figure-2">
+        <div class="alignLeft art-text artwork" id="section-4-8.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101:128:base2
+urn:uuid:154072644812979270675542139334331768221:128:base10
+</pre>
+</div>
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
+<a href="#name-extended-urn-uuid-example-2" class="selfRef">Extended URN UUID Example:</a>
+        </figcaption></figure>
+</section>
+</div>
+<div id="uuid_encoding">
+<section id="section-5">
+      <h2 id="name-alternate-encodings">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
+      </h2>
+<p id="section-5-1">
+                    The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">
+                    Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. 
+ Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. 
+ When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUID values and collision resistance provided by all UUIDs.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3">
+                    When utilizing alternate encoding techniques with other applications; 
+ the encoded UUID MUST be prefixed with extended "urn:uuid:" to signal that the value therein is that of a UUID. 
+ Additionally the UUID MUST and post-fixed with the required extended UUID URN values as defined by <a href="#extended_uuid_namespace" class="xref">Section 4</a> to signal the alternate encoding technique in use and the length of the underlying encoded UUID.<a href="#section-5-3" class="pilcrow">¶</a></p>
+<p id="section-5-4">
+                    The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-5-4" class="pilcrow">¶</a></p>
+<span id="name-alternate-encoding-examples"></span><figure id="figure-3">
+        <div class="alignLeft art-text artwork" id="section-5-5.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT:128:base32
+urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1:128:base36
+</pre>
+</div>
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
+        </figcaption></figure>
+<p id="section-5-6">
+                    For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-5-6" class="pilcrow">¶</a></p>
+<p id="section-5-7">
+ Furthermore, when utilizing alternate encoding techniques along with Extended UUID URN namespaces; remember that disallowed characters MUST be percent-encoded as per <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span>.<a href="#section-5-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="uuid_long">
+<section id="section-6">
+      <h2 id="name-uuid-long">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
+      </h2>
+<p id="section-6-1">
+                    UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-6-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6-2">
+        <dt id="section-6-2.1">Increased Entropy:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.2">
+ While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities or guessability.<a href="#section-6-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-6-2.3">Requirements for additional embedded items:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.4">
+ Some implementations require more than 128 bits to properly embed all of the application specific data they require. 
+ Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers for distributed UUID generation.<a href="#section-6-2.4" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-6-3">
+                    UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. 
+ UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. 
+ UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex and dash format to create 8-4-4-4-12-{variable_length} text format.<a href="#section-6-3" class="pilcrow">¶</a></p>
+<p id="section-6-4">
+ The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-6-4" class="pilcrow">¶</a></p>
+<span id="name-uuid-long-examples"></span><figure id="figure-4">
+        <div class="alignLeft art-text artwork" id="section-6-5.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-05fa17aaac4f8954d9fac2df2fce30f6:160:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-02df3f4babc63a3b2775e27804528a6d23c679eed60fe31df3f8b014e7915595:192:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-8fe05412f24ca9974637a10c0b372a7109fb810f61068c0074b480f09f18b30fe03ae7bf09c98b241e8c9c0d51516b963ac75abe447dbff34177093b4b781a46:256:base16hd
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
+        </figcaption></figure>
+<p id="section-6-6">
+                    Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-6-6" class="pilcrow">¶</a></p>
+<p id="section-6-7">
+ UUID Long values MAY be coupled with alternate encoding techniques described in this document.<a href="#section-6-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="IANA">
+<section id="section-7">
+      <h2 id="name-iana-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-7-1">If Adopted, this document SHOULD be listed in https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml.<a href="#section-7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Security">
+<section id="section-8">
+      <h2 id="name-security-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-8-1">This document has no security considerations.<a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Acknowledgements">
+<section id="section-9">
+      <h2 id="name-acknowledgements">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="section-9-1">The authors gratefully acknowledge the contributions of 
+ Ben Campbell,
+ Ben Ramsey,
+ Fabio Lima,
+ Gonzalo Salgueiro, 
+ Martin Thomson,
+ Murray S. Kucherawy,
+ Rick van Rein,
+ Rob Wilton,
+ Sean Leonard,
+ Theodore Y. Ts'o.,
+ Robert Kieffer,
+ sergeyprokhorenko,
+ LiosK
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-9-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-10">
+      <h2 id="name-normative-references">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="RFC2119">[RFC2119]</dt>
+      <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+      <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4122">[RFC4122]</dt>
+      <dd>
+<span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4648">[RFC4648]</dt>
+      <dd>
+<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8141">[RFC8141]</dt>
+    <dd>
+<span class="refAuthor">Saint-Andre, P.</span> and <span class="refAuthor">J. Klensin</span>, <span class="refTitle">"Uniform Resource Names (URNs)"</span>, <span class="seriesInfo">RFC 8141</span>, <span class="seriesInfo">DOI 10.17487/RFC8141</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8141">https://www.rfc-editor.org/info/rfc8141</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="authors-addresses">
+<section id="appendix-A">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Brad G. Peabody</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:brad@peabody.io" class="email">brad@peabody.io</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Kyzer R. Davis</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:kydavis@cisco.com" class="email">kydavis@cisco.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.txt
+++ b/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.txt
@@ -1,0 +1,392 @@
+
+
+
+
+dispatch                                                    BGP. Peabody
+Internet-Draft                                                          
+Updates: 4122 (if approved)                                     K. Davis
+Intended status: Standards Track                           21 March 2022
+Expires: 22 September 2022
+
+
+                      New UUID Encoding Techniques
+      draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00
+
+Abstract
+
+   This document presents new Universally Unique Identifier (UUID)
+   encoding techniques which facilitate greater efficiency in storage or
+   transport versus the unnecessarily verbose text representation from
+   [RFC4122].  Furthermore UUID can now be been extended beyond 128 bits
+   to facilitate enhanced collision resistance or for embedding
+   additional data within a given UUID value.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 22 September 2022.
+
+Copyright Notice
+
+   Copyright (c) 2022 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 1]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   2
+     2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  changelog . . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   4.  Extended URN UUID Namespace . . . . . . . . . . . . . . . . .   3
+   5.  Alternate Encodings . . . . . . . . . . . . . . . . . . . . .   4
+   6.  UUID Long . . . . . . . . . . . . . . . . . . . . . . . . . .   5
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
+   10. Normative References  . . . . . . . . . . . . . . . . . . . .   6
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
+
+1.  Introduction
+
+   The original "hex and dash", 8-4-4-4-12, format of UUIDs defined by
+   [RFC4122] represents a 128 bit UUID value as a 288 bit value.  While
+   this may be great for human readability; the only available UUID text
+   representation suffers poorly for storage, transmission and
+   application parsing.
+
+   Furthermore, UUIDs static length of 128 bits has lead to many
+   alternative, non-standard, Globally Unique Identifiers which aim to
+   pack more information into a larger bit space.
+
+2.  Terminology
+
+2.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 2]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+2.2.  Abbreviations
+
+   The following abbreviations are used in this document:
+
+   UUID          Universally Unique Identifier [RFC4122]
+
+   URN           Uniform Resource Name [RFC8141]
+
+3.  changelog
+
+   RFC EDITOR PLEASE DELETE THIS SECTION.
+
+   draft-00
+
+      - Initial Release
+
+4.  Extended URN UUID Namespace
+
+   The Existing UUID URN introduced by [RFC4122] will remain as
+   urn:uuid:{uuid_value} however a new, extended URN structures will be
+   leveraged to convey finer topics introduced by this document.
+
+   The UUIDs defined by this document MUST leverage the extended URN
+   UUID namespace such that the encoding technique and length of the
+   UUID are easily parsable using [RFC8141] compatible logic.  If an
+   application does not care about parsing, converting, or otherwise
+   ascertaining information from a given UUID value then that
+   application MAY choose to simply store the actual UUID value in the
+   desired format and omit any UUID URN information.
+
+   The Extended UUID namespace syntax is composed of the following
+   parts:
+
+   urn
+      Uniform Resource Name as defined by [RFC8141]
+
+   uuid
+      Universally Unique IDentifier as defined by [RFC4122]
+
+   {uuid_value}
+      The actual UUID Value which may have been encoded using Section 5
+      or longer than 128 bits as per Section 6.  Any colon character (:)
+      within this field MUST be percent-encoded as "%3A"
+
+   {uuid_length}
+      Variable entry which describes the total length of encoded UUID
+      Value (uuid_value) as an integer value.
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 3]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   {uuid_encoding}
+      Variable entry which describes the encoding of the UUID Value
+      (uuid_value).  This value MAY include dashes characters thus
+      base32 is the same as base-32.
+
+   The existing UUID URN is equivalent to an Extended UUID URN via the
+   following syntax where "base16hd" is a shorthand key for the 128 bit,
+   base16 "Hex and Dashes" format introduced by [RFC4122].
+
+   urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d
+   urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+
+                    Figure 1: Extended URN UUID Example:
+
+   The next section defines some other Extended UUID URN namespace usage
+   examples for alternate encodings for the same UUID Version 4 example
+   as Base 16 Hex and Dashes (base16hd), Base2 (Binary), and Base10
+   (Decimal) values.
+
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101:128:base2
+urn:uuid:154072644812979270675542139334331768221:128:base10
+
+                 Figure 2: Extended URN UUID Example:
+
+5.  Alternate Encodings
+
+   The existing UUID hex and dash format of 8-4-4-4-12 is retained for
+   both backwards compatibility and human readability.  This format MUST
+   be implemented for all UUIDs.
+
+   Where required, UUIDs defined by this specification and [RFC4122] MAY
+   be encoded utilizing new techniques such as, but not limited to,
+   Base32, Base36, or Base64.  Applications MAY also utilize other
+   encoding techniques such as modulo division or alternate alphabets
+   such as Crockford's base32.  When selecting an alternate encoding
+   implementations SHOULD take into consideration items such as:
+   uppercase/lowercase/mixed character encoding for application
+   sortability, special character inclusions or omissions, and the
+   exclusion of key letters like "I", "L", "O", and "U" which may impact
+   sortability of UUID values and collision resistance provided by all
+   UUIDs.
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 4]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   When utilizing alternate encoding techniques with other applications;
+   the encoded UUID MUST be prefixed with extended "urn:uuid:" to signal
+   that the value therein is that of a UUID.  Additionally the UUID MUST
+   and post-fixed with the required extended UUID URN values as defined
+   by Section 4 to signal the alternate encoding technique in use and
+   the length of the underlying encoded UUID.
+
+   The conversion from UUID to a new encoding technique SHOULD be done
+   utilizing the underlying integer or binary value for a given UUID
+   versus converting the hex representation.  Two examples for UUIDv4
+   encoded as base-32 and base-36 are included below.
+
+   urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+   urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT:128:base32
+   urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1:128:base36
+
+                   Figure 3: Alternate Encoding Examples
+
+   For information on converting a UUID into Base 16, Base 32 or Base 64
+   refer to [RFC4648].
+
+   Furthermore, when utilizing alternate encoding techniques along with
+   Extended UUID URN namespaces; remember that disallowed characters
+   MUST be percent-encoded as per [RFC8141].
+
+6.  UUID Long
+
+   UUID Long generally references any variable length UUID longer than
+   128 bits.  There are two main driving factors behind extending UUID
+   beyond 128 bits:
+
+   Increased Entropy:
+      While existing UUID formats provide sufficient entropy for most
+      use cases; there exists scenarios where even more entropy is
+      required to further reduce collision probabilities or
+      guessability.
+
+   Requirements for additional embedded items:
+      Some implementations require more than 128 bits to properly embed
+      all of the application specific data they require.  Some examples
+      include database metadata like entity types, checksum values,
+      shard/partition identifiers, and even node identifiers for
+      distributed UUID generation.
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 5]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   UUID Long is compatible with any UUID specified in this document and
+   [RFC4122].  UUID long is variable in length and there is no minimum
+   or maximum value for UUID Long; however, UUID Long SHOULD leverage
+   natural byte boundaries.  UUID long is defined by appending an
+   additional dash to the existing 8-4-4-4-12 hex and dash format to
+   create 8-4-4-4-12-{variable_length} text format.
+
+   The next example shows a UUID Long +32, +64 and +128 example for
+   UUIDv4 with random data filling the values beyond 128 bits.
+
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-05fa17aaac4f8954d9fac2df2fce30f6:160:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-02df3f4babc63a3b2775e27804528a6d23c679eed60fe31df3f8b014e7915595:192:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-8fe05412f24ca9974637a10c0b372a7109fb810f61068c0074b480f09f18b30fe03ae7bf09c98b241e8c9c0d51516b963ac75abe447dbff34177093b4b781a46:256:base16hd
+
+                     Figure 4: UUID Long Examples
+
+   Where required, for compatibility with legacy UUID implementations,
+   the most significant, left-most, 128 bits MUST be leveraged to
+   truncate from UUID Long back to a regular UUID.
+
+   UUID Long values MAY be coupled with alternate encoding techniques
+   described in this document.
+
+7.  IANA Considerations
+
+   If Adopted, this document SHOULD be listed in
+   https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml.
+
+8.  Security Considerations
+
+   This document has no security considerations.
+
+9.  Acknowledgements
+
+   The authors gratefully acknowledge the contributions of Ben Campbell,
+   Ben Ramsey, Fabio Lima, Gonzalo Salgueiro, Martin Thomson, Murray S.
+   Kucherawy, Rick van Rein, Rob Wilton, Sean Leonard, Theodore Y.
+   Ts'o., Robert Kieffer, sergeyprokhorenko, LiosK As well as all of
+   those in the IETF community and on GitHub to who contributed to the
+   discussions which resulted in this document.
+
+10.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 6]
+
+Internet-Draft               new-uuid-format                  March 2022
+
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC4122]  Leach, P., Mealling, M., and R. Salz, "A Universally
+              Unique IDentifier (UUID) URN Namespace", RFC 4122,
+              DOI 10.17487/RFC4122, July 2005,
+              <https://www.rfc-editor.org/info/rfc4122>.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <https://www.rfc-editor.org/info/rfc4122>.
+
+   [RFC8141]  Saint-Andre, P. and J. Klensin, "Uniform Resource Names
+              (URNs)", RFC 8141, DOI 10.17487/RFC8141, October 2006,
+              <https://www.rfc-editor.org/info/rfc8141>.
+
+Authors' Addresses
+
+   Brad G. Peabody
+   Email: brad@peabody.io
+
+
+   Kyzer R. Davis
+   Email: kydavis@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 22 September 2022               [Page 7]

--- a/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.xml
+++ b/new-encoding-techniques/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="US-ASCII"?>
+<?xml-stylesheet type="text/xsl" href="rfc2629.xslt" ?> <!-- used by XSLT processors -->
+<!-- OPTIONS, known as processing instructions (PIs) go here. -->
+<!-- For a complete list and description of PIs,
+please see http://xml.resource.org/authoring/README.html. -->
+<!-- Below are generally applicable PIs that most I-Ds might want to use. -->
+<?rfc strict="yes" ?> <!-- give errors regarding ID-nits and DTD validation -->
+<!-- control the table of contents (ToC): -->
+<?rfc toc="yes"?> <!-- generate a ToC -->
+<?rfc tocdepth="3"?> <!-- the number of levels of subsections in ToC. default: 3 -->
+<!-- control references: -->
+<?rfc symrefs="yes"?> <!-- use symbolic references tags, i.e, [RFC2119] instead of [1] -->
+<?rfc sortrefs="yes" ?> <!-- sort the reference entries alphabetically -->
+<!-- control vertical white space: 
+(using these PIs as follows is recommended by the RFC Editor) -->
+<!-- end of popular PIs -->
+<rfc version="3" category="std" updates="4122" submissionType="IETF" consensus="true" ipr="trust200902" docName="draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00">
+	<front>
+		<title abbrev="new-uuid-format">New UUID Encoding Techniques</title>
+		<seriesInfo name="Internet-Draft" value="draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00" stream="IETF"/>
+		<author fullname="Brad G. Peabody" initials="BGP" surname="Peabody">
+			<address>
+				<email>brad@peabody.io</email>
+			</address>
+		</author>
+		<author fullname="Kyzer R. Davis" initials="K" surname="Davis">
+			<address>
+				<email>kydavis@cisco.com</email>
+			</address>
+		</author>
+		<date year="2022" />
+		<area>ART</area>
+		<workgroup>dispatch</workgroup>
+		<keyword>uuid</keyword>
+		<abstract>
+			<t>
+				This document presents new Universally Unique Identifier (UUID) encoding techniques which facilitate greater efficiency in storage or transport versus the unnecessarily verbose text representation from <xref target="RFC4122"/>.
+				Furthermore UUID can now be been extended beyond 128 bits to facilitate enhanced collision resistance or for embedding additional data within a given UUID value.
+			</t>
+		</abstract>
+	</front>
+	<middle>
+		<section anchor="Background" title="Introduction">
+			<t>
+				The original "hex and dash", 8-4-4-4-12, format of UUIDs defined by <xref target="RFC4122"/> represents a 128 bit UUID value as a 288 bit value. 
+				While this may be great for human readability; the only available UUID text representation suffers poorly for storage, transmission and application parsing.
+			</t>
+			<t>
+				Furthermore, UUIDs static length of 128 bits has lead to many alternative, non-standard, Globally Unique Identifiers which aim to pack more information into a larger bit space.
+			</t>
+		</section>
+		<section title="Terminology">
+			<section anchor="requirements_language" title="Requirements Language">
+				<t>
+					The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/> when, and only when, they appear in all capitals, as shown here.
+				</t>
+			</section>
+			<section anchor="acronyms" title="Abbreviations">
+				<t>The following abbreviations are used in this document: </t>
+				<dl newline="false" spacing="normal" indent="14" pn="section-2.2-2">
+					<dt>UUID</dt><dd>Universally Unique Identifier <xref target="RFC4122"/></dd>
+					<dt>URN</dt><dd>Uniform Resource Name <xref target="RFC8141"/></dd>
+				</dl>
+			</section>
+		</section>
+		<section anchor="changelog" title="changelog">
+			<t>RFC EDITOR PLEASE DELETE THIS SECTION.</t>
+			<t>draft-00</t>
+			<ul spacing="compact" empty="true">
+				<li><t>- Initial Release</t></li>
+			</ul>
+		</section>
+		
+		<section anchor="extended_uuid_namespace" title="Extended URN UUID Namespace">
+			<t>
+				The Existing UUID URN introduced by <xref target="RFC4122"/> will remain as urn:uuid:{uuid_value} however a new, extended URN structures will be leveraged to convey finer topics introduced by this document.
+			</t>
+			<t>
+				The UUIDs defined by this document MUST leverage the extended URN UUID namespace such that the encoding technique and length of the UUID are easily parsable using <xref target="RFC8141"/> compatible logic.
+				If an application does not care about parsing, converting, or otherwise ascertaining information from a given UUID value then that application MAY choose to simply store the actual UUID value in the desired format and omit any UUID URN information.				
+			</t>
+			<t>
+				The Extended UUID namespace syntax is composed of the following parts:
+			</t>
+			<dl newline="true">
+				<dt>urn</dt><dd>Uniform Resource Name as defined by <xref target="RFC8141"/></dd>
+				<dt>uuid</dt><dd>Universally Unique IDentifier as defined by <xref target="RFC4122"/></dd>
+				<dt>{uuid_value}</dt><dd>The actual UUID Value which may have been encoded using <xref target="uuid_encoding"/> or longer than 128 bits as per <xref target="uuid_long"/>. Any colon character (:) within this field MUST be percent-encoded as "%3A"</dd>
+				<dt>{uuid_length}</dt><dd>Variable entry which describes the total length of encoded UUID Value (uuid_value) as an integer value.</dd>
+				<dt>{uuid_encoding}</dt><dd>Variable entry which describes the encoding of the UUID Value (uuid_value). This value MAY include dashes characters thus base32 is the same as base-32.</dd>
+			</dl>
+			<t>
+				The existing UUID URN is equivalent to an Extended UUID URN via the following syntax where "base16hd" is a shorthand key for the 128 bit, base16 "Hex and Dashes" format introduced by <xref target="RFC4122"/>.
+			</t>
+			<figure>
+                    <name>Extended URN UUID Example:</name>
+                    <artwork><![CDATA[
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+                    ]]></artwork>
+			</figure>
+			<t>
+				The next section defines some other Extended UUID URN namespace usage examples for alternate encodings for the same UUID Version 4 example as Base 16 Hex and Dashes (base16hd), Base2 (Binary), and Base10 (Decimal) values.
+			</t>
+			<figure>
+                    <name>Extended URN UUID Example:</name>
+                    <artwork><![CDATA[
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101:128:base2
+urn:uuid:154072644812979270675542139334331768221:128:base10
+                    ]]></artwork>
+			</figure>
+		</section>
+		
+		<section anchor="uuid_encoding" title="Alternate Encodings">
+                <t>
+                    The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.
+                </t>
+                <t>
+                    Where required, UUIDs defined by this specification and <xref target="RFC4122"/> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. 
+					Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. 
+					When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUID values and collision resistance provided by all UUIDs.
+                </t>
+                <t>
+                    When utilizing alternate encoding techniques with other applications; 
+					the encoded UUID MUST be prefixed with extended "urn:uuid:" to signal that the value therein is that of a UUID. 
+					Additionally the UUID MUST and post-fixed with the required extended UUID URN values as defined by <xref target="extended_uuid_namespace"/> to signal the alternate encoding technique in use and the length of the underlying encoded UUID.
+                </t>
+                <t>
+                    The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.
+                </t>
+                <figure>
+                    <name>Alternate Encoding Examples</name>
+                    <artwork><![CDATA[
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT:128:base32
+urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1:128:base36
+                    ]]></artwork>
+                </figure>
+                <t>
+                    For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <xref target="RFC4648"/>.
+                </t>
+				<t>
+					Furthermore, when utilizing alternate encoding techniques along with Extended UUID URN namespaces; remember that disallowed characters MUST be percent-encoded as per <xref target="RFC8141"/>.
+				</t>
+		</section>
+		
+		<section anchor="uuid_long" title="UUID Long">
+                <t>
+                    UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:
+                </t>
+                <dl newline="true">
+                    <dt>Increased Entropy:</dt>
+                        <dd>
+							While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities or guessability.
+					    </dd>
+                    <dt>Requirements for additional embedded items:</dt>
+                        <dd>
+							Some implementations require more than 128 bits to properly embed all of the application specific data they require. 
+							Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers for distributed UUID generation.
+						</dd>
+                </dl>
+                <t>
+                    UUID Long is compatible with any UUID specified in this document and <xref target="RFC4122"/>. 
+					UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. 
+					UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex and dash format to create 8-4-4-4-12-{variable_length} text format. 
+					
+				</t>
+				<t>
+					The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.
+                </t>
+                <figure>
+                    <name>UUID Long Examples</name>
+                    <artwork><![CDATA[
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-05fa17aaac4f8954d9fac2df2fce30f6:160:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-02df3f4babc63a3b2775e27804528a6d23c679eed60fe31df3f8b014e7915595:192:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-8fe05412f24ca9974637a10c0b372a7109fb810f61068c0074b480f09f18b30fe03ae7bf09c98b241e8c9c0d51516b963ac75abe447dbff34177093b4b781a46:256:base16hd
+                    ]]></artwork>
+                </figure>
+                <t>
+                    Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.
+                </t>
+				<t>
+					UUID Long values MAY be coupled with alternate encoding techniques described in this document.
+				</t>
+                <!-- <t>
+                    When UUID Long is utilized with Nil UUID or Max UUID all bits should be set as specified. That is for Nil UUID Long all bits MUST be set to 0 while Max UUID Long all bits MUST be set to 1.
+                </t> -->
+                
+		</section>
+		
+		<section anchor="IANA" title="IANA Considerations">
+			<!--TODO Figure out how to format this section -->
+			<t>If Adopted, this document SHOULD be listed in https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml.</t>
+		</section>
+
+		<section anchor="Security" title="Security Considerations">
+			<t>This document has no security considerations.</t>
+		</section>
+
+		<section anchor="Acknowledgements" title="Acknowledgements">
+			<t>The authors gratefully acknowledge the contributions of 
+				Ben Campbell,
+				Ben Ramsey,
+				Fabio Lima,
+				Gonzalo Salgueiro, 
+				Martin Thomson,
+				Murray S. Kucherawy,
+				Rick van Rein,
+				Rob Wilton,
+				Sean Leonard,
+				Theodore Y. Ts'o.,
+				Robert Kieffer,
+				sergeyprokhorenko,
+				LiosK
+				As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.
+			</t>
+		</section>
+
+	</middle>
+
+	<back>
+		<references title="Normative References">
+			<reference anchor="RFC2119" target="https://www.rfc-editor.org/info/rfc2119" quoteTitle="true" derivedAnchor="RFC2119">
+				<front>
+					<title>Key words for use in RFCs to Indicate Requirement Levels</title>
+					<author initials="S." surname="Bradner" fullname="S. Bradner">
+						<organization showOnFrontPage="true"/>
+					</author>
+					<date year="1997" month="March"/>
+					<abstract>
+						<t indent="0">In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t>
+					</abstract>
+				</front>
+				<seriesInfo name="BCP" value="14"/>
+				<seriesInfo name="RFC" value="2119"/>
+				<seriesInfo name="DOI" value="10.17487/RFC2119"/>
+			</reference>
+			<reference anchor="RFC8174" target="https://www.rfc-editor.org/info/rfc8174" quoteTitle="true" derivedAnchor="RFC8174">
+			  <front>
+				<title>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</title>
+				<author initials="B." surname="Leiba" fullname="B. Leiba">
+				  <organization showOnFrontPage="true"/>
+				</author>
+				<date year="2017" month="May"/>
+				<abstract>
+				  <t indent="0">RFC 2119 specifies common key words that may be used in protocol  specifications.  This document aims to reduce the ambiguity by clarifying that only UPPERCASE usage of the key words have the  defined special meanings.</t>
+				</abstract>
+			  </front>
+			  <seriesInfo name="BCP" value="14"/>
+			  <seriesInfo name="RFC" value="8174"/>
+			  <seriesInfo name="DOI" value="10.17487/RFC8174"/>
+			</reference>
+			<reference anchor="RFC4122" target="https://www.rfc-editor.org/info/rfc4122">
+				<front>
+					<title>A Universally Unique IDentifier (UUID) URN Namespace</title>
+					<author initials="P." surname="Leach" fullname="P. Leach">
+						<organization/>
+					</author>
+					<author initials="M." surname="Mealling" fullname="M. Mealling">
+						<organization/>
+					</author>
+					<author initials="R." surname="Salz" fullname="R. Salz">
+						<organization/>
+					</author>
+					<date year="2005" month="July"/>
+					<abstract>
+						<t>This specification defines a Uniform Resource Name namespace for UUIDs (Universally Unique IDentifier), also known as GUIDs (Globally Unique IDentifier). A UUID is 128 bits long, and can guarantee uniqueness across space and time. UUIDs were originally used in the Apollo Network Computing System and later in the Open Software Foundation\'s (OSF) Distributed Computing Environment (DCE), and then in Microsoft Windows platforms.</t>
+						<t>This specification is derived from the DCE specification with the kind permission of the OSF (now known as The Open Group). Information from earlier versions of the DCE specification have been incorporated into this document. [STANDARDS-TRACK]</t>
+					</abstract>
+				</front>
+				<seriesInfo name="RFC" value="4122"/>
+				<seriesInfo name="DOI" value="10.17487/RFC4122"/>
+			</reference>
+			<reference anchor="RFC4648" target="https://www.rfc-editor.org/info/rfc4122">
+				<front>
+					<title>The Base16, Base32, and Base64 Data Encodings</title>
+					<author initials="S." surname="Josefsson" fullname="S. Josefsson">
+						<organization/>
+					</author>
+					<date year="2006" month="October"/>
+					<abstract>
+						<t> This document describes the commonly used base 64, base 32, and base 16 encoding schemes.  It also discusses the use of line-feeds in encoded data, use of padding in encoded data, use of non-alphabet characters in encoded data, use of different encoding alphabets, and canonical encodings.</t>
+					</abstract>
+				</front>
+				<seriesInfo name="RFC" value="4648"/>
+				<seriesInfo name="DOI" value="10.17487/RFC4648"/>
+			</reference>
+			<reference anchor="RFC8141" target="https://www.rfc-editor.org/info/rfc8141">
+				<front>
+					<title>Uniform Resource Names (URNs)</title>
+					<author initials="P." surname="Saint-Andre" fullname="P. Saint-Andre">
+						<organization/>
+					</author>
+					<author initials="J." surname="Klensin" fullname="J. Klensin">
+						<organization/>
+					</author>
+					<date year="2006" month="October"/>
+					<abstract>
+						<t>A Uniform Resource Name (URN) is a Uniform Resource Identifier (URI) that is assigned under the "urn" URI scheme and a particular URN namespace, with the intent that the URN will be a persistent, location-independent resource identifier. With regard to URN syntax, this document defines the canonical syntax for URNs (in a way that is consistent with URI syntax), specifies methods for determining URN-equivalence, and discusses URI conformance. With regard to URN namespaces, this document specifies a method for defining a URN namespace and associating it with a namespace identifier, and it describes procedures for registering namespace identifiers with the Internet Assigned Numbers Authority (IANA). This document obsoletes both RFCs 2141 and 3406.</t>
+					</abstract>
+				</front>
+				<seriesInfo name="RFC" value="8141"/>
+				<seriesInfo name="DOI" value="10.17487/RFC8141"/>
+			</reference>
+		</references>
+	</back>
+</rfc>

--- a/new-encoding-techniques/index.html
+++ b/new-encoding-techniques/index.html
@@ -1,0 +1,1621 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>New UUID Encoding Techniques</title>
+<meta content="Brad G. Peabody" name="author">
+<meta content="Kyzer R. Davis" name="author">
+<meta content="
+       
+ This document presents new Universally Unique Identifier (UUID) encoding techniques which facilitate greater efficiency in storage or transport versus the unnecessarily verbose text representation from  .
+ Furthermore UUID can now be been extended beyond 128 bits to facilitate enhanced collision resistance or for embedding additional data within a given UUID value.
+       
+    " name="description">
+<meta content="xml2rfc 3.12.2" name="generator">
+<meta content="uuid" name="keyword">
+<meta content="draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.12.2
+    Python 3.6.9
+    appdirs 1.4.4
+    ConfigArgParse 1.2.3
+    google-i18n-address 2.4.0
+    html5lib 1.1
+    intervaltree 3.1.0
+    Jinja2 2.11.2
+    kitchen 1.2.6
+    lxml 4.5.2
+    pycountry 20.7.3
+    pyflakes 2.2.0
+    PyYAML 5.3.1
+    requests 2.24.0
+    setuptools 40.6.2
+    six 1.15.0
+-->
+<link href="/tmp/QvTERtS8Xo.dir/draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necssary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+@viewport {
+  zoom: 1.0;
+  width: extend-to-zoom;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: 'Noto Sans', Arial, Helvetica, sans-serif;
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  border: none;
+  /* this isn't optimal, but it's an existence proof.  PrinceXML doesn't
+     support flexbox yet.
+  */
+  display: table;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre, code {
+  background-color: #f9f9f9;
+  font-family: 'Roboto Mono', monospace;
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    float: none;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: "Noto Sans",Arial,Helvetica,sans-serif;
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The follwing is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre, code {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+pre.sourcecode,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact informatio look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background sligthtly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottim margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the comact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div:first-child > pre.sourcecode,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body>
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">new-uuid-format</td>
+<td class="right">March 2022</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Peabody &amp; Davis</td>
+<td class="center">Expires 22 September 2022</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">dispatch</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-davis-peabody-dispatch-new-uuid-encoding-techniques-00</dd>
+<dt class="label-updates">Updates:</dt>
+<dd class="updates">
+<a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2022-03-21" class="published">21 March 2022</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2022-09-22">22 September 2022</time></dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">BGP. Peabody</div>
+</div>
+<div class="author">
+      <div class="author-name">K. Davis</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">New UUID Encoding Techniques</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">
+ This document presents new Universally Unique Identifier (UUID) encoding techniques which facilitate greater efficiency in storage or transport versus the unnecessarily verbose text representation from <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.
+ Furthermore UUID can now be been extended beyond 128 bits to facilitate enhanced collision resistance or for embedding additional data within a given UUID value.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 22 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2022 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Revised BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Revised BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-terminology" class="xref">Terminology</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
+                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="xref">2.1</a>.  <a href="#name-requirements-language" class="xref">Requirements Language</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
+                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="xref">2.2</a>.  <a href="#name-abbreviations" class="xref">Abbreviations</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-changelog" class="xref">changelog</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-extended-urn-uuid-namespace" class="xref">Extended URN UUID Namespace</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-alternate-encodings" class="xref">Alternate Encodings</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-uuid-long" class="xref">UUID Long</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-acknowledgements" class="xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#section-10" class="xref">10</a>. <a href="#name-normative-references" class="xref">Normative References</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#appendix-A" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<div id="Background">
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">
+ The original "hex and dash", 8-4-4-4-12, format of UUIDs defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> represents a 128 bit UUID value as a 288 bit value. 
+ While this may be great for human readability; the only available UUID text representation suffers poorly for storage, transmission and application parsing.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<p id="section-1-2">
+ Furthermore, UUIDs static length of 128 bits has lead to many alternative, non-standard, Globally Unique Identifiers which aim to pack more information into a larger bit space.<a href="#section-1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-2">
+      <h2 id="name-terminology">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-terminology" class="section-name selfRef">Terminology</a>
+      </h2>
+<div id="requirements_language">
+<section id="section-2.1">
+        <h3 id="name-requirements-language">
+<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-requirements-language" class="section-name selfRef">Requirements Language</a>
+        </h3>
+<p id="section-2.1-1">
+ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="xref">RFC8174</a>]</span> when, and only when, they appear in all capitals, as shown here.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="acronyms">
+<section id="section-2.2">
+        <h3 id="name-abbreviations">
+<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-abbreviations" class="section-name selfRef">Abbreviations</a>
+        </h3>
+<p id="section-2.2-1">The following abbreviations are used in this document:<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-2.2-2">
+          <dt id="section-2.2-2.1">UUID</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.2">Universally Unique Identifier <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span><a href="#section-2.2-2.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.2-2.3">URN</dt>
+          <dd style="margin-left: 7.0em" id="section-2.2-2.4">Uniform Resource Name <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span><a href="#section-2.2-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+<div id="changelog">
+<section id="section-3">
+      <h2 id="name-changelog">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-changelog" class="section-name selfRef">changelog</a>
+      </h2>
+<p id="section-3-1">RFC EDITOR PLEASE DELETE THIS SECTION.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">draft-00<a href="#section-3-2" class="pilcrow">¶</a></p>
+<ul class="compact ulEmpty">
+<li class="compact ulEmpty" id="section-3-3.1">
+          <p id="section-3-3.1.1">- Initial Release<a href="#section-3-3.1.1" class="pilcrow">¶</a></p>
+</li>
+      </ul>
+</section>
+</div>
+<div id="extended_uuid_namespace">
+<section id="section-4">
+      <h2 id="name-extended-urn-uuid-namespace">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-extended-urn-uuid-namespace" class="section-name selfRef">Extended URN UUID Namespace</a>
+      </h2>
+<p id="section-4-1">
+ The Existing UUID URN introduced by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> will remain as urn:uuid:{uuid_value} however a new, extended URN structures will be leveraged to convey finer topics introduced by this document.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-2">
+ The UUIDs defined by this document MUST leverage the extended URN UUID namespace such that the encoding technique and length of the UUID are easily parsable using <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span> compatible logic.
+ If an application does not care about parsing, converting, or otherwise ascertaining information from a given UUID value then that application MAY choose to simply store the actual UUID value in the desired format and omit any UUID URN information.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-3">
+ The Extended UUID namespace syntax is composed of the following parts:<a href="#section-4-3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-4-4">
+        <dt id="section-4-4.1">urn</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.2">Uniform Resource Name as defined by <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span><a href="#section-4-4.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.3">uuid</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.4">Universally Unique IDentifier as defined by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span><a href="#section-4-4.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.5">{uuid_value}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.6">The actual UUID Value which may have been encoded using <a href="#uuid_encoding" class="xref">Section 5</a> or longer than 128 bits as per <a href="#uuid_long" class="xref">Section 6</a>. Any colon character (:) within this field MUST be percent-encoded as "%3A"<a href="#section-4-4.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.7">{uuid_length}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.8">Variable entry which describes the total length of encoded UUID Value (uuid_value) as an integer value.<a href="#section-4-4.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-4-4.9">{uuid_encoding}</dt>
+        <dd style="margin-left: 1.5em" id="section-4-4.10">Variable entry which describes the encoding of the UUID Value (uuid_value). This value MAY include dashes characters thus base32 is the same as base-32.<a href="#section-4-4.10" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-4-5">
+ The existing UUID URN is equivalent to an Extended UUID URN via the following syntax where "base16hd" is a shorthand key for the 128 bit, base16 "Hex and Dashes" format introduced by <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>.<a href="#section-4-5" class="pilcrow">¶</a></p>
+<span id="name-extended-urn-uuid-example"></span><figure id="figure-1">
+        <div class="alignLeft art-text artwork" id="section-4-6.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+</pre>
+</div>
+<figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
+<a href="#name-extended-urn-uuid-example" class="selfRef">Extended URN UUID Example:</a>
+        </figcaption></figure>
+<p id="section-4-7">
+ The next section defines some other Extended UUID URN namespace usage examples for alternate encodings for the same UUID Version 4 example as Base 16 Hex and Dashes (base16hd), Base2 (Binary), and Base10 (Decimal) values.<a href="#section-4-7" class="pilcrow">¶</a></p>
+<span id="name-extended-urn-uuid-example-2"></span><figure id="figure-2">
+        <div class="alignLeft art-text artwork" id="section-4-8.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:1110011111010010100111111100000111010010101000101000001010100111010101011110011010100001110010011100110000010001001110110011101:128:base2
+urn:uuid:154072644812979270675542139334331768221:128:base10
+</pre>
+</div>
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
+<a href="#name-extended-urn-uuid-example-2" class="selfRef">Extended URN UUID Example:</a>
+        </figcaption></figure>
+</section>
+</div>
+<div id="uuid_encoding">
+<section id="section-5">
+      <h2 id="name-alternate-encodings">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-alternate-encodings" class="section-name selfRef">Alternate Encodings</a>
+      </h2>
+<p id="section-5-1">
+                    The existing UUID hex and dash format of 8-4-4-4-12 is retained for both backwards compatibility and human readability. This format MUST be implemented for all UUIDs.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">
+                    Where required, UUIDs defined by this specification and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span> MAY be encoded utilizing new techniques such as, but not limited to, Base32, Base36, or Base64. 
+ Applications MAY also utilize other encoding techniques such as modulo division or alternate alphabets such as Crockford's base32. 
+ When selecting an alternate encoding implementations SHOULD take into consideration items such as: uppercase/lowercase/mixed character encoding for application sortability, special character inclusions or omissions, and the exclusion of key letters like "I", "L", "O", and "U" which may impact sortability of UUID values and collision resistance provided by all UUIDs.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3">
+                    When utilizing alternate encoding techniques with other applications; 
+ the encoded UUID MUST be prefixed with extended "urn:uuid:" to signal that the value therein is that of a UUID. 
+ Additionally the UUID MUST and post-fixed with the required extended UUID URN values as defined by <a href="#extended_uuid_namespace" class="xref">Section 4</a> to signal the alternate encoding technique in use and the length of the underlying encoded UUID.<a href="#section-5-3" class="pilcrow">¶</a></p>
+<p id="section-5-4">
+                    The conversion from UUID to a new encoding technique SHOULD be done utilizing the underlying integer or binary value for a given UUID versus converting the hex representation. Two examples for UUIDv4 encoded as base-32 and base-36 are included below.<a href="#section-5-4" class="pilcrow">¶</a></p>
+<span id="name-alternate-encoding-examples"></span><figure id="figure-3">
+        <div class="alignLeft art-text artwork" id="section-5-5.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:3JT57U1QAH859QLSQGSJJ0H7CT:128:base32
+urn:uuid:6V1GDX0NNGFV95EFF5TPJ0TR1:128:base36
+</pre>
+</div>
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<a href="#name-alternate-encoding-examples" class="selfRef">Alternate Encoding Examples</a>
+        </figcaption></figure>
+<p id="section-5-6">
+                    For information on converting a UUID into Base 16, Base 32 or Base 64 refer to <span>[<a href="#RFC4648" class="xref">RFC4648</a>]</span>.<a href="#section-5-6" class="pilcrow">¶</a></p>
+<p id="section-5-7">
+ Furthermore, when utilizing alternate encoding techniques along with Extended UUID URN namespaces; remember that disallowed characters MUST be percent-encoded as per <span>[<a href="#RFC8141" class="xref">RFC8141</a>]</span>.<a href="#section-5-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="uuid_long">
+<section id="section-6">
+      <h2 id="name-uuid-long">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-uuid-long" class="section-name selfRef">UUID Long</a>
+      </h2>
+<p id="section-6-1">
+                    UUID Long generally references any variable length UUID longer than 128 bits. There are two main driving factors behind extending UUID beyond 128 bits:<a href="#section-6-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlNewline" id="section-6-2">
+        <dt id="section-6-2.1">Increased Entropy:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.2">
+ While existing UUID formats provide sufficient entropy for most use cases; there exists scenarios where even more entropy is required to further reduce collision probabilities or guessability.<a href="#section-6-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="section-6-2.3">Requirements for additional embedded items:</dt>
+        <dd style="margin-left: 1.5em" id="section-6-2.4">
+ Some implementations require more than 128 bits to properly embed all of the application specific data they require. 
+ Some examples include database metadata like entity types, checksum values, shard/partition identifiers, and even node identifiers for distributed UUID generation.<a href="#section-6-2.4" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<p id="section-6-3">
+                    UUID Long is compatible with any UUID specified in this document and <span>[<a href="#RFC4122" class="xref">RFC4122</a>]</span>. 
+ UUID long is variable in length and there is no minimum or maximum value for UUID Long; however, UUID Long SHOULD leverage natural byte boundaries. 
+ UUID long is defined by appending an additional dash to the existing 8-4-4-4-12 hex and dash format to create 8-4-4-4-12-{variable_length} text format.<a href="#section-6-3" class="pilcrow">¶</a></p>
+<p id="section-6-4">
+ The next example shows a UUID Long +32, +64 and +128 example for UUIDv4 with random data filling the values beyond 128 bits.<a href="#section-6-4" class="pilcrow">¶</a></p>
+<span id="name-uuid-long-examples"></span><figure id="figure-4">
+        <div class="alignLeft art-text artwork" id="section-6-5.1">
+<pre>
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d:128:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-05fa17aaac4f8954d9fac2df2fce30f6:160:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-02df3f4babc63a3b2775e27804528a6d23c679eed60fe31df3f8b014e7915595:192:base16hd
+urn:uuid:73e94fe0-e951-4153-aaf3-50e4e6089d9d-8fe05412f24ca9974637a10c0b372a7109fb810f61068c0074b480f09f18b30fe03ae7bf09c98b241e8c9c0d51516b963ac75abe447dbff34177093b4b781a46:256:base16hd
+</pre>
+</div>
+<figcaption><a href="#figure-4" class="selfRef">Figure 4</a>:
+<a href="#name-uuid-long-examples" class="selfRef">UUID Long Examples</a>
+        </figcaption></figure>
+<p id="section-6-6">
+                    Where required, for compatibility with legacy UUID implementations, the most significant, left-most, 128 bits MUST be leveraged to truncate from UUID Long back to a regular UUID.<a href="#section-6-6" class="pilcrow">¶</a></p>
+<p id="section-6-7">
+ UUID Long values MAY be coupled with alternate encoding techniques described in this document.<a href="#section-6-7" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="IANA">
+<section id="section-7">
+      <h2 id="name-iana-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<p id="section-7-1">If Adopted, this document SHOULD be listed in https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml.<a href="#section-7-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Security">
+<section id="section-8">
+      <h2 id="name-security-considerations">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-8-1">This document has no security considerations.<a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Acknowledgements">
+<section id="section-9">
+      <h2 id="name-acknowledgements">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="section-9-1">The authors gratefully acknowledge the contributions of 
+ Ben Campbell,
+ Ben Ramsey,
+ Fabio Lima,
+ Gonzalo Salgueiro, 
+ Martin Thomson,
+ Murray S. Kucherawy,
+ Rick van Rein,
+ Rob Wilton,
+ Sean Leonard,
+ Theodore Y. Ts'o.,
+ Robert Kieffer,
+ sergeyprokhorenko,
+ LiosK
+ As well as all of those in the IETF community and on GitHub to who contributed to the discussions which resulted in this document.<a href="#section-9-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-10">
+      <h2 id="name-normative-references">
+<a href="#section-10" class="section-number selfRef">10. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+      </h2>
+<dl class="references">
+<dt id="RFC2119">[RFC2119]</dt>
+      <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+      <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4122">[RFC4122]</dt>
+      <dd>
+<span class="refAuthor">Leach, P.</span>, <span class="refAuthor">Mealling, M.</span>, and <span class="refAuthor">R. Salz</span>, <span class="refTitle">"A Universally Unique IDentifier (UUID) URN Namespace"</span>, <span class="seriesInfo">RFC 4122</span>, <span class="seriesInfo">DOI 10.17487/RFC4122</span>, <time datetime="2005-07" class="refDate">July 2005</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC4648">[RFC4648]</dt>
+      <dd>
+<span class="refAuthor">Josefsson, S.</span>, <span class="refTitle">"The Base16, Base32, and Base64 Data Encodings"</span>, <span class="seriesInfo">RFC 4648</span>, <span class="seriesInfo">DOI 10.17487/RFC4648</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc4122">https://www.rfc-editor.org/info/rfc4122</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8141">[RFC8141]</dt>
+    <dd>
+<span class="refAuthor">Saint-Andre, P.</span> and <span class="refAuthor">J. Klensin</span>, <span class="refTitle">"Uniform Resource Names (URNs)"</span>, <span class="seriesInfo">RFC 8141</span>, <span class="seriesInfo">DOI 10.17487/RFC8141</span>, <time datetime="2006-10" class="refDate">October 2006</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8141">https://www.rfc-editor.org/info/rfc8141</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<div id="authors-addresses">
+<section id="appendix-A">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Brad G. Peabody</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:brad@peabody.io" class="email">brad@peabody.io</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Kyzer R. Davis</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:kydavis@cisco.com" class="email">kydavis@cisco.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
- Pruned bad reference closing #87 
- Small tweak to verbiage closing #88 
- Slight change to sentence to resolve #89 
- Split up Rollover Handling and Rollover Guarding for #60 
- Some changes to left-most verbiage for consistency.
- Some changes to ## bit verbiage for consistency as per Draft 02 decision.

--- 

Did some work on `Alternate Encoding Technique Draft 00`, included within new folder which *should* be sharable via the GitHub Pages.