### PR TITLE
Draft 03 Final

### DIFF
--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/dbxn2Na0KX.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/Wvvk2ad6ew.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 30 September 2022</td>
+<td class="center">Expires 1 October 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-29" class="published">29 March 2022</time>
+<time datetime="2022-03-30" class="published">30 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-30">30 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-10-01">1 October 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 30 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 1 October 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -2074,7 +2074,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
 <p id="section-6.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+ For batch UUID creation implementions MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
 <p id="section-6.2-3">
  For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a><a href="#section-6.2-3" class="pilcrow">¶</a></p>
 <p id="section-6.2-4">
@@ -2206,7 +2206,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
 <p id="section-6.4-1">
- Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as<a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. 
+ Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as <a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. 
  This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a>.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
 <p id="section-6.4-2">
  There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-6.4-2" class="pilcrow">¶</a></p>
@@ -2256,7 +2256,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  UUIDv6 and UUIDv7 are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without need for parsing or introspection.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
 <p id="section-6.7-2">
  Time ordered monotonic UUIDs benefit from greater database index locality because the new values are near each other in the index. 
- As a result objects are more easily be clustered together for better performance.  
+ As a result objects are more easily clustered together for better performance.  
  The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-6.7-2" class="pilcrow">¶</a></p>
 <p id="section-6.7-3">
  UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-6.7-3" class="pilcrow">¶</a></p>
@@ -2316,7 +2316,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
       </h2>
 <p id="section-8-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
- Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
+ Instead CSPRNG data SHOULD be selected from a source with sufficient entropy to ensure guaranteed
  uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 6.6</a> for more information.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <p id="section-8-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 

--- a/draft-peabody-dispatch-new-uuid-format-03.html
+++ b/draft-peabody-dispatch-new-uuid-format-03.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/7Op3f5iYmO.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/dbxn2Na0KX.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 29 September 2022</td>
+<td class="center">Expires 30 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-28" class="published">28 March 2022</time>
+<time datetime="2022-03-29" class="published">29 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-29">29 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-30">30 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 29 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 30 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1860,38 +1860,7 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
  With UUIDv6 the steps for splitting the timestamp into time_high and time_mid are OPTIONAL
  since the 48 bits of time_high and time_mid will remain in the same order.
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
- 32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
- In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
-<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-2">
-          <caption>
-<a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-uuidv1-to-uuidv6-field-mapp" class="selfRef">UUIDv1 to UUIDv6 Field Mappings</a>
-          </caption>
-<thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">UUIDv1 Field</td>
-              <td class="text-left" rowspan="1" colspan="1">Bits</td>
-              <td class="text-left" rowspan="1" colspan="1">UUIDv6 Field</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_low </td>
-              <td class="text-left" rowspan="1" colspan="1">32</td>
-              <td class="text-left" rowspan="1" colspan="1">time_high</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_mid </td>
-              <td class="text-left" rowspan="1" colspan="1">16</td>
-              <td class="text-left" rowspan="1" colspan="1">time_mid</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_high</td>
-              <td class="text-left" rowspan="1" colspan="1">12</td>
-              <td class="text-left" rowspan="1" colspan="1">time_low</td>
-            </tr>
-          </tbody>
-        </table>
+ 32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="v7">
@@ -1900,7 +1869,8 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 <a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-uuid-version-7" class="section-name selfRef">UUID Version 7</a>
         </h3>
 <p id="section-5.2-1">
- UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+ UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, the number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
+ As well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <p id="section-5.2-2">
  Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
 <span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-3">
@@ -2055,7 +2025,9 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="section-6.1-2">
           <dt id="section-6.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-6.1-2.2" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. 
+ Care SHOULD be taken to ensure that timestamp changes from the environment or operating system are handled in a way that is consistent with implementation requirements.  
+ For example, if it is possible for the system clock to move backward due to either manual adjustment or corrections from a time synchronization protocol, implementations must decide how to handle such cases. (See Altering, Fuzzing, or Smearing bullet below.)<a href="#section-6.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.3">Source:</dt>
@@ -2063,7 +2035,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. For other levels of precision UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.6">
+ Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond.
+ Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. 
+ Furthermore, system clocks themselves have an underlying granularity and it is frequently less than the precision offered by the operating system. 
+ With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch that does not exceed the granularity capable in most modern systems.
+ For other levels of precision UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.7">Length:</dt>
@@ -2183,7 +2160,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
             <p id="section-6.2-13.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-13.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-6.2-13.2">
-            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
+            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment the counter according to the desired method and type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-6.2-13.3">
             <p id="section-6.2-13.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-13.3.1" class="pilcrow">¶</a></p>
@@ -2204,7 +2181,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
  This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="section-6.3-2">
-          <dt id="section-6.3-2.1">Shared Knowledge System:</dt>
+          <dt id="section-6.3-2.1">Centralized Registry:</dt>
           <dd style="margin-left: 1.5em" id="section-6.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-6.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
@@ -2220,7 +2197,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
         <dd class="break"></dd>
 </dl>
 <p id="section-6.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
+ Utilization of either a Centralized Registry or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
@@ -2526,7 +2503,48 @@ void uuidv1tov6(uuid_t u) {
 <span id="name-uuidv7-function-in-c"></span><figure id="figure-7">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
-TODO UUIDv7
+#include &lt;stdio.h&gt;
+#include &lt;stdlib.h&gt;
+#include &lt;stdint.h&gt;
+#include &lt;string.h&gt;
+#include &lt;time.h&gt;
+
+// ...
+
+// csprng data source
+FILE *rndf;
+rndf = fopen("/dev/urandom", "r");
+if (rndf == 0) {
+    printf("fopen /dev/urandom error\n");
+    return 1;
+}
+
+// ...
+
+// generate one UUIDv7E
+uint8_t u[16];
+struct timespec ts;
+int ret;
+
+ret = clock_gettime(CLOCK_REALTIME, &amp;ts);
+if (ret != 0) {
+    printf("clock_gettime error: %d\n", ret);
+    return 1;
+}
+
+uint64_t tms;
+
+tms = ((uint64_t)ts.tv_sec) * 1000;
+tms += ((uint64_t)ts.tv_nsec) / 1000000;
+
+memset(u, 0, 16);
+
+fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
+
+*((uint64_t*)(u)) |= htonll(tms &lt;&lt; 16); // shift time into first 48 bits and OR into place
+
+u[8] = 0x80 | (u[8] &amp; 0x3F); // set variant field, top two bits are 1, 0
+u[6] = 0x70 | (u[6] &amp; 0x0F); // set version field, top four bits are 0, 1, 1, 1
 </pre>
 </div>
 <figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
@@ -2726,9 +2744,9 @@ final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
         <h3 id="name-variant-10xx-versions">
 <a href="#appendix-C.1" class="section-number selfRef">C.1. </a><a href="#name-variant-10xx-versions" class="section-name selfRef">Variant 10xx Versions</a>
         </h3>
-<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-3">
+<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
           <caption>
-<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-all-uuid-variant-10xx-8-9-a" class="selfRef">All UUID variant 10xx (8/9/A/B) version definitions.</a>
           </caption>
 <thead>

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                           29 March 2022
-Expires: 30 September 2022
+Intended status: Standards Track                           30 March 2022
+Expires: 1 October 2022
 
 
                             New UUID Formats
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 30 September 2022.
+   This Internet-Draft will expire on 1 October 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 1]
+Peabody & Davis          Expires 1 October 2022                 [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 2]
+Peabody & Davis          Expires 1 October 2022                 [Page 2]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -165,7 +165,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 3]
+Peabody & Davis          Expires 1 October 2022                 [Page 3]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -221,7 +221,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 4]
+Peabody & Davis          Expires 1 October 2022                 [Page 4]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -277,7 +277,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 5]
+Peabody & Davis          Expires 1 October 2022                 [Page 5]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -333,7 +333,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 6]
+Peabody & Davis          Expires 1 October 2022                 [Page 6]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -389,7 +389,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 7]
+Peabody & Davis          Expires 1 October 2022                 [Page 7]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -445,7 +445,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 8]
+Peabody & Davis          Expires 1 October 2022                 [Page 8]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -501,7 +501,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022               [Page 9]
+Peabody & Davis          Expires 1 October 2022                 [Page 9]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -557,7 +557,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 10]
+Peabody & Davis          Expires 1 October 2022                [Page 10]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -613,7 +613,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 11]
+Peabody & Davis          Expires 1 October 2022                [Page 11]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -669,7 +669,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 12]
+Peabody & Davis          Expires 1 October 2022                [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -713,8 +713,8 @@ Internet-Draft               new-uuid-format                  March 2022
    are also monotonic.  That is, if one-thousand UUIDs are generated for
    the same timestamp; there is sufficient logic for organizing the
    creation order of those one-thousand UUIDs.  For batch UUID creation
-   implements MAY utilize a monotonic counter which SHOULD increment for
-   each UUID created during a given timestamp.
+   implementions MAY utilize a monotonic counter which SHOULD increment
+   for each UUID created during a given timestamp.
 
    For single-node UUID implementations that do not need to create
    batches of UUIDs, the embedded timestamp within UUID version 1, 6,
@@ -725,7 +725,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 13]
+Peabody & Davis          Expires 1 October 2022                [Page 13]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -781,7 +781,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 14]
+Peabody & Davis          Expires 1 October 2022                [Page 14]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -837,7 +837,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 15]
+Peabody & Davis          Expires 1 October 2022                [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -893,7 +893,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 16]
+Peabody & Davis          Expires 1 October 2022                [Page 16]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -919,7 +919,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
    Implementations SHOULD weigh the consequences of UUID collisions
    within their application and when deciding between UUID versions that
-   use entropy (random) versus the other components such asSection 6.1
+   use entropy (random) versus the other components such as Section 6.1
    and Section 6.2.  This is especially true for distributed node
    collision resistance as defined by Section 6.3.
 
@@ -949,7 +949,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 17]
+Peabody & Davis          Expires 1 October 2022                [Page 17]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -988,7 +988,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
    Time ordered monotonic UUIDs benefit from greater database index
    locality because the new values are near each other in the index.  As
-   a result objects are more easily be clustered together for better
+   a result objects are more easily clustered together for better
    performance.  The real-world differences in this approach of index
    locality vs random data inserts can be quite large.
 
@@ -1005,7 +1005,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 18]
+Peabody & Davis          Expires 1 October 2022                [Page 18]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1051,7 +1051,7 @@ Internet-Draft               new-uuid-format                  March 2022
 8.  Security Considerations
 
    MAC addresses pose inherent security risks and SHOULD not be used
-   within a UUID.  Instead CSPRNG data SHOULD selected from a source
+   within a UUID.  Instead CSPRNG data SHOULD be selected from a source
    with sufficient entropy to ensure guaranteed uniqueness among UUID
    generation.  See Section 6.6 for more information.
 
@@ -1061,7 +1061,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 19]
+Peabody & Davis          Expires 1 October 2022                [Page 19]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1117,7 +1117,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 20]
+Peabody & Davis          Expires 1 October 2022                [Page 20]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1173,7 +1173,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 21]
+Peabody & Davis          Expires 1 October 2022                [Page 21]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1229,7 +1229,7 @@ A.1.  Creating a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 22]
+Peabody & Davis          Expires 1 October 2022                [Page 22]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1285,7 +1285,7 @@ u[6] = 0x70 | (u[6] & 0x0F); // set version field, top four bits are 0, 1, 1, 1
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 23]
+Peabody & Davis          Expires 1 October 2022                [Page 23]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1341,7 +1341,7 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 24]
+Peabody & Davis          Expires 1 October 2022                [Page 24]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1397,7 +1397,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 25]
+Peabody & Davis          Expires 1 October 2022                [Page 25]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1453,7 +1453,7 @@ B.3.  Example of a UUIDv8 Value
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 26]
+Peabody & Davis          Expires 1 October 2022                [Page 26]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1509,7 +1509,7 @@ C.1.  Variant 10xx Versions
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 27]
+Peabody & Davis          Expires 1 October 2022                [Page 27]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1565,7 +1565,7 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 28]
+Peabody & Davis          Expires 1 October 2022                [Page 28]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1621,4 +1621,4 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 30 September 2022              [Page 29]
+Peabody & Davis          Expires 1 October 2022                [Page 29]

--- a/draft-peabody-dispatch-new-uuid-format-03.txt
+++ b/draft-peabody-dispatch-new-uuid-format-03.txt
@@ -5,8 +5,8 @@
 dispatch                                                    BGP. Peabody
 Internet-Draft                                                          
 Updates: 4122 (if approved)                                     K. Davis
-Intended status: Standards Track                           28 March 2022
-Expires: 29 September 2022
+Intended status: Standards Track                           29 March 2022
+Expires: 30 September 2022
 
 
                             New UUID Formats
@@ -32,7 +32,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 29 September 2022.
+   This Internet-Draft will expire on 30 September 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 1]
+Peabody & Davis         Expires 30 September 2022               [Page 1]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -69,9 +69,9 @@ Table of Contents
    4.  Variant and Version Fields  . . . . . . . . . . . . . . . . .   7
    5.  New Formats . . . . . . . . . . . . . . . . . . . . . . . . .   8
      5.1.  UUID Version 6  . . . . . . . . . . . . . . . . . . . . .   8
-     5.2.  UUID Version 7  . . . . . . . . . . . . . . . . . . . . .  10
+     5.2.  UUID Version 7  . . . . . . . . . . . . . . . . . . . . .   9
      5.3.  UUID Version 8  . . . . . . . . . . . . . . . . . . . . .  10
-     5.4.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     5.4.  Max UUID  . . . . . . . . . . . . . . . . . . . . . . . .  11
    6.  UUID Best Practices . . . . . . . . . . . . . . . . . . . . .  12
      6.1.  Timestamp Granularity . . . . . . . . . . . . . . . . . .  12
      6.2.  Monotonicity and Counters . . . . . . . . . . . . . . . .  13
@@ -90,14 +90,14 @@ Table of Contents
    Appendix A.  Example Code . . . . . . . . . . . . . . . . . . . .  22
      A.1.  Creating a UUIDv6 Value . . . . . . . . . . . . . . . . .  22
      A.2.  Creating a UUIDv7 Value . . . . . . . . . . . . . . . . .  23
-     A.3.  Creating a UUIDv8 Value . . . . . . . . . . . . . . . . .  23
-   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  23
-     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  24
-     B.2.  Example of a UUIDv7 Value . . . . . . . . . . . . . . . .  25
-     B.3.  Example of a UUIDv8 Value . . . . . . . . . . . . . . . .  25
-   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  26
-     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  26
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  27
+     A.3.  Creating a UUIDv8 Value . . . . . . . . . . . . . . . . .  24
+   Appendix B.  Test Vectors . . . . . . . . . . . . . . . . . . . .  24
+     B.1.  Example of a UUIDv6 Value . . . . . . . . . . . . . . . .  25
+     B.2.  Example of a UUIDv7 Value . . . . . . . . . . . . . . . .  26
+     B.3.  Example of a UUIDv8 Value . . . . . . . . . . . . . . . .  26
+   Appendix C.  Version and Variant Tables . . . . . . . . . . . . .  27
+     C.1.  Variant 10xx Versions . . . . . . . . . . . . . . . . . .  27
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  28
 
 
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 2]
+Peabody & Davis         Expires 30 September 2022               [Page 2]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -165,7 +165,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 3]
+Peabody & Davis         Expires 30 September 2022               [Page 3]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -221,7 +221,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 4]
+Peabody & Davis         Expires 30 September 2022               [Page 4]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -277,7 +277,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 5]
+Peabody & Davis         Expires 30 September 2022               [Page 5]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -333,7 +333,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 6]
+Peabody & Davis         Expires 30 September 2022               [Page 6]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -389,7 +389,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 7]
+Peabody & Davis         Expires 30 September 2022               [Page 7]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -445,7 +445,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022               [Page 8]
+Peabody & Davis         Expires 30 September 2022               [Page 8]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -478,42 +478,33 @@ Internet-Draft               new-uuid-format                  March 2022
    will remain in the same order.  An extra step of splitting the first
    48 bits of the timestamp into the most significant 32 bits and least
    significant 16 bits proves useful when reusing an existing UUIDv1
-   implementation.  In which the following logic can be applied to
-   reshuffle the bits with minimal modifications.
-
-                  +--------------+------+--------------+
-                  | UUIDv1 Field | Bits | UUIDv6 Field |
-                  +--------------+------+--------------+
-                  | time_low     | 32   | time_high    |
-                  +--------------+------+--------------+
-                  | time_mid     | 16   | time_mid     |
-                  +--------------+------+--------------+
-                  | time_high    | 12   | time_low     |
-                  +--------------+------+--------------+
-
-                     Table 2: UUIDv1 to UUIDv6 Field
-                                 Mappings
-
-
-
-
-
-
-
-
-Peabody & Davis         Expires 29 September 2022               [Page 9]
-
-Internet-Draft               new-uuid-format                  March 2022
-
+   implementation.
 
 5.2.  UUID Version 7
 
    UUID version 7 features a time-ordered value field derived from the
-   widely implemented and well known Unix Epoch timestamp source, as
-   well as improved entropy characteristics over versions 1 or 6.
+   widely implemented and well known Unix Epoch timestamp source, the
+   number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap
+   seconds excluded.  As well as improved entropy characteristics over
+   versions 1 or 6.
 
    Implementations SHOULD utilize UUID version 7 over UUID version 1 and
    6 if possible.
+
+
+
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 30 September 2022               [Page 9]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -554,14 +545,6 @@ Internet-Draft               new-uuid-format                  March 2022
    and version bits MUST be set as defined in Section 4.  UUIDv8's
    uniqueness will be implementation-specific and SHOULD NOT be assumed.
 
-
-
-
-Peabody & Davis         Expires 29 September 2022              [Page 10]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
    The only explicitly defined bits are the Version and Variant leaving
    120 bits for implementation specific time-based UUIDs.  To be clear:
    UUIDv8 is not a replacement for UUIDv4 where all 122 extra bits are
@@ -571,6 +554,13 @@ Internet-Draft               new-uuid-format                  March 2022
 
    *  An implementation would like to embed extra information within the
       UUID other than what is defined in this document.
+
+
+
+Peabody & Davis         Expires 30 September 2022              [Page 10]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
    *  An implementation has other application/language restrictions
       which inhibit the use of one of the current UUIDs.
@@ -607,17 +597,6 @@ Internet-Draft               new-uuid-format                  March 2022
       The final 62 bits of the layout immediatly following the var field
       to be filled as an implementation sees fit.
 
-
-
-
-
-
-
-Peabody & Davis         Expires 29 September 2022              [Page 11]
-
-Internet-Draft               new-uuid-format                  March 2022
-
-
 5.4.  Max UUID
 
    The Max UUID is special form of UUID that is specified to have all
@@ -627,6 +606,17 @@ Internet-Draft               new-uuid-format                  March 2022
    FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 
                          Figure 5: Max UUID Format
+
+
+
+
+
+
+
+Peabody & Davis         Expires 30 September 2022              [Page 11]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
 6.  UUID Best Practices
 
@@ -647,8 +637,13 @@ Internet-Draft               new-uuid-format                  March 2022
    Reliability:
       Implementations SHOULD use the current timestamp from a reliable
       source to provide values that are time-ordered and continually
-      increasing.  Care SHOULD be taken to ensure the timestamp does not
-      move backwards which will impact UUID sorting.
+      increasing.  Care SHOULD be taken to ensure that timestamp changes
+      from the environment or operating system are handled in a way that
+      is consistent with implementation requirements.  For example, if
+      it is possible for the system clock to move backward due to either
+      manual adjustment or corrections from a time synchronization
+      protocol, implementations must decide how to handle such cases.
+      (See Altering, Fuzzing, or Smearing bullet below.)
 
    Source:
       UUID version 1 and 6 both utilize a Gregorian epoch timestamp
@@ -660,16 +655,21 @@ Internet-Draft               new-uuid-format                  March 2022
       Many levels of precision exist for timestamps: milliseconds,
       microseconds, nanoseconds, and beyond.  Additionally fractional
       representations of sub-second precision may be desired to mix
-      various levels of precision in a time-ordered manner.  With UUID
-      version 1 and 6, 100-nanoseconds of precision are present while
-      UUIDv7 features fixed millisecond level of precision within the
-      Unix epoch.  For other levels of precision UUIDv8 SHOULD be
-      utilized.
+      various levels of precision in a time-ordered manner.
+      Furthermore, system clocks themselves have an underlying
+      granularity and it is frequently less than the precision offered
+      by the operating system.  With UUID version 1 and 6,
+      100-nanoseconds of precision are present while UUIDv7 features
+      fixed millisecond level of precision within the Unix epoch that
+      does not exceed the granularity capable in most modern systems.
+      For other levels of precision UUIDv8 SHOULD be utilized.
 
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 12]
+
+
+Peabody & Davis         Expires 30 September 2022              [Page 12]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -725,7 +725,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 13]
+Peabody & Davis         Expires 30 September 2022              [Page 13]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -781,7 +781,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 14]
+Peabody & Davis         Expires 30 September 2022              [Page 14]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -837,7 +837,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 15]
+Peabody & Davis         Expires 30 September 2022              [Page 15]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -855,7 +855,7 @@ Internet-Draft               new-uuid-format                  March 2022
    1.  Compare the current timestamp against the previously stored
        timestamp.
    2.  If the current timestamp is equal to the previous timestamp;
-       increment desired counter method and increment type.
+       increment the counter according to the desired method and type.
    3.  If the current timestamp is greater than the previous timestamp;
        re-initialize the desired counter method to the new timestamp and
        generate new random bytes (if the bytes were frozen or being used
@@ -880,7 +880,7 @@ Internet-Draft               new-uuid-format                  March 2022
    utilized by multi-node UUID implementations in distributed
    environments.
 
-   Shared Knowledge System:
+   Centralized Registry:
       With this method all nodes tasked with creating UUIDs consult a
       central registry and confirm the generated value is unique.  As
       applications scale the communication with the central registry
@@ -893,7 +893,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 16]
+Peabody & Davis         Expires 30 September 2022              [Page 16]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -910,7 +910,7 @@ Internet-Draft               new-uuid-format                  March 2022
       Furthermore, the creation and negotiation of unique node ids among
       nodes is also out of scope for this specification.
 
-   Utilization of either a shared knowledge scheme or Node ID are not
+   Utilization of either a Centralized Registry or Node ID are not
    required for implementing UUIDs in this specification.  However
    implementations SHOULD utilize one of the two aforementioned methods
    if distributed UUID generation is a requirement.
@@ -949,7 +949,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 17]
+Peabody & Davis         Expires 30 September 2022              [Page 17]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1005,7 +1005,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 18]
+Peabody & Davis         Expires 30 September 2022              [Page 18]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1061,7 +1061,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 19]
+Peabody & Davis         Expires 30 September 2022              [Page 19]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1117,7 +1117,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 20]
+Peabody & Davis         Expires 30 September 2022              [Page 20]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1173,7 +1173,7 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 21]
+Peabody & Davis         Expires 30 September 2022              [Page 21]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1229,7 +1229,7 @@ A.1.  Creating a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 22]
+Peabody & Davis         Expires 30 September 2022              [Page 22]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1238,9 +1238,57 @@ Internet-Draft               new-uuid-format                  March 2022
 
 A.2.  Creating a UUIDv7 Value
 
-   TODO UUIDv7
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
 
-                       Figure 7: UUIDv7 Function in C
+// ...
+
+// csprng data source
+FILE *rndf;
+rndf = fopen("/dev/urandom", "r");
+if (rndf == 0) {
+    printf("fopen /dev/urandom error\n");
+    return 1;
+}
+
+// ...
+
+// generate one UUIDv7E
+uint8_t u[16];
+struct timespec ts;
+int ret;
+
+ret = clock_gettime(CLOCK_REALTIME, &ts);
+if (ret != 0) {
+    printf("clock_gettime error: %d\n", ret);
+    return 1;
+}
+
+uint64_t tms;
+
+tms = ((uint64_t)ts.tv_sec) * 1000;
+tms += ((uint64_t)ts.tv_nsec) / 1000000;
+
+memset(u, 0, 16);
+
+fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
+
+*((uint64_t*)(u)) |= htonll(tms << 16); // shift time into first 48 bits and OR into place
+
+u[8] = 0x80 | (u[8] & 0x3F); // set variant field, top two bits are 1, 0
+u[6] = 0x70 | (u[6] & 0x0F); // set version field, top four bits are 0, 1, 1, 1
+
+                    Figure 7: UUIDv7 Function in C
+
+
+
+Peabody & Davis         Expires 30 September 2022              [Page 23]
+
+Internet-Draft               new-uuid-format                  March 2022
+
 
 A.3.  Creating a UUIDv8 Value
 
@@ -1285,7 +1333,15 @@ Appendix B.  Test Vectors
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 23]
+
+
+
+
+
+
+
+
+Peabody & Davis         Expires 30 September 2022              [Page 24]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1341,7 +1397,7 @@ B.1.  Example of a UUIDv6 Value
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 24]
+Peabody & Davis         Expires 30 September 2022              [Page 25]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1397,7 +1453,7 @@ B.3.  Example of a UUIDv8 Value
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 25]
+Peabody & Davis         Expires 30 September 2022              [Page 26]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1453,7 +1509,7 @@ C.1.  Variant 10xx Versions
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 26]
+Peabody & Davis         Expires 30 September 2022              [Page 27]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1501,7 +1557,7 @@ Internet-Draft               new-uuid-format                  March 2022
    |      |      |      |      |         | definition.                |
    +------+------+------+------+---------+----------------------------+
 
-      Table 3: All UUID variant 10xx (8/9/A/B) version definitions.
+      Table 2: All UUID variant 10xx (8/9/A/B) version definitions.
 
 Authors' Addresses
 
@@ -1509,7 +1565,7 @@ Authors' Addresses
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 27]
+Peabody & Davis         Expires 30 September 2022              [Page 28]
 
 Internet-Draft               new-uuid-format                  March 2022
 
@@ -1565,4 +1621,4 @@ Internet-Draft               new-uuid-format                  March 2022
 
 
 
-Peabody & Davis         Expires 29 September 2022              [Page 28]
+Peabody & Davis         Expires 30 September 2022              [Page 29]

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -300,24 +300,13 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 				since the 48 bits of time_high and time_mid will remain in the same order.
 				An extra step of splitting the first 48 bits of the timestamp into the most significant 
 				32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
-				In which the following logic can be applied to reshuffle the bits with minimal modifications.
 				</t>
-				<table>
-				<name>UUIDv1 to UUIDv6 Field Mappings</name>
-				<thead>
-					<tr><td>UUIDv1 Field</td><td>Bits</td><td>UUIDv6 Field</td></tr>
-				</thead>
-				<tbody>
-					<tr><td>time_low </td><td>32</td><td>time_high</td></tr>
-					<tr><td>time_mid </td><td>16</td><td>time_mid</td></tr>
-					<tr><td>time_high</td><td>12</td><td>time_low</td></tr>
-				</tbody>
-				</table>
 				
 			</section>
 			<section anchor="v7" title="UUID Version 7">
 				<t>
-					UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.
+					UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, the number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
+					As well as improved entropy characteristics over versions 1 or 6.
 				</t>
 				<t>
 					Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible. 
@@ -422,11 +411,20 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</t>
 				<dl newline="true">
 					<dt>Reliability:</dt>
-						<dd>Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.</dd>
+						<dd>Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. 
+							Care SHOULD be taken to ensure that timestamp changes from the environment or operating system are handled in a way that is consistent with implementation requirements.  
+							For example, if it is possible for the system clock to move backward due to either manual adjustment or corrections from a time synchronization protocol, implementations must decide how to handle such cases. (See Altering, Fuzzing, or Smearing bullet below.)
+						</dd>
 					<dt>Source:</dt>
 						<dd>UUID version 1 and 6 both utilize a Gregorian epoch timestamp while UUIDv7 utilizes a Unix Epoch timestamp. If other timestamp sources or a custom timestamp epoch are required UUIDv8 SHOULD be leveraged.</dd>
 					<dt>Sub-second Precision and Accuracy:</dt>
-						<dd>Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. For other levels of precision UUIDv8 SHOULD be utilized.</dd>
+						<dd>
+							Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond.
+							Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. 
+							Furthermore, system clocks themselves have an underlying granularity and it is frequently less than the precision offered by the operating system. 
+							With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch that does not exceed the granularity capable in most modern systems.
+							For other levels of precision UUIDv8 SHOULD be utilized.
+						</dd>
 					<dt>Length:</dt>
 						<dd>The length of a given timestamp directly impacts how long a given UUID will be valid. 
 						That is, how many timestamp ticks can be contained in a UUID before the maximum value for the timestamp field is reached. 
@@ -529,7 +527,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				<ol spacing="compact">
 					<li><t>Compare the current timestamp against the previously stored timestamp.</t></li>
 					<li>
-						<t>If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.</t>
+						<t>If the current timestamp is equal to the previous timestamp; increment the counter according to the desired method and type.</t>
 					</li>
 					<li><t>If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).</t></li>
 				</ol>
@@ -545,7 +543,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.
 				</t>
 				<dl newline="true">
-					<dt>Shared Knowledge System:</dt> 
+					<dt>Centralized Registry:</dt> 
 						<dd>With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.</dd>
 					<dt>Node IDs:</dt> 
 						<dd>
@@ -558,7 +556,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 						</dd>
 				</dl>
 				<t>
-					Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.
+					Utilization of either a Centralized Registry or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.
 				</t>
 			</section>
 			<section anchor="collision_resistance" title="Collision Resistance">
@@ -961,7 +959,48 @@ void uuidv1tov6(uuid_t u) {
 				<figure>
 					<name>UUIDv7 Function in C</name>
 					<artwork><![CDATA[
-TODO UUIDv7
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+// ...
+
+// csprng data source
+FILE *rndf;
+rndf = fopen("/dev/urandom", "r");
+if (rndf == 0) {
+    printf("fopen /dev/urandom error\n");
+    return 1;
+}
+
+// ...
+
+// generate one UUIDv7E
+uint8_t u[16];
+struct timespec ts;
+int ret;
+
+ret = clock_gettime(CLOCK_REALTIME, &ts);
+if (ret != 0) {
+    printf("clock_gettime error: %d\n", ret);
+    return 1;
+}
+
+uint64_t tms;
+
+tms = ((uint64_t)ts.tv_sec) * 1000;
+tms += ((uint64_t)ts.tv_nsec) / 1000000;
+
+memset(u, 0, 16);
+
+fread(&u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
+
+*((uint64_t*)(u)) |= htonll(tms << 16); // shift time into first 48 bits and OR into place
+
+u[8] = 0x80 | (u[8] & 0x3F); // set variant field, top two bits are 1, 0
+u[6] = 0x70 | (u[6] & 0x0F); // set version field, top four bits are 0, 1, 1, 1
 					]]></artwork>
 				</figure>
 			</section>

--- a/draft-peabody-dispatch-new-uuid-format-03.xml
+++ b/draft-peabody-dispatch-new-uuid-format-03.xml
@@ -444,7 +444,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</t>
 				<t>
 					Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation order of those one-thousand UUIDs.
-					For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp. 
+					For batch UUID creation implementions MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp. 
 				</t>
 				<t>
 					For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <xref target="distributed_shared_knowledge"/>
@@ -561,7 +561,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 			</section>
 			<section anchor="collision_resistance" title="Collision Resistance">
 				<t>
-					Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as<xref target="timestamp_granularity"/> and <xref target="monotonicity_counters"/>. 
+					Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as <xref target="timestamp_granularity"/> and <xref target="monotonicity_counters"/>. 
 					This is especially true for distributed node collision resistance as defined by <xref target="distributed_shared_knowledge"/>.
 				</t>
 				<t>
@@ -599,7 +599,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 				</t>
 				<t>
 					Time ordered monotonic UUIDs benefit from greater database index locality because the new values are near each other in the index. 
-					As a result objects are more easily be clustered together for better performance.  
+					As a result objects are more easily clustered together for better performance.  
 					The real-world differences in this approach of index locality vs random data inserts can be quite large.
 				</t>
 				<t>
@@ -642,7 +642,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 		<section anchor="Security" title="Security Considerations">
 			<t> 
 				MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
-				Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
+				Instead CSPRNG data SHOULD be selected from a source with sufficient entropy to ensure guaranteed
 				uniqueness among UUID generation. See <xref target="unguessability"/> for more information. 
 			</t>
 			<t>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/dbxn2Na0KX.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/Wvvk2ad6ew.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 30 September 2022</td>
+<td class="center">Expires 1 October 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-29" class="published">29 March 2022</time>
+<time datetime="2022-03-30" class="published">30 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-30">30 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-10-01">1 October 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 30 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 1 October 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -2074,7 +2074,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  Monotonicity is the backbone of time-based sortable UUIDs. Naturally time-based UUIDs from this document will be monotonic due to an embedded timestamp however implementations can guarantee additional monotonicity via the concepts covered in this section.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
 <p id="section-6.2-2">
  Additionally, care MUST be taken to ensure UUIDs generated in batches are also monotonic. That is, if one-thousand UUIDs are generated for the same timestamp; there is sufficient logic for organizing the creation order of those one-thousand UUIDs.
- For batch UUID creation implements MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+ For batch UUID creation implementions MAY utilize a monotonic counter which SHOULD increment for each UUID created during a given timestamp.<a href="#section-6.2-2" class="pilcrow">¶</a></p>
 <p id="section-6.2-3">
  For single-node UUID implementations that do not need to create batches of UUIDs, the embedded timestamp within UUID version 1, 6, and 7 can provide sufficient monotonicity guarantees by simply ensuring that timestamp increments before creating a new UUID. For the topic of Distributed Nodes please refer to <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a><a href="#section-6.2-3" class="pilcrow">¶</a></p>
 <p id="section-6.2-4">
@@ -2206,7 +2206,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 <a href="#section-6.4" class="section-number selfRef">6.4. </a><a href="#name-collision-resistance" class="section-name selfRef">Collision Resistance</a>
         </h3>
 <p id="section-6.4-1">
- Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as<a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. 
+ Implementations SHOULD weigh the consequences of UUID collisions within their application and when deciding between UUID versions that use entropy (random) versus the other components such as <a href="#timestamp_granularity" class="xref">Section 6.1</a> and <a href="#monotonicity_counters" class="xref">Section 6.2</a>. 
  This is especially true for distributed node collision resistance as defined by <a href="#distributed_shared_knowledge" class="xref">Section 6.3</a>.<a href="#section-6.4-1" class="pilcrow">¶</a></p>
 <p id="section-6.4-2">
  There are two example scenarios below which help illustrate the varying seriousness of a collision within an application.<a href="#section-6.4-2" class="pilcrow">¶</a></p>
@@ -2256,7 +2256,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  UUIDv6 and UUIDv7 are designed so that implementations that require sorting (e.g. database indexes) SHOULD sort as opaque raw bytes, without need for parsing or introspection.<a href="#section-6.7-1" class="pilcrow">¶</a></p>
 <p id="section-6.7-2">
  Time ordered monotonic UUIDs benefit from greater database index locality because the new values are near each other in the index. 
- As a result objects are more easily be clustered together for better performance.  
+ As a result objects are more easily clustered together for better performance.  
  The real-world differences in this approach of index locality vs random data inserts can be quite large.<a href="#section-6.7-2" class="pilcrow">¶</a></p>
 <p id="section-6.7-3">
  UUIDs formats created by this specification SHOULD be Lexicographically sortable while in the textual representation.<a href="#section-6.7-3" class="pilcrow">¶</a></p>
@@ -2316,7 +2316,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
       </h2>
 <p id="section-8-1"> 
  MAC addresses pose inherent security risks and SHOULD not be used within a UUID. 
- Instead CSPRNG data SHOULD selected from a source with sufficient entropy to ensure guaranteed
+ Instead CSPRNG data SHOULD be selected from a source with sufficient entropy to ensure guaranteed
  uniqueness among UUID generation. See <a href="#unguessability" class="xref">Section 6.6</a> for more information.<a href="#section-8-1" class="pilcrow">¶</a></p>
 <p id="section-8-2">
  Timestamps embedded in the UUID do pose a very small attack surface. The timestamp in conjunction with 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     setuptools 40.6.2
     six 1.15.0
 -->
-<link href="/tmp/7Op3f5iYmO.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
+<link href="/tmp/dbxn2Na0KX.dir/draft-peabody-dispatch-new-uuid-format-03.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1192,7 +1192,7 @@ li > p:last-of-type {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Peabody &amp; Davis</td>
-<td class="center">Expires 29 September 2022</td>
+<td class="center">Expires 30 September 2022</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1208,12 +1208,12 @@ li > p:last-of-type {
 <a href="https://www.rfc-editor.org/rfc/rfc4122" class="eref">4122</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2022-03-28" class="published">28 March 2022</time>
+<time datetime="2022-03-29" class="published">29 March 2022</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Standards Track</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2022-09-29">29 September 2022</time></dd>
+<dd class="expires"><time datetime="2022-09-30">30 September 2022</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1250,7 +1250,7 @@ li > p:last-of-type {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 29 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 30 September 2022.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1860,38 +1860,7 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
  With UUIDv6 the steps for splitting the timestamp into time_high and time_mid are OPTIONAL
  since the 48 bits of time_high and time_mid will remain in the same order.
  An extra step of splitting the first 48 bits of the timestamp into the most significant 
- 32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.
- In which the following logic can be applied to reshuffle the bits with minimal modifications.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
-<span id="name-uuidv1-to-uuidv6-field-mapp"></span><table class="center" id="table-2">
-          <caption>
-<a href="#table-2" class="selfRef">Table 2</a>:
-<a href="#name-uuidv1-to-uuidv6-field-mapp" class="selfRef">UUIDv1 to UUIDv6 Field Mappings</a>
-          </caption>
-<thead>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">UUIDv1 Field</td>
-              <td class="text-left" rowspan="1" colspan="1">Bits</td>
-              <td class="text-left" rowspan="1" colspan="1">UUIDv6 Field</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_low </td>
-              <td class="text-left" rowspan="1" colspan="1">32</td>
-              <td class="text-left" rowspan="1" colspan="1">time_high</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_mid </td>
-              <td class="text-left" rowspan="1" colspan="1">16</td>
-              <td class="text-left" rowspan="1" colspan="1">time_mid</td>
-            </tr>
-            <tr>
-              <td class="text-left" rowspan="1" colspan="1">time_high</td>
-              <td class="text-left" rowspan="1" colspan="1">12</td>
-              <td class="text-left" rowspan="1" colspan="1">time_low</td>
-            </tr>
-          </tbody>
-        </table>
+ 32 bits and least significant 16 bits proves useful when reusing an existing UUIDv1 implementation.<a href="#section-5.1-8" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="v7">
@@ -1900,7 +1869,8 @@ xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
 <a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-uuid-version-7" class="section-name selfRef">UUID Version 7</a>
         </h3>
 <p id="section-5.2-1">
- UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, as well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
+ UUID version 7 features a time-ordered value field derived from the widely implemented and well known Unix Epoch timestamp source, the number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
+ As well as improved entropy characteristics over versions 1 or 6.<a href="#section-5.2-1" class="pilcrow">¶</a></p>
 <p id="section-5.2-2">
  Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.<a href="#section-5.2-2" class="pilcrow">¶</a></p>
 <span id="name-uuidv7-field-and-bit-layout"></span><figure id="figure-3">
@@ -2055,7 +2025,9 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  UUID timestamp source, precision and length was the topic of great debate while creating this specification. As such choosing the right timestamp for your application is a very important topic. This section will detail some of the most common points on this topic.<a href="#section-6.1-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="section-6.1-2">
           <dt id="section-6.1-2.1">Reliability:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. Care SHOULD be taken to ensure the timestamp does not move backwards which will impact UUID sorting.<a href="#section-6.1-2.2" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.2">Implementations SHOULD use the current timestamp from a reliable source to provide values that are time-ordered and continually increasing. 
+ Care SHOULD be taken to ensure that timestamp changes from the environment or operating system are handled in a way that is consistent with implementation requirements.  
+ For example, if it is possible for the system clock to move backward due to either manual adjustment or corrections from a time synchronization protocol, implementations must decide how to handle such cases. (See Altering, Fuzzing, or Smearing bullet below.)<a href="#section-6.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.3">Source:</dt>
@@ -2063,7 +2035,12 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.5">Sub-second Precision and Accuracy:</dt>
-          <dd style="margin-left: 1.5em" id="section-6.1-2.6">Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond. Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch. For other levels of precision UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-6.1-2.6">
+ Many levels of precision exist for timestamps: milliseconds, microseconds, nanoseconds, and beyond.
+ Additionally fractional representations of sub-second precision may be desired to mix various levels of precision in a time-ordered manner. 
+ Furthermore, system clocks themselves have an underlying granularity and it is frequently less than the precision offered by the operating system. 
+ With UUID version 1 and 6, 100-nanoseconds of precision are present while UUIDv7 features fixed millisecond level of precision within the Unix epoch that does not exceed the granularity capable in most modern systems.
+ For other levels of precision UUIDv8 SHOULD be utilized.<a href="#section-6.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-6.1-2.7">Length:</dt>
@@ -2183,7 +2160,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
             <p id="section-6.2-13.1.1">Compare the current timestamp against the previously stored timestamp.<a href="#section-6.2-13.1.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-6.2-13.2">
-            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment desired counter method and increment type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
+            <p id="section-6.2-13.2.1">If the current timestamp is equal to the previous timestamp; increment the counter according to the desired method and type.<a href="#section-6.2-13.2.1" class="pilcrow">¶</a></p>
 </li>
           <li id="section-6.2-13.3">
             <p id="section-6.2-13.3.1">If the current timestamp is greater than the previous timestamp; re-initialize the desired counter method to the new timestamp and generate new random bytes (if the bytes were frozen or being used as the seed for a monotonic counter).<a href="#section-6.2-13.3.1" class="pilcrow">¶</a></p>
@@ -2204,7 +2181,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
  While UUIDs already feature sufficient entropy to ensure that the chances of collision are low as the total number of nodes increase; so does the likelihood of a collision. 
  This section will detail the approaches that MAY be utilized by multi-node UUID implementations in distributed environments.<a href="#section-6.3-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlNewline" id="section-6.3-2">
-          <dt id="section-6.3-2.1">Shared Knowledge System:</dt>
+          <dt id="section-6.3-2.1">Centralized Registry:</dt>
           <dd style="margin-left: 1.5em" id="section-6.3-2.2">With this method all nodes tasked with creating UUIDs consult a central registry and confirm the generated value is unique. As applications scale the communication with the central registry could become a bottleneck and impact UUID generation in a negative way. Utilization of shared knowledge schemes with central/global registries is outside the scope of this specification.<a href="#section-6.3-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
@@ -2220,7 +2197,7 @@ FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
         <dd class="break"></dd>
 </dl>
 <p id="section-6.3-3">
- Utilization of either a shared knowledge scheme or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
+ Utilization of either a Centralized Registry or Node ID are not required for implementing UUIDs in this specification. However implementations SHOULD utilize one of the two aforementioned methods if distributed UUID generation is a requirement.<a href="#section-6.3-3" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="collision_resistance">
@@ -2526,7 +2503,48 @@ void uuidv1tov6(uuid_t u) {
 <span id="name-uuidv7-function-in-c"></span><figure id="figure-7">
           <div class="alignLeft art-text artwork" id="appendix-A.2-1.1">
 <pre>
-TODO UUIDv7
+#include &lt;stdio.h&gt;
+#include &lt;stdlib.h&gt;
+#include &lt;stdint.h&gt;
+#include &lt;string.h&gt;
+#include &lt;time.h&gt;
+
+// ...
+
+// csprng data source
+FILE *rndf;
+rndf = fopen("/dev/urandom", "r");
+if (rndf == 0) {
+    printf("fopen /dev/urandom error\n");
+    return 1;
+}
+
+// ...
+
+// generate one UUIDv7E
+uint8_t u[16];
+struct timespec ts;
+int ret;
+
+ret = clock_gettime(CLOCK_REALTIME, &amp;ts);
+if (ret != 0) {
+    printf("clock_gettime error: %d\n", ret);
+    return 1;
+}
+
+uint64_t tms;
+
+tms = ((uint64_t)ts.tv_sec) * 1000;
+tms += ((uint64_t)ts.tv_nsec) / 1000000;
+
+memset(u, 0, 16);
+
+fread(&amp;u[6], 10, 1, rndf); // fill everything after the timestamp with random bytes
+
+*((uint64_t*)(u)) |= htonll(tms &lt;&lt; 16); // shift time into first 48 bits and OR into place
+
+u[8] = 0x80 | (u[8] &amp; 0x3F); // set variant field, top two bits are 1, 0
+u[6] = 0x70 | (u[6] &amp; 0x0F); // set version field, top four bits are 0, 1, 1, 1
 </pre>
 </div>
 <figcaption><a href="#figure-7" class="selfRef">Figure 7</a>:
@@ -2726,9 +2744,9 @@ final: 320C3D4D-CC00-875B-8EC9-32D5F69181C0
         <h3 id="name-variant-10xx-versions">
 <a href="#appendix-C.1" class="section-number selfRef">C.1. </a><a href="#name-variant-10xx-versions" class="section-name selfRef">Variant 10xx Versions</a>
         </h3>
-<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-3">
+<span id="name-all-uuid-variant-10xx-8-9-a"></span><table class="center" id="table-2">
           <caption>
-<a href="#table-3" class="selfRef">Table 3</a>:
+<a href="#table-2" class="selfRef">Table 2</a>:
 <a href="#name-all-uuid-variant-10xx-8-9-a" class="selfRef">All UUID variant 10xx (8/9/A/B) version definitions.</a>
           </caption>
 <thead>


### PR DESCRIPTION
@bradleypeabody's Updates passed to me via email to merge:
- UUIDv7 C Snippet
- Removal of unrequired, and confusing, UUIDv1 to UUIDv6 table from Version and Variant Section
- Define Unix Epoch in UUIDv7 section
- More clarity on Timestamp, Reliability around moving backwards i.e leap seconds
- Added info about system vs OS reliability and why MS was selected for UUIDv7 in Timestamp, Sub-second Precision and Accuracy
- Better verbiage clarity in "when to increment counter paragraph"
- Changed "Shared Knowledge Scheme" bullet to "Centralized Registry"